### PR TITLE
Enable approximate ann operator

### DIFF
--- a/vespa/query.py
+++ b/vespa/query.py
@@ -129,6 +129,7 @@ class ANN(MatchFilter):
         query_vector: str,
         hits: int,
         label: str,
+        approximate: bool = True
     ) -> None:
         """
         Match documents according to the nearest neighbor operator.
@@ -139,17 +140,20 @@ class ANN(MatchFilter):
         :param query_vector: Name of the query field to be used in the distance calculation.
         :param hits: Lower bound on the number of hits to return.
         :param label: A label to identify this specific operator instance.
+        :param approximate: True to use approximate nearest neighbor and False to use brute force. Default to True.
         """
         super().__init__()
         self.doc_vector = doc_vector
         self.query_vector = query_vector
         self.hits = hits
         self.label = label
+        self.approximate = approximate
+        self._approximate = "true" if self.approximate is True else "false"
 
     def create_match_filter(self, query: str) -> str:
         return (
-            '([{{"targetNumHits": {}, "label": "{}"}}]nearestNeighbor({}, {}))'.format(
-                self.hits, self.label, self.doc_vector, self.query_vector
+            '([{{"targetNumHits": {}, "label": "{}", "approximate": {}}}]nearestNeighbor({}, {}))'.format(
+                self.hits, self.label, self._approximate, self.doc_vector, self.query_vector
             )
         )
 

--- a/vespa/test_query.py
+++ b/vespa/test_query.py
@@ -67,7 +67,23 @@ class TestMatchFilter(unittest.TestCase):
         )
         self.assertEqual(
             match_filter.create_match_filter(query=self.query),
-            '([{"targetNumHits": 10, "label": "label"}]nearestNeighbor(doc_vector, query_vector))',
+            '([{"targetNumHits": 10, "label": "label", "approximate": true}]nearestNeighbor(doc_vector, query_vector))',
+        )
+        self.assertDictEqual(
+            match_filter.get_query_properties(query=self.query),
+            {},
+        )
+
+        match_filter = ANN(
+            doc_vector="doc_vector",
+            query_vector="query_vector",
+            hits=10,
+            label="label",
+            approximate=False,
+        )
+        self.assertEqual(
+            match_filter.create_match_filter(query=self.query),
+            '([{"targetNumHits": 10, "label": "label", "approximate": false}]nearestNeighbor(doc_vector, query_vector))',
         )
         self.assertDictEqual(
             match_filter.get_query_properties(query=self.query),
@@ -89,7 +105,7 @@ class TestMatchFilter(unittest.TestCase):
             '([{"targetNumHits": 10}]weakAnd(field_name contains "this", field_name contains "is", '
             'field_name contains "", '
             'field_name contains "a", field_name contains "test")) or '
-            '([{"targetNumHits": 10, "label": "label"}]nearestNeighbor(doc_vector, query_vector))',
+            '([{"targetNumHits": 10, "label": "label", "approximate": true}]nearestNeighbor(doc_vector, query_vector))',
         )
         self.assertDictEqual(
             match_filter.get_query_properties(query=self.query),
@@ -151,7 +167,7 @@ class TestQuery(unittest.TestCase):
         self.assertDictEqual(
             query_model.create_body(query=self.query),
             {
-                "yql": 'select * from sources * where ([{"targetNumHits": 10, "label": "label"}]nearestNeighbor(doc_vector, query_vector));',
+                "yql": 'select * from sources * where ([{"targetNumHits": 10, "label": "label", "approximate": true}]nearestNeighbor(doc_vector, query_vector));',
                 "ranking": {"profile": "bm25", "listFeatures": "true"},
                 "ranking.features.query(query_vector)": "[1, 2, 3]",
             },


### PR DESCRIPTION
Now that we can build HNSW indexes we can specify if we want to set `approximate` equal to `True` or `False` when  use `ANN` operator.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
