### PR TITLE
support df as input to app.evaluate

### DIFF
--- a/vespa/application.py
+++ b/vespa/application.py
@@ -1,7 +1,7 @@
 # Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 import sys
-from typing import Optional, Dict, Tuple, List, IO
+from typing import Optional, Dict, Tuple, List, IO, Union
 from pandas import DataFrame
 from requests import Session
 from requests.models import Response
@@ -22,6 +22,37 @@ adapter = HTTPAdapter(max_retries=retry_strategy)
 http = Session()
 http.mount("https://", adapter)
 http.mount("http://", adapter)
+
+
+def parse_labeled_data(df):
+    """
+    Convert a DataFrame with labeled data to format used internally
+
+    :param df: DataFrame with the following required columns ["qid", "query", "doc_id", "relevance"].
+    :return: List of Dict containing a concise representation of the labeled data, grouped by query_id and query.
+    """
+    required_columns = ["qid", "query", "doc_id", "relevance"]
+    assert all(
+        [x in list(df.columns) for x in required_columns]
+    ), "DataFrame needs at least the following columns: {}".format(required_columns)
+    qid_query = (
+        df[["qid", "query"]].drop_duplicates(["qid", "query"]).to_dict(orient="records")
+    )
+    labeled_data = []
+    for q in qid_query:
+        docid_relevance = df[(df["qid"] == q["qid"]) & (df["query"] == q["query"])][
+            ["doc_id", "relevance"]
+        ]
+        relevant_docs = []
+        for idx, row in docid_relevance.iterrows():
+            relevant_docs.append({"id": row["doc_id"], "score": row["relevance"]})
+        data_point = {
+            "query_id": q["qid"],
+            "query": q["query"],
+            "relevant_docs": relevant_docs,
+        }
+        labeled_data.append(data_point)
+    return labeled_data
 
 
 class Vespa(object):
@@ -375,7 +406,7 @@ class Vespa(object):
 
     def evaluate(
         self,
-        labeled_data: List[Dict],
+        labeled_data: Union[List[Dict], DataFrame],
         eval_metrics: List[EvalMetric],
         query_model: QueryModel,
         id_field: str,
@@ -383,8 +414,33 @@ class Vespa(object):
         **kwargs
     ) -> DataFrame:
         """
+        Evaluate a :class:`QueryModel` according to a list of :class:`EvalMetric`.
 
-        :param labeled_data: Labelled data containing query, query_id and relevant ids.
+        labeled_data can be a DataFrame or a List of Dict:
+
+        >>> labeled_data_df = DataFrame(
+        ...     data={
+        ...         "qid": [0, 0, 1, 1],
+        ...         "query": ["Intrauterine virus infections and congenital heart disease", "Intrauterine virus infections and congenital heart disease", "Clinical and immunologic studies in identical twins discordant for systemic lupus erythematosus", "Clinical and immunologic studies in identical twins discordant for systemic lupus erythematosus"],
+        ...         "doc_id": [0, 3, 1, 5],
+        ...         "relevance": [1,1,1,1]
+        ...     }
+        ... )
+
+        >>> labeled_data = [
+        ...     {
+        ...         "query_id": 0,
+        ...         "query": "Intrauterine virus infections and congenital heart disease",
+        ...         "relevant_docs": [{"id": 0, "score": 1}, {"id": 3, "score": 1}]
+        ...     },
+        ...     {
+        ...         "query_id": 1,
+        ...         "query": "Clinical and immunologic studies in identical twins discordant for systemic lupus erythematosus",
+        ...         "relevant_docs": [{"id": 1, "score": 1}, {"id": 5, "score": 1}]
+        ...     }
+        ... ]
+
+        :param labeled_data: Labelled data containing query, query_id and relevant ids. See details about data format.
         :param eval_metrics: A list of evaluation metrics.
         :param query_model: Query model.
         :param id_field: The Vespa field representing the document id.
@@ -392,6 +448,9 @@ class Vespa(object):
         :param kwargs: Extra keyword arguments to be included in the Vespa Query.
         :return: DataFrame containing query_id and metrics according to the selected evaluation metrics.
         """
