### PR TITLE
Create 'default' Schema if none is specified.

### DIFF
--- a/vespa/package.py
+++ b/vespa/package.py
@@ -95,7 +95,7 @@ class Document(ToJson, FromJson["Document"]):
         """
         self.fields = [] if not fields else fields
 
-    def add_fields(self, *fields: Field):
+    def add_fields(self, *fields: Field) -> None:
         """
         Add Fields to the document.
 
@@ -236,6 +236,21 @@ class Schema(ToJson, FromJson["Schema"]):
                 rank_profile.name: rank_profile for rank_profile in rank_profiles
             }
 
+    def add_fields(self, *fields: Field) -> None:
+        """
+        Add `Field` to the Schema's document.
+
+        :param fields: fields to be added.
+        """
+        self.document.add_fields(*fields)
+
+    def add_field_set(self, field_set: FieldSet) -> None:
+        """
+        Add a `FieldSet` to the `Schema`.
+        :param field_set: `FieldSet` to be added.
+        """
+        self.fieldsets[field_set.name] = field_set
+
     def add_rank_profile(self, rank_profile: RankProfile) -> None:
         """
         Add a `RankProfile` to the `Schema`.
@@ -297,14 +312,16 @@ class Schema(ToJson, FromJson["Schema"]):
 
 
 class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
-    def __init__(self, name: str, schema: Schema) -> None:
+    def __init__(self, name: str, schema: Optional[Schema] = None) -> None:
         """
         Vespa Application Package.
 
         :param name: Application name.
-        :param schema: Schema of the application.
+        :param schema: Schema of the application. If None, a 'default' Schema will be created by default.
         """
         self.name = name
+        if not schema:
+            schema = Schema(name="default", document=Document())
         self.schema = schema
 
     @property

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -321,7 +321,7 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
         """
         self.name = name
         if not schema:
-            schema = Schema(name="default", document=Document())
+            schema = Schema(name=self.name, document=Document())
         self.schema = schema
 
     @property

--- a/vespa/test_package.py
+++ b/vespa/test_package.py
@@ -293,8 +293,8 @@ class TestSimplifiedApplicationPackage(unittest.TestCase):
 
     def test_schema_to_text(self):
         expected_result = (
-            "schema default {\n"
-            "    document default {\n"
+            "schema test_app {\n"
+            "    document test_app {\n"
             "        field id type string {\n"
             "            indexing: attribute | summary\n"
             "        }\n"
@@ -347,7 +347,7 @@ class TestSimplifiedApplicationPackage(unittest.TestCase):
             '    <content id="test_app_content" version="1.0">\n'
             '        <redundancy reply-after="1">1</redundancy>\n'
             "        <documents>\n"
-            '            <document type="default" mode="index"></document>\n'
+            '            <document type="test_app" mode="index"></document>\n'
             "        </documents>\n"
             "        <nodes>\n"
             '            <node distribution-key="0" hostalias="node1"></node>\n'


### PR DESCRIPTION
Implement default schema as described [here](https://thigm85.github.io/blog/pyvespa/embeddings/2020/11/17/pyvespa-simplified-api.html#Default-Schema).

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
