### PR TITLE
create disk folder if not exist when deploying to vespa cloud

### DIFF
--- a/vespa/package.py
+++ b/vespa/package.py
@@ -666,6 +666,8 @@ class VespaCloud(object):
 
         application_zip_bytes = self._to_application_zip()
 
+        Path(disk_folder).mkdir(parents=True, exist_ok=True)
+
         self._write_private_key_and_cert(
             self.data_key, self.data_certificate, disk_folder
         )


### PR DESCRIPTION
This is similar to what is done in `VespaDocker`.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
