### PR TITLE
Export application to disk and enable deploying from disk for Docker

### DIFF
--- a/vespa/package.py
+++ b/vespa/package.py
@@ -389,39 +389,33 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
 class VespaDocker(object):
     def __init__(
         self,
-        application_package: ApplicationPackage,
         output_file: IO = sys.stdout,
     ) -> None:
         """
-        Deploy application to a Vespa container
-
-        :param application_package: ApplicationPackage to be deployed.
+        Manage Docker deployments.
         :param output_file: Output file to write output messages.
         """
-        self.application_package = application_package
         self.container = None
         self.local_port = 8080
         self.output = output_file
 
-    def _run_vespa_engine_container(self, disk_folder: str, container_memory: str):
-        """
-        Run a vespa container.
-
-        :param disk_folder: Folder containing the application files.
-        :param container_memory: Memory limit of the container
-        :return:
-        """
+    def _run_vespa_engine_container(
+        self,
+        application_name: str,
+        disk_folder: str,
+        container_memory: str,
+    ):
         client = docker.from_env()
         if self.container is None:
             try:
-                self.container = client.containers.get(self.application_package.name)
+                self.container = client.containers.get(application_name)
             except docker.errors.NotFound:
                 self.container = client.containers.run(
                     "vespaengine/vespa",
                     detach=True,
                     mem_limit=container_memory,
-                    name=self.application_package.name,
-                    hostname=self.application_package.name,
+                    name=application_name,
+                    hostname=application_name,
                     privileged=True,
                     volumes={disk_folder: {"bind": "/app", "mode": "rw"}},
                     ports={self.local_port: self.local_port, 19112: 19112},
@@ -430,7 +424,6 @@ class VespaDocker(object):
     def _check_configuration_server(self) -> bool:
         """
         Check if configuration server is running and ready for deployment
-
         :return: True if configuration server is running.
         """
         return (
@@ -443,39 +436,43 @@ class VespaDocker(object):
             == "HTTP/1.1 200 OK"
         )
 
-    def _create_application_package_files(self, dir_path):
+    @staticmethod
+    def export_application_package(
+        dir_path: str, application_package: ApplicationPackage
+    ) -> None:
+        """
+        Export application package to disk.
+        :param dir_path: Desired application path. Directory will be created if not already exist.
+        :param application_package: Application package to export.
+        :return: None. Application package file will be stored on `dir_path`.
+        """
         Path(os.path.join(dir_path, "application/schemas")).mkdir(
             parents=True, exist_ok=True
         )
         with open(
             os.path.join(
                 dir_path,
-                "application/schemas/{}.sd".format(
-                    self.application_package.schema.name
-                ),
+                "application/schemas/{}.sd".format(application_package.schema.name),
             ),
             "w",
         ) as f:
-            f.write(self.application_package.schema_to_text)
+            f.write(application_package.schema_to_text)
         with open(os.path.join(dir_path, "application/hosts.xml"), "w") as f:
-            f.write(self.application_package.hosts_to_text)
+            f.write(application_package.hosts_to_text)
         with open(os.path.join(dir_path, "application/services.xml"), "w") as f:
-            f.write(self.application_package.services_to_text)
+            f.write(application_package.services_to_text)
 
-    def deploy(self, disk_folder: str, container_memory: str = "4G"):
-        """
-        Deploy the application into a Vespa container.
-
-        :param disk_folder: Disk folder to save the required Vespa config files.
-        :param container_memory: Docker container memory available to the application.
-
-        :return: a Vespa connection instance.
-        """
-
-        self._create_application_package_files(dir_path=disk_folder)
+    def _execute_deployment(
+        self,
+        application_name: str,
+        disk_folder: str,
+        container_memory: str = "4G",
+    ):
 
         self._run_vespa_engine_container(
-            disk_folder=disk_folder, container_memory=container_memory
+            application_name=application_name,
+            disk_folder=disk_folder,
+            container_memory=container_memory,
         )
 
         while not self._check_configuration_server():
@@ -495,6 +492,50 @@ class VespaDocker(object):
             url="http://localhost",
             port=self.local_port,
             deployment_message=deployment_message,
+        )
+
+    def deploy(
+        self,
+        application_package: ApplicationPackage,
+        disk_folder: str,
+        container_memory: str = "4G",
+    ) -> Vespa:
+        """
+        Deploy the application package into a Vespa container.
+        :param application_package: ApplicationPackage to be deployed.
+        :param disk_folder: Disk folder to save the required Vespa config files.
+        :param container_memory: Docker container memory available to the application.
+        :return: a Vespa connection instance.
+        """
+
+        self.export_application_package(
+            dir_path=disk_folder, application_package=application_package
+        )
+
+        return self._execute_deployment(
+            application_name=application_package.name,
+            disk_folder=disk_folder,
+            container_memory=container_memory,
+        )
+
+    def deploy_from_disk(
+        self,
+        application_name: str,
+        disk_folder: str,
+        container_memory: str = "4G",
+    ) -> Vespa:
+        """
+        Deploy disk-based application package into a Vespa container.
+        :param application_name: Name of the application.
+        :param disk_folder: Disk folder to save the required Vespa config files.
+        :param container_memory: Docker container memory available to the application.
+        :return: a Vespa connection instance.
+        """
+
+        return self._execute_deployment(
+            application_name=application_name,
+            disk_folder=disk_folder,
+            container_memory=container_memory,
         )
 
 

--- a/vespa/test_integration_docker.py
+++ b/vespa/test_integration_docker.py
@@ -38,19 +38,33 @@ class TestDockerDeployment(unittest.TestCase):
                 RankProfile(name="default", first_phase="nativeRank(title, body)")
             ],
         )
-        app_package = ApplicationPackage(name="msmarco", schema=msmarco_schema)
-        #
-        # Deploy in a Docker container
-        #
-        vespa_docker = VespaDocker(application_package=app_package)
+        self.app_package = ApplicationPackage(name="msmarco", schema=msmarco_schema)
         self.disk_folder = os.path.join(os.getenv("WORK_DIR"), "sample_application")
-        self.app = vespa_docker.deploy(
-            disk_folder=self.disk_folder
+
+    def test_deploy(self):
+        self.vespa_docker = VespaDocker()
+        app = self.vespa_docker.deploy(
+            application_package=self.app_package, disk_folder=self.disk_folder
         )
 
-    def test_deployment_message(self):
-        self.assertTrue(any(re.match("Generation: [0-9]+", line) for line in self.app.deployment_message))
+        self.assertTrue(
+            any(re.match("Generation: [0-9]+", line) for line in app.deployment_message)
+        )
+
+    def test_deploy_from_disk(self):
+        self.vespa_docker = VespaDocker()
+        self.vespa_docker.export_application_package(
+            dir_path=self.disk_folder, application_package=self.app_package
+        )
+        app = self.vespa_docker.deploy_from_disk(
+            application_name=self.app_package.name, disk_folder=self.disk_folder
+        )
+
+        self.assertTrue(
+            any(re.match("Generation: [0-9]+", line) for line in app.deployment_message)
+        )
 
     def tearDown(self) -> None:
         shutil.rmtree(self.disk_folder, ignore_errors=True)
-
+        self.vespa_docker.container.stop()
+        self.vespa_docker.container.remove()


### PR DESCRIPTION
* It is now possible to export application packages to disk for inspection and modification. 
* Allow to deploy application packages to docker containers from disk folder.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
