### PR TITLE
Simplified metrics output by default with option for detailed metrics

### DIFF
--- a/vespa/application.py
+++ b/vespa/application.py
@@ -347,6 +347,7 @@ class Vespa(object):
         id_field: str,
         relevant_docs: List[Dict],
         default_score: int = 0,
+        detailed_metrics=False,
         **kwargs
     ) -> Dict:
         """
@@ -359,6 +360,7 @@ class Vespa(object):
         :param id_field: The Vespa field representing the document id.
         :param relevant_docs: A list with dicts where each dict contains a doc id a optionally a doc score.
         :param default_score: Score to assign to the additional documents that are not relevant. Default to 0.
+        :param detailed_metrics: Return intermediate computations if available.
         :param kwargs: Extra keyword arguments to be included in the Vespa Query.
         :return: Dict containing query_id and metrics according to the selected evaluation metrics.
         """
@@ -368,7 +370,11 @@ class Vespa(object):
         for evaluator in eval_metrics:
             evaluation.update(
                 evaluator.evaluate_query(
-                    query_results, relevant_docs, id_field, default_score
+                    query_results,
+                    relevant_docs,
+                    id_field,
+                    default_score,
+                    detailed_metrics,
                 )
             )
         return evaluation
@@ -380,6 +386,7 @@ class Vespa(object):
         query_model: QueryModel,
         id_field: str,
         default_score: int = 0,
+        detailed_metrics=False,
         **kwargs
     ) -> DataFrame:
         """
@@ -389,6 +396,7 @@ class Vespa(object):
         :param query_model: Query model.
         :param id_field: The Vespa field representing the document id.
         :param default_score: Score to assign to the additional documents that are not relevant. Default to 0.
+        :param detailed_metrics: Return intermediate computations if available.
         :param kwargs: Extra keyword arguments to be included in the Vespa Query.
         :return: DataFrame containing query_id and metrics according to the selected evaluation metrics.
         """
@@ -402,6 +410,7 @@ class Vespa(object):
                 id_field=id_field,
                 relevant_docs=query_data["relevant_docs"],
                 default_score=default_score,
+                detailed_metrics=detailed_metrics,
                 **kwargs
             )
             evaluation.append(evaluation_query)

--- a/vespa/evaluation.py
+++ b/vespa/evaluation.py
@@ -10,7 +10,12 @@ class EvalMetric(object):
         pass
 
     def evaluate_query(
-        self, query_results, relevant_docs, id_field, default_score
+        self,
+        query_results,
+        relevant_docs,
+        id_field,
+        default_score,
+        detailed_metrics=False,
     ) -> Dict:
         raise NotImplementedError
 
@@ -29,6 +34,7 @@ class MatchRatio(EvalMetric):
         relevant_docs: List[Dict],
         id_field: str,
         default_score: int,
+        detailed_metrics=False,
     ) -> Dict:
         """
         Evaluate query results.
@@ -37,6 +43,7 @@ class MatchRatio(EvalMetric):
         :param relevant_docs: A list with dicts where each dict contains a doc id a optionally a doc score.
         :param id_field: The Vespa field representing the document id.
         :param default_score: Score to assign to the additional documents that are not relevant. Default to 0.
+        :param detailed_metrics: Return intermediate computations if available.
         :return: Dict containing the number of retrieved docs (_retrieved_docs), the number of docs available in
             the corpus (_docs_available) and the match ratio (_value).
         """
@@ -45,11 +52,17 @@ class MatchRatio(EvalMetric):
         value = 0
         if docs_available > 0:
             value = retrieved_docs / docs_available
-        return {
-            str(self.name) + "_retrieved_docs": retrieved_docs,
-            str(self.name) + "_docs_available": docs_available,
+        metrics = {
             str(self.name) + "_value": value,
         }
+        if detailed_metrics:
+            metrics.update(
+                {
+                    str(self.name) + "_retrieved_docs": retrieved_docs,
+                    str(self.name) + "_docs_available": docs_available,
+                }
+            )
+        return metrics
 
 
 class Recall(EvalMetric):
@@ -69,6 +82,7 @@ class Recall(EvalMetric):
         relevant_docs: List[Dict],
         id_field: str,
         default_score: int,
+        detailed_metrics=False,
     ) -> Dict:
         """
         Evaluate query results.
@@ -77,6 +91,7 @@ class Recall(EvalMetric):
         :param relevant_docs: A list with dicts where each dict contains a doc id a optionally a doc score.
         :param id_field: The Vespa field representing the document id.
         :param default_score: Score to assign to the additional documents that are not relevant. Default to 0.
+        :param detailed_metrics: Return intermediate computations if available.
         :return: Dict containing the recall value (_value).
         """
 
