### PR TITLE
Add 'schema' argument into add_model_ranking method

### DIFF
--- a/vespa/package.py
+++ b/vespa/package.py
@@ -1082,7 +1082,7 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
     def get_schema(self, name: Optional[str] = None):
         if not name:
             assert (
-                    len(self.schemas) == 1
+                len(self.schemas) == 1
             ), "Your application has more than one Schema, specify name argument."
             return self.schema
         return self._schema[name]
@@ -1098,12 +1098,17 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
             self._schema.update({schema.name: schema})
 
     def add_model_ranking(
-        self, model_config: ModelConfig, include_model_summary_features=False, **kwargs
+        self,
+        model_config: ModelConfig,
+        schema=None,
+        include_model_summary_features=False,
+        **kwargs
     ) -> None:
         """
         Add ranking profile based on a specific model config.
 
         :param model_config: Model config instance specifying the model to be used on the RankProfile.
+        :param schema: Name of the schema to add model ranking to.
         :param include_model_summary_features: True to include model specific summary features, such as
             inputs and outputs that are useful for debugging. Default to False as this requires an extra model
             evaluation when fetching summary features.
@@ -1124,6 +1129,7 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
             self._add_bert_rank_profile(
                 model_config=model_config,
                 include_model_summary_features=include_model_summary_features,
+                schema=schema,
                 **kwargs
             )
         else:
@@ -1133,6 +1139,7 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
         self,
         model_config: BertModelConfig,
         include_model_summary_features,
+        schema=None,
         doc_token_ids_indexing=None,
         **kwargs
     ) -> None:
@@ -1145,7 +1152,7 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
         model_file_path = model_id + ".onnx"
         model_config.export_to_onnx(output_path=model_file_path)
 
-        self.schema.add_model(
+        self.get_schema(schema).add_model(
             OnnxModel(
                 model_name=model_id,
                 model_file_path=model_file_path,
@@ -1177,7 +1184,7 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
         #
         if not doc_token_ids_indexing:
             doc_token_ids_indexing = ["attribute", "summary"]
-        self.schema.add_fields(
+        self.get_schema(schema).add_fields(
             Field(
                 name=model_config.doc_token_ids_name,
                 type="tensor<float>(d0[{}])".format(
@@ -1257,7 +1264,7 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
         if "summary_features" in kwargs:
             summary_features.extend(kwargs.pop("summary_features"))
 
-        self.schema.add_rank_profile(
+        self.get_schema(schema).add_rank_profile(
             RankProfile(
                 name=model_id,
                 constants=constants,

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -1079,7 +1079,12 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
         ), "Your application has more than one Schema, use get_schema instead."
         return self.schemas[0]
 
-    def get_schema(self, name):
+    def get_schema(self, name: Optional[str] = None):
+        if not name:
+            assert (
+                    len(self.schemas) == 1
+            ), "Your application has more than one Schema, specify name argument."
+            return self.schema
         return self._schema[name]
 
     def add_schema(self, *schemas: Schema) -> None:

--- a/vespa/test_integration_docker.py
+++ b/vespa/test_integration_docker.py
@@ -46,7 +46,7 @@ class TestDockerDeployment(unittest.TestCase):
                 Field(
                     name="tensor_field",
                     type="tensor<float>(x[128])",
-                    indexing=["attribute"],
+                    indexing=["attribute", "index"],
                     ann=HNSW(
                         distance_metric="euclidean",
                         max_links_per_node=16,

--- a/vespa/test_integration_vespa_cloud.py
+++ b/vespa/test_integration_vespa_cloud.py
@@ -45,7 +45,7 @@ class TestCloudDeployment(unittest.TestCase):
                 Field(
                     name="tensor_field",
                     type="tensor<float>(x[128])",
-                    indexing=["attribute"],
+                    indexing=["attribute", "index"],
                     ann=HNSW(
                         distance_metric="euclidean",
                         max_links_per_node=16,


### PR DESCRIPTION
This is required to handle cases where the application has multiple schemas.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
