### PR TITLE
Make it possible to format query results

### DIFF
--- a/vespa/query.py
+++ b/vespa/query.py
@@ -259,12 +259,12 @@ def trec_format(
     """
     Function to format Vespa output according to TREC format.
 
-    TREC format include qid, docno, score and rank.
+    TREC format include qid, doc_id, score and rank.
 
     :param vespa_result: raw Vespa result from query.
-    :param id_field: Name of the Vespa field to use as 'docno' value.
+    :param id_field: Name of the Vespa field to use as 'doc_id' value.
     :param qid: custom query id.
-    :return: pandas DataFrame with columns qid, docno, score and rank.
+    :return: pandas DataFrame with columns qid, doc_id, score and rank.
     """
     hits = vespa_result.get("root", {}).get("children", [])
     records = []
@@ -272,7 +272,7 @@ def trec_format(
         records.append(
             {
                 "qid": qid,
-                "docno": hit["fields"][id_field] if id_field is not None else hit["id"],
+                "doc_id": hit["fields"][id_field] if id_field is not None else hit["id"],
                 "score": hit["relevance"],
                 "rank": rank,
             }

--- a/vespa/query.py
+++ b/vespa/query.py
@@ -1,6 +1,7 @@
 # Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 from typing import Callable, List, Optional, Dict
+from pandas import DataFrame
 
 
 #
@@ -252,6 +253,33 @@ class QueryModel(object):
         return body
 
 
+def trec_format(
+    vespa_result, id_field: Optional[str] = None, qid: int = 0
+) -> DataFrame:
+    """
+    Function to format Vespa output according to TREC format.
+
+    TREC format include qid, docno, score and rank.
+
+    :param vespa_result: raw Vespa result from query.
+    :param id_field: Name of the Vespa field to use as 'docno' value.
+    :param qid: custom query id.
+    :return: pandas DataFrame with columns qid, docno, score and rank.
+    """
+    hits = vespa_result.get("root", {}).get("children", [])
+    records = []
+    for rank, hit in enumerate(hits):
+        records.append(
+            {
+                "qid": qid,
+                "docno": hit["fields"][id_field] if id_field is not None else hit["id"],
+                "score": hit["relevance"],
+                "rank": rank,
+            }
+        )
+    return DataFrame.from_records(records)
+
+
 class VespaResult(object):
     def __init__(self, vespa_result, request_body=None):
         self._vespa_result = vespa_result
@@ -268,6 +296,18 @@ class VespaResult(object):
     @property
     def hits(self) -> List:
         return self._vespa_result.get("root", {}).get("children", [])
+
+    def get_hits(self, format_function=trec_format, **kwargs):
+        """
+        Get Vespa hits according to `format_function` format.
+
+        :param format_function: function to format the raw Vespa result. Should take raw vespa result as first argument.
+        :param kwargs: Extra arguments to be passed to `format_function`.
+        :return: Output of the `format_function`.
+        """
+        if not format_function:
+            return self.hits
+        return format_function(self._vespa_result, **kwargs)
 
     @property
     def number_documents_retrieved(self) -> int:

--- a/vespa/test_query.py
+++ b/vespa/test_query.py
@@ -342,11 +342,11 @@ class TestVespaResult(unittest.TestCase):
             DataFrame(
                 data={
                     "qid": [0],
-                    "docno": ["id:covid-19:doc::40215"],
+                    "doc_id": ["id:covid-19:doc::40215"],
                     "score": [30.368213170494712],
                     "rank": [0],
                 },
-                columns=["qid", "docno", "score", "rank"],
+                columns=["qid", "doc_id", "score", "rank"],
             ),
         )
         vespa_result = VespaResult(vespa_result=self.raw_vespa_result_multiple)
@@ -355,7 +355,7 @@ class TestVespaResult(unittest.TestCase):
             DataFrame(
                 data={
                     "qid": [0, 0, 0],
-                    "docno": [
+                    "doc_id": [
                         "id:covid-19:doc::142863",
                         "id:covid-19:doc::31328",
                         "id:covid-19:doc::187156",
@@ -367,7 +367,7 @@ class TestVespaResult(unittest.TestCase):
                     ],
                     "rank": [0, 1, 2],
                 },
-                columns=["qid", "docno", "score", "rank"],
+                columns=["qid", "doc_id", "score", "rank"],
             ),
         )
         assert_frame_equal(
@@ -375,7 +375,7 @@ class TestVespaResult(unittest.TestCase):
             DataFrame(
                 data={
                     "qid": [2, 2, 2],
-                    "docno": [
+                    "doc_id": [
                         "0p6vrujx",
                         "moy0u7n5",
                         "rhmywn8n",
@@ -387,6 +387,6 @@ class TestVespaResult(unittest.TestCase):
                     ],
                     "rank": [0, 1, 2],
                 },
-                columns=["qid", "docno", "score", "rank"],
+                columns=["qid", "doc_id", "score", "rank"],
             ),
         )

--- a/vespa/test_query.py
+++ b/vespa/test_query.py
@@ -1,6 +1,8 @@
 # Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 import unittest
+from pandas import DataFrame
+from pandas.testing import assert_frame_equal
 
 from vespa.query import (
     QueryModel,
@@ -241,6 +243,54 @@ class TestVespaResult(unittest.TestCase):
             }
         }
 
+        self.raw_vespa_result_multiple = {
+            "root": {
+                "id": "toplevel",
+                "relevance": 1.0,
+                "fields": {"totalCount": 236369},
+                "coverage": {
+                    "coverage": 100,
+                    "documents": 309201,
+                    "full": True,
+                    "nodes": 2,
+                    "results": 1,
+                    "resultsFull": 1,
+                },
+                "children": [
+                    {
+                        "id": "id:covid-19:doc::142863",
+                        "relevance": 11.893775281559614,
+                        "source": "content",
+                        "fields": {
+                            "sddocname": "doc",
+                            "title": "A workable strategy for COVID-19 <hi>testing</hi>: stratified periodic <hi>testing</hi> rather than universal random <hi>testing</hi>",
+                            "cord_uid": "0p6vrujx",
+                        },
+                    },
+                    {
+                        "id": "id:covid-19:doc::31328",
+                        "relevance": 11.891779491908013,
+                        "source": "content",
+                        "fields": {
+                            "sddocname": "doc",
+                            "title": "A workable strategy for COVID-19 <hi>testing</hi>: stratified periodic <hi>testing</hi> rather than universal random <hi>testing</hi>",
+                            "cord_uid": "moy0u7n5",
+                        },
+                    },
+                    {
+                        "id": "id:covid-19:doc::187156",
+                        "relevance": 11.887045666057702,
+                        "source": "content",
+                        "fields": {
+                            "sddocname": "doc",
+                            "title": "A comparison of group <hi>testing</hi> architectures for COVID-19 <hi>testing</hi>",
+                            "cord_uid": "rhmywn8n",
+                        },
+                    },
+                ],
+            }
+        }
+
     def test_json(self):
         vespa_result = VespaResult(vespa_result=self.raw_vespa_result)
         self.assertDictEqual(vespa_result.json, self.raw_vespa_result)
@@ -265,4 +315,78 @@ class TestVespaResult(unittest.TestCase):
                     },
                 }
             ],