@@ -111,6 +126,7 @@ class ReciprocalRank(EvalMetric):
         relevant_docs: List[Dict],
         id_field: str,
         default_score: int,
+        detailed_metrics=False,
     ) -> Dict:
         """
         Evaluate query results.
@@ -119,6 +135,7 @@ class ReciprocalRank(EvalMetric):
         :param relevant_docs: A list with dicts where each dict contains a doc id a optionally a doc score.
         :param id_field: The Vespa field representing the document id.
         :param default_score: Score to assign to the additional documents that are not relevant. Default to 0.
+        :param detailed_metrics: Return intermediate computations if available.
         :return: Dict containing the reciprocal rank value (_value).
         """
 
@@ -154,6 +171,7 @@ class NormalizedDiscountedCumulativeGain(EvalMetric):
         relevant_docs: List[Dict],
         id_field: str,
         default_score: int,
+        detailed_metrics=False,
     ) -> Dict:
         """
         Evaluate query results.
@@ -162,6 +180,7 @@ class NormalizedDiscountedCumulativeGain(EvalMetric):
         :param relevant_docs: A list with dicts where each dict contains a doc id a optionally a doc score.
         :param id_field: The Vespa field representing the document id.
         :param default_score: Score to assign to the additional documents that are not relevant. Default to 0.
+        :param detailed_metrics: Return intermediate computations if available.
         :return: Dict containing the ideal discounted cumulative gain (_ideal_dcg), the discounted cumulative
             gain (_dcg) and the normalized discounted cumulative gain (_value).
         """
@@ -179,8 +198,14 @@ class NormalizedDiscountedCumulativeGain(EvalMetric):
         if ideal_dcg > 0:
             ndcg = dcg / ideal_dcg
 
