### PR TITLE
track data collection progress

### DIFF
--- a/vespa/application.py
+++ b/vespa/application.py
@@ -228,20 +228,16 @@ class Vespa(object):
         training_data = []
         number_queries = len(labelled_data)
         idx_total = 0
-        idx_query = 0
-        for query_data in labelled_data:
-            idx_query += 1
-            idx_doc = 0
+        for query_idx, query_data in enumerate(labelled_data):
             number_relevant_docs = len(query_data["relevant_docs"])
-            for doc_data in query_data["relevant_docs"]:
+            for doc_idx, doc_data in enumerate(query_data["relevant_docs"]):
                 idx_total += 1
-                idx_doc += 1
                 if (show_progress is not None) and (idx_total % show_progress == 0):
                     print(
                         "Query {}/{}, Doc {}/{}. Query id: {}. Doc id: {}".format(
-                            idx_query,
+                            query_idx,
                             number_queries,
-                            idx_doc,
+                            doc_idx,
                             number_relevant_docs,
                             query_data["query_id"],
                             doc_data["id"],


### PR DESCRIPTION
This PR enable some information when collecting training data from Vespa apps. Before this PR the following code

```
training_data_batch = app.collect_training_data(
    labelled_data = train_set,
    id_field = "cord_uid",
    query_model = query_models["or_bm25"],
    number_additional_docs = 9,
    fields = ["title-full"]
)
```
would processed many queries and documents without indicating how far into the process the call was. So the user did not know if the process was still running.

This PR adds the possibility of printing progress statement of the following form at every `show_progress` iteration.

`Query {}/{}, Doc {}/{}. Query id: {}. Doc id: {}`

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