+        )
+
+    def test_get_hits_none(self):
+        empty_hits_vespa_result = VespaResult(
+            vespa_result=self.raw_vespa_result_empty_hits
+        )
+        self.assertEqual(
+            empty_hits_vespa_result.get_hits(format_function=None),
+            empty_hits_vespa_result.hits,
+        )
+        vespa_result = VespaResult(vespa_result=self.raw_vespa_result)
+        self.assertEqual(
+            vespa_result.get_hits(format_function=None),
+            vespa_result.hits,
+        )
+
+    def test_get_hits_trec_format(self):
+        empty_hits_vespa_result = VespaResult(
+            vespa_result=self.raw_vespa_result_empty_hits
+        )
+        self.assertTrue(empty_hits_vespa_result.get_hits().empty)
+        vespa_result = VespaResult(vespa_result=self.raw_vespa_result)
+        assert_frame_equal(
+            vespa_result.get_hits(),
+            DataFrame(
+                data={
+                    "qid": [0],
+                    "docno": ["id:covid-19:doc::40215"],
+                    "score": [30.368213170494712],
+                    "rank": [0],
+                },
+                columns=["qid", "docno", "score", "rank"],
+            ),
+        )
+        vespa_result = VespaResult(vespa_result=self.raw_vespa_result_multiple)
+        assert_frame_equal(
+            vespa_result.get_hits(),
+            DataFrame(
+                data={
+                    "qid": [0, 0, 0],
+                    "docno": [
+                        "id:covid-19:doc::142863",
+                        "id:covid-19:doc::31328",
+                        "id:covid-19:doc::187156",
+                    ],
+                    "score": [
+                        11.893775281559614,
+                        11.891779491908013,
+                        11.887045666057702,
+                    ],
+                    "rank": [0, 1, 2],
+                },
+                columns=["qid", "docno", "score", "rank"],
+            ),
+        )
+        assert_frame_equal(
+            vespa_result.get_hits(id_field="cord_uid", qid=2),
+            DataFrame(
+                data={
+                    "qid": [2, 2, 2],
+                    "docno": [
+                        "0p6vrujx",
+                        "moy0u7n5",
+                        "rhmywn8n",
+                    ],
+                    "score": [
+                        11.893775281559614,
+                        11.891779491908013,
+                        11.887045666057702,
+                    ],
+                    "rank": [0, 1, 2],
+                },
+                columns=["qid", "docno", "score", "rank"],
+            ),
         )


### PR DESCRIPTION
Allow formatting query results according to TREC format.

<img width="392" alt="Skjermbilde 2021-04-27 kl  09 19 52" src="https://user-images.githubusercontent.com/2162939/116240042-c41ad780-a739-11eb-8aec-294ec87d841b.png">



I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