-        return {
-            str(self.name) + "_ideal_dcg": ideal_dcg,
-            str(self.name) + "_dcg": dcg,
+        metrics = {
             str(self.name) + "_value": ndcg,
         }
+        if detailed_metrics:
+            metrics.update(
+                {
+                    str(self.name) + "_ideal_dcg": ideal_dcg,
+                    str(self.name) + "_dcg": dcg,
+                }
+            )
+        return metrics

--- a/vespa/test_application.py
+++ b/vespa/test_application.py
@@ -484,7 +484,7 @@ class TestVespaEvaluate(unittest.TestCase):
         self.assertEqual(eval_metric.evaluate_query.call_count, 1)
         eval_metric.evaluate_query.assert_has_calls(
             [
-                call({}, self.labeled_data[0]["relevant_docs"], "vespa_id_field", 0),
+                call({}, self.labeled_data[0]["relevant_docs"], "vespa_id_field", 0, False),
             ]
         )
         self.assertDictEqual(evaluation, {"query_id": "0", "metric": 1, "metric_2": 2})

--- a/vespa/test_evaluation.py
+++ b/vespa/test_evaluation.py
@@ -139,6 +139,21 @@ class TestEvalMetric(unittest.TestCase):
         self.assertDictEqual(
             evaluation,
             {
+                "match_ratio_value": 1083 / 62529,
+            },
+        )
+
+        evaluation = metric.evaluate_query(
+            query_results=VespaResult(self.query_results),
+            relevant_docs=self.labeled_data[0]["relevant_docs"],
+            id_field="vespa_id_field",
+            default_score=0,
+            detailed_metrics=True,
+        )
+
+        self.assertDictEqual(
+            evaluation,
+            {
                 "match_ratio_retrieved_docs": 1083,
                 "match_ratio_docs_available": 62529,
                 "match_ratio_value": 1083 / 62529,
@@ -170,6 +185,36 @@ class TestEvalMetric(unittest.TestCase):
         self.assertDictEqual(
             evaluation,
             {
+                "match_ratio_value": 0 / 62529,
+            },
+        )
+
+        evaluation = metric.evaluate_query(
+            query_results=VespaResult(
+                {
+                    "root": {
+                        "id": "toplevel",
+                        "relevance": 1.0,
+                        "coverage": {
+                            "coverage": 100,
+                            "documents": 62529,
+                            "full": True,
+                            "nodes": 2,
+                            "results": 1,
+                            "resultsFull": 1,
+                        },
+                    }
+                }
+            ),
+            relevant_docs=self.labeled_data[0]["relevant_docs"],
+            id_field="vespa_id_field",
+            default_score=0,
+            detailed_metrics=True,
+        )
+
+        self.assertDictEqual(
+            evaluation,
+            {
                 "match_ratio_retrieved_docs": 0,
                 "match_ratio_docs_available": 62529,
                 "match_ratio_value": 0 / 62529,
@@ -196,6 +241,36 @@ class TestEvalMetric(unittest.TestCase):
             relevant_docs=self.labeled_data[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
+        )
+
+        self.assertDictEqual(
+            evaluation,
+            {
+                "match_ratio_value": 0,
+            },
+        )
+
+        evaluation = metric.evaluate_query(
+            query_results=VespaResult(
+                {
+                    "root": {
+                        "id": "toplevel",
+                        "relevance": 1.0,
+                        "fields": {"totalCount": 1083},
+                        "coverage": {
+                            "coverage": 100,
+                            "full": True,
+                            "nodes": 2,
+                            "results": 1,
+                            "resultsFull": 1,
+                        },
+                    }
+                }
+            ),
+            relevant_docs=self.labeled_data[0]["relevant_docs"],
+            id_field="vespa_id_field",
+            default_score=0,
+            detailed_metrics=True,
         )
 
         self.assertDictEqual(
@@ -305,6 +380,21 @@ class TestEvalMetric(unittest.TestCase):
         expected_dcg = 0 / math.log2(2) + 1 / math.log2(3)
         expected_ideal_dcg = 1 / math.log2(2) + 0 / math.log2(3)
         expected_ndcg = expected_dcg / expected_ideal_dcg
+
+        self.assertDictEqual(
+            evaluation,
+            {
+                "ndcg_2_value": expected_ndcg,
+            },
+        )
+        evaluation = metric.evaluate_query(
+            query_results=VespaResult(self.query_results),
+            relevant_docs=self.labeled_data[0]["relevant_docs"],
+            id_field="vespa_id_field",
+            default_score=0,
+            detailed_metrics=True,
+        )
+
         self.assertDictEqual(
             evaluation,
             {
@@ -327,6 +417,20 @@ class TestEvalMetric(unittest.TestCase):
         self.assertDictEqual(
             evaluation,
             {
+                "ndcg_1_value": expected_ndcg,
+            },
+        )
+        evaluation = metric.evaluate_query(
+            query_results=VespaResult(self.query_results),
+            relevant_docs=self.labeled_data[0]["relevant_docs"],
+            id_field="vespa_id_field",
+            default_score=0,
+            detailed_metrics=True,
+        )
+
+        self.assertDictEqual(
+            evaluation,
+            {
                 "ndcg_1_ideal_dcg": expected_ideal_dcg,
                 "ndcg_1_dcg": expected_dcg,
                 "ndcg_1_value": expected_ndcg,
@@ -343,6 +447,21 @@ class TestEvalMetric(unittest.TestCase):
         expected_dcg = 1 / math.log2(2) + 0 / math.log2(3) + 2 / math.log2(4)
         expected_ideal_dcg = 2 / math.log2(2) + 1 / math.log2(3) + 0 / math.log2(4)
         expected_ndcg = expected_dcg / expected_ideal_dcg
+        self.assertDictEqual(
+            evaluation,
+            {
+                "ndcg_3_value": expected_ndcg,
+            },
+        )
+
+        evaluation = metric.evaluate_query(
+            query_results=VespaResult(self.query_results2),
+            relevant_docs=self.labeled_data2[0]["relevant_docs"],
+            id_field="vespa_id_field",
+            default_score=0,
+            detailed_metrics=True,
+        )
+
         self.assertDictEqual(
             evaluation,
             {

--- a/vespa/test_integration_running_instance.py
+++ b/vespa/test_integration_running_instance.py
@@ -98,7 +98,7 @@ class TestRunningInstance(unittest.TestCase):
             query_model=query_model,
             id_field="id",
         )
-        self.assertEqual(evaluation.shape, (2, 6))
+        self.assertEqual(evaluation.shape, (2, 4))
 
     def test_collect_training_data(self):
         app = Vespa(url="https://api.cord19.vespa.ai")

--- a/vespa/test_integration_running_instance.py
+++ b/vespa/test_integration_running_instance.py
@@ -120,6 +120,7 @@ class TestRunningInstance(unittest.TestCase):
             eval_metrics=eval_metrics,
             query_model=query_model,
             id_field="id",
+            detailed_metrics=True
         )
         self.assertEqual(evaluation.shape, (2, 6))
 


### PR DESCRIPTION
Evaluation returns just the basic metric values by default. The option `detailed_metrics` allow intermediate metric values to be returned as well.

<img width="1017" alt="Skjermbilde 2021-04-28 kl  08 01 40" src="https://user-images.githubusercontent.com/2162939/116393434-fdb21800-a7f7-11eb-84a3-5d3b0933b491.png">


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
