### PR TITLE
Make QueryModel more flexible by adding body_function argument

### DIFF
--- a/vespa/test_application.py
+++ b/vespa/test_application.py
@@ -61,6 +61,38 @@ class TestVespaQuery(unittest.TestCase):
             },
         )
 
+    def test_query_with_body_function(self):
+        app = Vespa(url="http://localhost", port=8080)
+
+        def body_function(query):
+            body = {
+                "yql": "select * from sources * where userQuery();",
+                "query": query,
+                "type": "any",
+                "ranking": {"profile": "bm25", "listFeatures": "true"},
+            }
+            return body
+
+        query_model = QueryModel(body_function=body_function)
+
+        self.assertDictEqual(
+            app.query(
+                query="this is a test",
+                query_model=query_model,
+                debug_request=True,
+                hits=10,
+                recall=("id", [1, 5]),
+            ).request_body,
+            {
+                "yql": "select * from sources * where userQuery();",
+                "query": "this is a test",
+                "type": "any",
+                "ranking": {"profile": "bm25", "listFeatures": "true"},
+                "hits": 10,
+                "recall": "+(id:1 id:5)",
+            },
+        )
+
 
 class TestVespaCollectData(unittest.TestCase):
     def setUp(self) -> None:

--- a/vespa/test_query.py
+++ b/vespa/test_query.py
@@ -155,45 +155,44 @@ class TestQuery(unittest.TestCase):
             },
         )
 
+    def test_query_properties_match_and_rank(self):
 
-def test_query_properties_match_and_rank(self):
+        query_model = QueryModel(
+            query_properties=[
+                QueryRankingFeature(name="query_vector", mapping=lambda x: [1, 2, 3])
+            ],
+            match_phase=OR(),
+            rank_profile=RankProfile(name="bm25", list_features=True),
+        )
+        self.assertDictEqual(
+            query_model.create_body(query=self.query),
+            {
+                "yql": 'select * from sources * where ([{"grammar": "any"}]userInput("this is  a test"));',
+                "ranking": {"profile": "bm25", "listFeatures": "true"},
+                "ranking.features.query(query_vector)": "[1, 2, 3]",
+            },
+        )
 
-    query_model = QueryModel(
-        query_properties=[
-            QueryRankingFeature(name="query_vector", mapping=lambda x: [1, 2, 3])
-        ],
-        match_phase=OR(),
-        rank_profile=RankProfile(name="bm25", list_features=True),
-    )
-    self.assertDictEqual(
-        query_model.create_body(query=self.query),
-        {
-            "yql": 'select * from sources * where ([{"grammar": "any"}]userInput("this is  a test"));',
-            "ranking": {"profile": "bm25", "listFeatures": "true"},
-            "ranking.features.query(query_vector)": "[1, 2, 3]",
-        },
-    )
-
-    query_model = QueryModel(
-        query_properties=[
-            QueryRankingFeature(name="query_vector", mapping=lambda x: [1, 2, 3])
-        ],
-        match_phase=ANN(
-            doc_vector="doc_vector",
-            query_vector="query_vector",
-            hits=10,
-            label="label",
-        ),
-        rank_profile=RankProfile(name="bm25", list_features=True),
-    )
-    self.assertDictEqual(
-        query_model.create_body(query=self.query),
-        {
-            "yql": 'select * from sources * where ([{"targetNumHits": 10, "label": "label", "approximate": true}]nearestNeighbor(doc_vector, query_vector));',
-            "ranking": {"profile": "bm25", "listFeatures": "true"},
-            "ranking.features.query(query_vector)": "[1, 2, 3]",
-        },
-    )
+        query_model = QueryModel(
+            query_properties=[
+                QueryRankingFeature(name="query_vector", mapping=lambda x: [1, 2, 3])
+            ],
+            match_phase=ANN(
+                doc_vector="doc_vector",
+                query_vector="query_vector",
+                hits=10,
+                label="label",
+            ),
+            rank_profile=RankProfile(name="bm25", list_features=True),
+        )
+        self.assertDictEqual(
+            query_model.create_body(query=self.query),
+            {
+                "yql": 'select * from sources * where ([{"targetNumHits": 10, "label": "label", "approximate": true}]nearestNeighbor(doc_vector, query_vector));',
+                "ranking": {"profile": "bm25", "listFeatures": "true"},
+                "ranking.features.query(query_vector)": "[1, 2, 3]",
+            },
+        )
 
 
 class TestVespaResult(unittest.TestCase):


### PR DESCRIPTION
The `body_function` argument allows us to specify the body of the request using the Vespa Query API

```
def body_function(query):
    body = {'yql': 'select * from sources * where userQuery();',
            'query': query,
            'type': 'any',
            'ranking': {'profile': 'bm25', 'listFeatures': 'true'}}
    return body

query_model = QueryModel(body_function = body_function)

res = app.query(query = "this is a test", query_model=query_model)
```

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
