### PR TITLE
Use complete application folder path when using deploy_from_disk

### DIFF
--- a/docs/sphinx/source/howto/deploy_app_package/deploy-docker.ipynb
+++ b/docs/sphinx/source/howto/deploy_app_package/deploy-docker.ipynb
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,6 +111,13 @@
     "    application_package=app_package, \n",
     "    disk_folder=os.path.join(os.getenv(\"WORK_DIR\"), \"sample_application\") # specify your desired absolute path here\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This will export the application files to an `application` folder within the `disk_folder` specified above."
    ]
   },
   {
@@ -129,13 +136,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Finished deployment.\n"
+     ]
+    }
+   ],
    "source": [
-    "vespa_docker.deploy_from_disk(\n",
+    "app = vespa_docker.deploy_from_disk(\n",
     "    application_name=\"sample_app\", \n",
-    "    disk_folder=os.path.join(os.getenv(\"WORK_DIR\"), \"sample_application\") # specify your desired absolute path here\n",
+    "    disk_folder=os.path.join(os.getenv(\"WORK_DIR\"), \"sample_application\"), # specify your desired absolute path here\n",
+    "    application_folder=\"application\"\n",
     ")"
    ]
   }

--- a/vespa/test_integration_docker.py
+++ b/vespa/test_integration_docker.py
@@ -174,16 +174,35 @@ class TestDockerDeployment(unittest.TestCase):
             },
         )
 
-    def test_deploy_from_disk(self):
+    def test_deploy_from_disk_with_disk_folder(self):
         self.vespa_docker = VespaDocker(port=8089)
         self.vespa_docker.export_application_package(
             disk_folder=self.disk_folder, application_package=self.app_package
         )
+        #
+        # Disk folder as the application folder
+        #
         app = self.vespa_docker.deploy_from_disk(
             application_name=self.app_package.name,
             disk_folder=os.path.join(self.disk_folder, "application"),
         )
+        self.assertTrue(
+            any(re.match("Generation: [0-9]+", line) for line in app.deployment_message)
+        )
 
+    def test_deploy_from_disk_with_application_folder(self):
+        self.vespa_docker = VespaDocker(port=8089)
+        self.vespa_docker.export_application_package(
+            disk_folder=self.disk_folder, application_package=self.app_package
+        )
+        #
+        # Application folder inside disk folder
+        #
+        app = self.vespa_docker.deploy_from_disk(
+            application_name=self.app_package.name,
+            disk_folder=self.disk_folder,
+            application_folder="application",
+        )
         self.assertTrue(
             any(re.match("Generation: [0-9]+", line) for line in app.deployment_message)
         )

--- a/vespa/test_integration_docker.py
+++ b/vespa/test_integration_docker.py
@@ -180,7 +180,8 @@ class TestDockerDeployment(unittest.TestCase):
             disk_folder=self.disk_folder, application_package=self.app_package
         )
         app = self.vespa_docker.deploy_from_disk(
-            application_name=self.app_package.name, disk_folder=self.disk_folder
+            application_name=self.app_package.name,
+            disk_folder=os.path.join(self.disk_folder, "application"),
         )
 
         self.assertTrue(


### PR DESCRIPTION
Before this PR, when using 
```
vespa_docker = VespaDocker(port=8080)
vespa_docker.deploy_from_disk(
    application_name="news", 
    disk_folder="/sample-apps/news/app-1-getting-started",
)
```
we assumed there would be an `application` folder inside `/sample-apps/news/app-1-getting-started`. This is not necessarily correct. The user should be responsible to specify the complete application path, without extra assumptions from pyvespa.

After this PR, both modes below works:
* Map docker container `/app` to `/sample-apps/news/app-1-getting-started` and assume the application folder is  in `/app`:
```
vespa_docker.deploy_from_disk(
    application_name="news", 
    disk_folder="/sample-apps/news/app-1-getting-started",
)
```
* Map docker container `/app` to `/sample-apps/news` and assume the application folder is  in `/app/app-1-getting-started`:
```
vespa_docker.deploy_from_disk(
    application_name="news", 
    disk_folder="/sample-apps/news",
    application_folder="app-1-getting-started"
)
```


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
