### PR TITLE
Add default query profile with root query profile type by default to all apps

### DIFF
--- a/vespa/package.py
+++ b/vespa/package.py
@@ -755,6 +755,14 @@ class VespaCloud(object):
                 self.application_package.schema_to_text,
             )
             zip_archive.writestr(
+                "application/search/query-profiles/default.xml",
+                self.application_package.query_profile_to_text,
+            )
+            zip_archive.writestr(
+                "application/search/query-profiles/types/root.xml",
+                self.application_package.query_profile_type_to_text,
+            )
+            zip_archive.writestr(
                 "application/services.xml", self.application_package.services_to_text
             )
             zip_archive.writestr(

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -329,6 +329,36 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
         )
 
     @property
+    def query_profile_to_text(self):
+        env = Environment(
+            loader=PackageLoader("vespa", "templates"),
+            autoescape=select_autoescape(
+                disabled_extensions=("txt",),
+                default_for_string=True,
+                default=True,
+            ),
+        )
+        env.trim_blocks = True
+        env.lstrip_blocks = True
+        schema_template = env.get_template("query_profile.xml")
+        return schema_template.render()
+
+    @property
+    def query_profile_type_to_text(self):
+        env = Environment(
+            loader=PackageLoader("vespa", "templates"),
+            autoescape=select_autoescape(
+                disabled_extensions=("txt",),
+                default_for_string=True,
+                default=True,
+            ),
+        )
+        env.trim_blocks = True
+        env.lstrip_blocks = True
+        schema_template = env.get_template("query_profile_type.xml")
+        return schema_template.render()
+
+    @property
     def hosts_to_text(self):
         env = Environment(
             loader=PackageLoader("vespa", "templates"),

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -488,6 +488,26 @@ class VespaDocker(object):
             "w",
         ) as f:
             f.write(application_package.schema_to_text)
+
+        Path(os.path.join(dir_path, "application/search/query-profiles/types")).mkdir(
+            parents=True, exist_ok=True
+        )
+        with open(
+            os.path.join(
+                dir_path,
+                "application/search/query-profiles/default.xml",
+            ),
+            "w",
+        ) as f:
+            f.write(application_package.query_profile_to_text)
+        with open(
+            os.path.join(
+                dir_path,
+                "application/search/query-profiles/types/root.xml",
+            ),
+            "w",
+        ) as f:
+            f.write(application_package.query_profile_type_to_text)
         with open(os.path.join(dir_path, "application/hosts.xml"), "w") as f:
             f.write(application_package.hosts_to_text)
         with open(os.path.join(dir_path, "application/services.xml"), "w") as f:

--- a/vespa/templates/query_profile.xml
+++ b/vespa/templates/query_profile.xml
@@ -1,0 +1,2 @@
+<query-profile id="default" type="root">
+</query-profile>

--- a/vespa/templates/query_profile_type.xml
+++ b/vespa/templates/query_profile_type.xml
@@ -1,0 +1,2 @@
+<query-profile-type id="root">
+</query-profile-type>

--- a/vespa/test_integration_docker.py
+++ b/vespa/test_integration_docker.py
@@ -138,7 +138,7 @@ class TestDockerDeployment(unittest.TestCase):
         )
 
     def test_data_operations(self):
-        self.vespa_docker = VespaDocker()
+        self.vespa_docker = VespaDocker(port=8089)
         app = self.vespa_docker.deploy(
             application_package=self.app_package, disk_folder=self.disk_folder
         )

--- a/vespa/test_package.py
+++ b/vespa/test_package.py
@@ -241,3 +241,13 @@ class TestApplicationPackage(unittest.TestCase):
         )
 
         self.assertEqual(self.app_package.services_to_text, expected_result)
+
+    def test_query_profile_to_text(self):
+        expected_result = (
+            '<query-profile id="default" type="root">\n' "</query-profile>"
+        )
+        self.assertEqual(self.app_package.query_profile_to_text, expected_result)
+
+    def test_query_profile_type_to_text(self):
+        expected_result = '<query-profile-type id="root">\n' "</query-profile-type>"
+        self.assertEqual(self.app_package.query_profile_type_to_text, expected_result)


### PR DESCRIPTION
Including default query profile and root query profile type by default so that the user does not have to specify it every time he creates an application. A future PR will allow them to include fields on the query profile and query profile type via pyvespa API.