+        if isinstance(labeled_data, DataFrame):
+            labeled_data = parse_labeled_data(df=labeled_data)
+
         evaluation = []
         for query_data in labeled_data:
             evaluation_query = self.evaluate_query(

--- a/vespa/test_application.py
+++ b/vespa/test_application.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, call
 from pandas import DataFrame
 from pandas.testing import assert_frame_equal
 
-from vespa.application import Vespa
+from vespa.application import Vespa, parse_labeled_data
 from vespa.query import QueryModel, OR, RankProfile, VespaResult
 
 
@@ -92,6 +92,48 @@ class TestVespaQuery(unittest.TestCase):
                 "recall": "+(id:1 id:5)",
             },
         )
+
+
+class TestLabeledData(unittest.TestCase):
+    def test_parse_labeled_data(self):
+        labeled_data_df = DataFrame(
+            data={
+                "qid": [0, 0, 1, 1],
+                "query": ["Intrauterine virus infections and congenital heart disease"]
+                * 2
+                + [
+                    "Clinical and immunologic studies in identical twins discordant for systemic lupus erythematosus"
+                ]
+                * 2,
+                "doc_id": [0, 3, 1, 5],
+                "relevance": [1, 1, 1, 1],
+            }
+        )
+        labeled_data = parse_labeled_data(df=labeled_data_df)
+        expected_labeled_data = [
+            {
+                "query_id": 0,
+                "query": "Intrauterine virus infections and congenital heart disease",
+                "relevant_docs": [{"id": 0, "score": 1}, {"id": 3, "score": 1}],
+            },
+            {
+                "query_id": 1,
+                "query": "Clinical and immunologic studies in identical twins discordant for systemic lupus erythematosus",
+                "relevant_docs": [{"id": 1, "score": 1}, {"id": 5, "score": 1}],
+            },
+        ]
+        self.assertEqual(labeled_data, expected_labeled_data)
+
+    def test_parse_labeled_data_with_wrong_columns(self):
+        labeled_data_df = DataFrame(
+            data={
+                "qid": [0, 0, 1, 1],
+                "doc_id": [0, 3, 1, 5],
+                "relevance": [1, 1, 1, 1],
+            }
+        )
+        with self.assertRaises(AssertionError):
+            _ = parse_labeled_data(df=labeled_data_df)
 
 
 class TestVespaCollectData(unittest.TestCase):

--- a/vespa/test_integration_running_instance.py
+++ b/vespa/test_integration_running_instance.py
@@ -69,6 +69,21 @@ class TestRunningInstance(unittest.TestCase):
                 "relevant_docs": [{"id": 1, "score": 1}, {"id": 5, "score": 1}],
             },
         ]
+        # equivalent data in df format
+        labeled_data_df = DataFrame(
+            data={
+                "qid": [0, 0, 1, 1],
+                "query": ["Intrauterine virus infections and congenital heart disease"]
+                * 2
+                + [
+                    "Clinical and immunologic studies in identical twins discordant for systemic lupus erythematosus"
+                ]
+                * 2,
+                "doc_id": [0, 3, 1, 5],
+                "relevance": [1, 1, 1, 1],
+            }
+        )
+
         #
         # Collect training data
         #
@@ -94,6 +109,14 @@ class TestRunningInstance(unittest.TestCase):
         eval_metrics = [MatchRatio(), Recall(at=10), ReciprocalRank(at=10)]
         evaluation = app.evaluate(
             labeled_data=labeled_data,
+            eval_metrics=eval_metrics,
+            query_model=query_model,
+            id_field="id",
+        )
+        self.assertEqual(evaluation.shape, (2, 6))
+
+        evaluation = app.evaluate(
+            labeled_data=labeled_data_df,
             eval_metrics=eval_metrics,
             query_model=query_model,
             id_field="id",


### PR DESCRIPTION
Before this PR we only accepted a list of Dict as input to app.evaluate:

<img width="1015" alt="Skjermbilde 2021-04-28 kl  06 24 27" src="https://user-images.githubusercontent.com/2162939/116380620-81fd9e80-a7ea-11eb-96f7-8e25969a856e.png">

This PR allows the user to use a more familiar df format as input:

<img width="1013" alt="Skjermbilde 2021-04-28 kl  06 26 33" src="https://user-images.githubusercontent.com/2162939/116380824-b5402d80-a7ea-11eb-9586-ddf956c1d278.png">

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
