### PR TITLE
Add field attribute

### DIFF
--- a/vespa/package.py
+++ b/vespa/package.py
@@ -108,12 +108,12 @@ class Field(ToJson, FromJson["Field"]):
         Field('title', 'string', ['index', 'summary'], 'enable-bm25', None, None)
 
         >>> Field(
-        ...     name = "title_bert",
-        ...     type = "tensor<float>(x[768])",
+        ...     name = "abstract",
+        ...     type = "string",
         ...     indexing = ["attribute"],
         ...     attribute=["fast-search", "fast-access"]
         ... )
-        Field('title_bert', 'tensor<float>(x[768])', ['attribute'], None, ['fast-search', 'fast-access'], None)
+        Field('abstract', 'string', ['attribute'], None, ['fast-search', 'fast-access'], None)
 
         >>> Field(name="tensor_field",
         ...     type="tensor<float>(x[128])",

--- a/vespa/templates/schema.txt
+++ b/vespa/templates/schema.txt
@@ -8,10 +8,19 @@ schema {{ schema_name }} {
             {% if field.index %}
             index: {{ field.index }}
             {% endif %}
-            {% if field.ann %}
+            {% if field.ann or field.attribute %}
             attribute {
+                {% if field.ann %}
                 distance-metric: {{ field.ann.distance_metric }}
+                {% endif %}
+                {% if field.attribute %}
+                {% for attribute in field.attribute %}
+                {{ attribute }}
+                {% endfor %}
+                {% endif %}
             }
+            {% endif %}
+            {% if field.ann %}
             index {
                 hnsw {
                     max-links-per-node: {{ field.ann.max_links_per_node }}

--- a/vespa/test_integration_docker.py
+++ b/vespa/test_integration_docker.py
@@ -38,6 +38,12 @@ class TestDockerDeployment(unittest.TestCase):
                     index="enable-bm25",
                 ),
                 Field(
+                    name="metadata",
+                    type="string",
+                    indexing=["attribute", "summary"],
+                    attribute=["fast-search", "fast-access"],
+                ),
+                Field(
                     name="tensor_field",
                     type="tensor<float>(x[128])",
                     indexing=["attribute"],

--- a/vespa/test_integration_vespa_cloud.py
+++ b/vespa/test_integration_vespa_cloud.py
@@ -37,6 +37,12 @@ class TestCloudDeployment(unittest.TestCase):
                     index="enable-bm25",
                 ),
                 Field(
+                    name="metadata",
+                    type="string",
+                    indexing=["attribute", "summary"],
+                    attribute=["fast-search", "fast-access"],
+                ),
+                Field(
                     name="tensor_field",
                     type="tensor<float>(x[128])",
                     indexing=["attribute"],

--- a/vespa/test_package.py
+++ b/vespa/test_package.py
@@ -66,6 +66,7 @@ class TestField(unittest.TestCase):
             name="tensor_field",
             type="tensor<float>(x[128])",
             indexing=["attribute"],
+            attribute=["fast-search", "fast-access"],
             ann=HNSW(
                 distance_metric="enclidean",
                 max_links_per_node=16,
@@ -436,6 +437,12 @@ class TestApplicationPackage(unittest.TestCase):
                         indexing=["index", "summary"],
                         index="enable-bm25",
                     ),
+                    Field(
+                        name="embedding",
+                        type="tensor<float>(x[128])",
+                        indexing=["attribute", "summary"],
+                        attribute=["fast-search", "fast-access"],
+                    ),
                 ]
             ),
             fieldsets=[FieldSet(name="default", fields=["title", "body"])],
@@ -555,6 +562,13 @@ class TestApplicationPackage(unittest.TestCase):
             "        field body type string {\n"
             "            indexing: index | summary\n"
             "            index: enable-bm25\n"
+            "        }\n"
+            "        field embedding type tensor<float>(x[128]) {\n"
+            "            indexing: attribute | summary\n"
+            "            attribute {\n"
+            "                fast-search\n"
+            "                fast-access\n"
+            "            }\n"
             "        }\n"
             "    }\n"
             "    fieldset default {\n"
@@ -719,6 +733,7 @@ class TestSimplifiedApplicationPackage(unittest.TestCase):
                 name="tensor_field",
                 type="tensor<float>(x[128])",
                 indexing=["attribute"],
+                attribute=["fast-search", "fast-access"],
                 ann=HNSW(
                     distance_metric="euclidean",
                     max_links_per_node=16,
@@ -774,6 +789,8 @@ class TestSimplifiedApplicationPackage(unittest.TestCase):
             "            indexing: attribute\n"
             "            attribute {\n"
             "                distance-metric: euclidean\n"
+            "                fast-search\n"
+            "                fast-access\n"
             "            }\n"
             "            index {\n"
             "                hnsw {\n"


### PR DESCRIPTION
Now we can specify stand-alone attribute properties like `fast-search` and `fast-access` for `Field`. Example:

``` 
Field(
    name="metadata",
    type="string",
    indexing=["attribute", "summary"],
    attribute=["fast-search", "fast-access"],
)
```

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
