### PR TITLE
Allow HNSW indexes for tensor fields

### DIFF
--- a/vespa/package.py
+++ b/vespa/package.py
@@ -103,10 +103,10 @@ class Field(ToJson, FromJson["Field"]):
         :param ann: Add configuration for approximate nearest neighbor.
 
         >>> Field(name = "title", type = "string", indexing = ["index", "summary"], index = "enable-bm25")
-        Field('title', 'string', ['index', 'summary'], 'enable-bm25')
+        Field('title', 'string', ['index', 'summary'], 'enable-bm25', None)
 
         >>> Field(name = "title_bert", type = "tensor<float>(x[768])", indexing = ["attribute"])
-        Field('title_bert', 'tensor<float>(x[768])', ['attribute'], None)
+        Field('title_bert', 'tensor<float>(x[768])', ['attribute'], None, None)
 
         >>> Field(name="tensor_field",
         ...     type="tensor<float>(x[128])",
@@ -117,6 +117,7 @@ class Field(ToJson, FromJson["Field"]):
         ...         neighbors_to_explore_at_insert=200,
         ...     ),
         ... ),
+        Field('tensor_field', 'tensor<float>(x[128])', ['attribute'], None, HNSW('enclidean', 16, 200))
 
         """
         self.name = name
@@ -190,7 +191,7 @@ class Document(ToJson, FromJson["Document"]):
         Document(None)
 
         >>> Document(fields=[Field(name="title", type="string")])
-        Document([Field('title', 'string', None, None)])
+        Document([Field('title', 'string', None, None, None)])
 
         """
         self.fields = [] if not fields else fields

--- a/vespa/templates/schema.txt
+++ b/vespa/templates/schema.txt
@@ -8,6 +8,17 @@ schema {{ schema_name }} {
             {% if field.index %}
             index: {{ field.index }}
             {% endif %}
+            {% if field.ann %}
+            attribute {
+                distance-metric: {{ field.ann.distance_metric }}
+            }
+            index {
+                hnsw {
+                    max-links-per-node: {{ field.ann.max_links_per_node }}
+                    neighbors-to-explore-at-insert: {{ field.ann.neighbors_to_explore_at_insert }}
+                }
+            }
+            {% endif %}
         }
         {% endfor %}
     }

--- a/vespa/test_integration_docker.py
+++ b/vespa/test_integration_docker.py
@@ -3,6 +3,7 @@ import os
 import re
 import shutil
 from vespa.package import (
+    HNSW,
     Document,
     Field,
     Schema,
@@ -35,6 +36,16 @@ class TestDockerDeployment(unittest.TestCase):
                     type="string",
                     indexing=["index", "summary"],
                     index="enable-bm25",
+                ),
+                Field(
+                    name="tensor_field",
+                    type="tensor<float>(x[128])",
+                    indexing=["attribute"],
+                    ann=HNSW(
+                        distance_metric="euclidean",
+                        max_links_per_node=16,
+                        neighbors_to_explore_at_insert=200,
+                    ),
                 ),
             ]
         )

--- a/vespa/test_integration_vespa_cloud.py
+++ b/vespa/test_integration_vespa_cloud.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import shutil
 from vespa.package import (
+    HNSW,
     Document,
     Field,
     Schema,
@@ -34,6 +35,16 @@ class TestCloudDeployment(unittest.TestCase):
                     type="string",
                     indexing=["index", "summary"],
                     index="enable-bm25",
+                ),
+                Field(
+                    name="tensor_field",
+                    type="tensor<float>(x[128])",
+                    indexing=["attribute"],
+                    ann=HNSW(
+                        distance_metric="euclidean",
+                        max_links_per_node=16,
+                        neighbors_to_explore_at_insert=200,
+                    ),
                 ),
             ]
         )


### PR DESCRIPTION
Example:

```  
Field(
    name="tensor_field",
    type="tensor<float>(x[128])",
    indexing=["attribute"],
    ann=HNSW(
        distance_metric="euclidean",
        max_links_per_node=16,
        neighbors_to_explore_at_insert=200,
    ),
),
```
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
