### PR TITLE
Remove deploy from disk argument

### DIFF
--- a/docs/sphinx/source/howto/deploy_app_package/deploy-docker.ipynb
+++ b/docs/sphinx/source/howto/deploy_app_package/deploy-docker.ipynb
@@ -151,7 +151,6 @@
    "source": [
     "app = vespa_docker.deploy_from_disk(\n",
     "    application_name=\"sample_app\", \n",
-    "    disk_folder=os.path.join(os.getenv(\"WORK_DIR\"), \"sample_application\"), # specify your desired absolute path here\n",
     "    application_folder=\"application\"\n",
     ")"
    ]

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -1504,13 +1504,11 @@ class VespaDocker(object):
     def deploy_from_disk(
         self,
         application_name: str,
-        disk_folder: str,
         application_folder: Optional[str] = None,
     ) -> Vespa:
         """
         Deploy disk-based application package into a Vespa container.
         :param application_name: Name of the application.
-        :param disk_folder: The disk_folder will be mapped to the /app directory inside the Docker container.
         :param application_folder: The folder inside `disk_folder` containing the application files. If None,
             we assume `disk_folder` to be the application folder.
         :return: a Vespa connection instance.
@@ -1518,7 +1516,7 @@ class VespaDocker(object):
 
         return self._execute_deployment(
             application_name=application_name,
-            disk_folder=disk_folder,
+            disk_folder=self.disk_folder,
             container_memory=self.container_memory,
             application_folder=application_folder,
         )

--- a/vespa/test_integration_docker.py
+++ b/vespa/test_integration_docker.py
@@ -68,9 +68,7 @@ class TestDockerDeployment(unittest.TestCase):
 
     def test_deploy(self):
         self.vespa_docker = VespaDocker(port=8089, disk_folder=self.disk_folder)
-        app = self.vespa_docker.deploy(
-            application_package=self.app_package
-        )
+        app = self.vespa_docker.deploy(application_package=self.app_package)
         self.assertTrue(
             any(re.match("Generation: [0-9]+", line) for line in app.deployment_message)
         )
@@ -78,23 +76,17 @@ class TestDockerDeployment(unittest.TestCase):
 
     def test_container_rerun(self):
         self.vespa_docker = VespaDocker(port=8089, disk_folder=self.disk_folder)
-        app = self.vespa_docker.deploy(
-            application_package=self.app_package
-        )
+        app = self.vespa_docker.deploy(application_package=self.app_package)
         self.assertTrue(
             any(re.match("Generation: [0-9]+", line) for line in app.deployment_message)
         )
         self.vespa_docker.container.stop()
-        app = self.vespa_docker.deploy(
-            application_package=self.app_package
-        )
+        app = self.vespa_docker.deploy(application_package=self.app_package)
         self.assertEqual(app.get_application_status().status_code, 200)
 
     def test_application_redeploy(self):
         self.vespa_docker = VespaDocker(port=8089, disk_folder=self.disk_folder)
-        app = self.vespa_docker.deploy(
-            application_package=self.app_package
-        )
+        app = self.vespa_docker.deploy(application_package=self.app_package)
         res = app.query(
             body={
                 "yql": "select * from sources * where default contains 'music';",
@@ -108,9 +100,7 @@ class TestDockerDeployment(unittest.TestCase):
         self.app_package.schema.add_rank_profile(
             RankProfile(name="bm25", inherits="default", first_phase="bm25(title)")
         )
-        app = self.vespa_docker.deploy(
-            application_package=self.app_package
-        )
+        app = self.vespa_docker.deploy(application_package=self.app_package)
         res = app.query(
             body={
                 "yql": "select * from sources * where default contains 'music';",
@@ -126,9 +116,7 @@ class TestDockerDeployment(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.vespa_docker.start_services()
 
-        app = self.vespa_docker.deploy(
-            application_package=self.app_package
-        )
+        app = self.vespa_docker.deploy(application_package=self.app_package)
         self.assertTrue(self.vespa_docker._check_configuration_server())
         self.assertEqual(app.get_application_status().status_code, 200)
         self.vespa_docker.stop_services()
@@ -143,9 +131,7 @@ class TestDockerDeployment(unittest.TestCase):
 
     def test_data_operation(self):
         self.vespa_docker = VespaDocker(port=8089, disk_folder=self.disk_folder)
-        app = self.vespa_docker.deploy(
-            application_package=self.app_package
-        )
+        app = self.vespa_docker.deploy(application_package=self.app_package)
         #
         # Get data that does not exist
         #
@@ -240,16 +226,18 @@ class TestDockerDeployment(unittest.TestCase):
         )
 
     def test_deploy_from_disk_with_disk_folder(self):
-        self.vespa_docker = VespaDocker(port=8089, disk_folder=self.disk_folder)
+        self.vespa_docker = VespaDocker(
+            port=8089, disk_folder=self.disk_folder
+        )
         self.vespa_docker.export_application_package(
             application_package=self.app_package
         )
         #
         # Disk folder as the application folder
         #
+        self.vespa_docker.disk_folder = os.path.join(self.disk_folder, "application")
         app = self.vespa_docker.deploy_from_disk(
             application_name=self.app_package.name,
-            disk_folder=os.path.join(self.disk_folder, "application"),
         )
         self.assertTrue(
             any(re.match("Generation: [0-9]+", line) for line in app.deployment_message)
@@ -265,7 +253,6 @@ class TestDockerDeployment(unittest.TestCase):
         #
         app = self.vespa_docker.deploy_from_disk(
             application_name=self.app_package.name,
-            disk_folder=self.disk_folder,
             application_folder="application",
         )
         self.assertTrue(
@@ -315,9 +302,7 @@ class TestOnnxModelDockerDeployment(unittest.TestCase):
         )
         self.disk_folder = os.path.join(os.getenv("WORK_DIR"), "sample_application")
         self.vespa_docker = VespaDocker(port=8089, disk_folder=self.disk_folder)
-        self.app = self.vespa_docker.deploy(
-            application_package=self.app_package
-        )
+        self.app = self.vespa_docker.deploy(application_package=self.app_package)
 
     def test_deploy(self):
         self.assertTrue(


### PR DESCRIPTION
remove redundant `disk_folder` argument from `deploy_from_disk` method.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
