### PR TITLE
Evaluate multiple query models

### DIFF
--- a/vespa/application.py
+++ b/vespa/application.py
@@ -397,7 +397,7 @@ class Vespa(object):
         """
 
         query_results = self.query(query=query, query_model=query_model, **kwargs)
-        evaluation = {"query_id": query_id}
+        evaluation = {"model": query_model.name, "query_id": query_id}
         for evaluator in eval_metrics:
             evaluation.update(
                 evaluator.evaluate_query(
@@ -462,6 +462,11 @@ class Vespa(object):
         if isinstance(query_model, QueryModel):
             query_model = [query_model]
 
+        model_names = [model.name for model in query_model]
+        assert len(model_names) == len(
+            set(model_names)
+        ), "Duplicate model names. Choose unique model names."
+
         evaluation = []
         for query_data in labeled_data:
             for model in query_model:
@@ -476,7 +481,6 @@ class Vespa(object):
                     detailed_metrics=detailed_metrics,
                     **kwargs
                 )
-                evaluation_query.update({"model": "model_name"})
                 evaluation.append(evaluation_query)
         evaluation = DataFrame.from_records(evaluation)
         return evaluation

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -347,6 +347,7 @@ class Vespa(object):
         id_field: str,
         relevant_docs: List[Dict],
         default_score: int = 0,
+        detailed_metrics=False,
         **kwargs
     ) -> Dict:
         """
@@ -359,6 +360,7 @@ class Vespa(object):
         :param id_field: The Vespa field representing the document id.
         :param relevant_docs: A list with dicts where each dict contains a doc id a optionally a doc score.
         :param default_score: Score to assign to the additional documents that are not relevant. Default to 0.
+        :param detailed_metrics: Return intermediate computations if available.
         :param kwargs: Extra keyword arguments to be included in the Vespa Query.
         :return: Dict containing query_id and metrics according to the selected evaluation metrics.
         """
@@ -368,7 +370,11 @@ class Vespa(object):
         for evaluator in eval_metrics:
             evaluation.update(
                 evaluator.evaluate_query(
-                    query_results, relevant_docs, id_field, default_score
+                    query_results,
+                    relevant_docs,
+                    id_field,
+                    default_score,
+                    detailed_metrics,
                 )
             )
         return evaluation
@@ -380,6 +386,7 @@ class Vespa(object):
         query_model: QueryModel,
         id_field: str,
         default_score: int = 0,
+        detailed_metrics=False,
         **kwargs
     ) -> DataFrame:
         """
@@ -389,6 +396,7 @@ class Vespa(object):
         :param query_model: Query model.
         :param id_field: The Vespa field representing the document id.
         :param default_score: Score to assign to the additional documents that are not relevant. Default to 0.
+        :param detailed_metrics: Return intermediate computations if available.
         :param kwargs: Extra keyword arguments to be included in the Vespa Query.
         :return: DataFrame containing query_id and metrics according to the selected evaluation metrics.
         """
@@ -402,6 +410,7 @@ class Vespa(object):
                 id_field=id_field,
                 relevant_docs=query_data["relevant_docs"],
                 default_score=default_score,
+                detailed_metrics=detailed_metrics,
                 **kwargs
             )
             evaluation.append(evaluation_query)

--- a/vespa/evaluation.py
+++ b/vespa/evaluation.py
@@ -10,7 +10,12 @@ class EvalMetric(object):
         pass
 
     def evaluate_query(
-        self, query_results, relevant_docs, id_field, default_score
+        self,
+        query_results,
+        relevant_docs,
+        id_field,
+        default_score,
+        detailed_metrics=False,
     ) -> Dict:
         raise NotImplementedError
 
@@ -29,6 +34,7 @@ class MatchRatio(EvalMetric):
         relevant_docs: List[Dict],
         id_field: str,
         default_score: int,
+        detailed_metrics=False,
     ) -> Dict:
         """
         Evaluate query results.
@@ -37,6 +43,7 @@ class MatchRatio(EvalMetric):
         :param relevant_docs: A list with dicts where each dict contains a doc id a optionally a doc score.
         :param id_field: The Vespa field representing the document id.
         :param default_score: Score to assign to the additional documents that are not relevant. Default to 0.
+        :param detailed_metrics: Return intermediate computations if available.
         :return: Dict containing the number of retrieved docs (_retrieved_docs), the number of docs available in
             the corpus (_docs_available) and the match ratio (_value).
         """
@@ -45,11 +52,17 @@ class MatchRatio(EvalMetric):
         value = 0
         if docs_available > 0:
             value = retrieved_docs / docs_available
-        return {
-            str(self.name) + "_retrieved_docs": retrieved_docs,
-            str(self.name) + "_docs_available": docs_available,
+        metrics = {
             str(self.name) + "_value": value,
         }
+        if detailed_metrics:
+            metrics.update(
+                {
+                    str(self.name) + "_retrieved_docs": retrieved_docs,
+                    str(self.name) + "_docs_available": docs_available,
+                }
+            )
+        return metrics
 
 
 class Recall(EvalMetric):
@@ -69,6 +82,7 @@ class Recall(EvalMetric):
         relevant_docs: List[Dict],
         id_field: str,
         default_score: int,
+        detailed_metrics=False,
     ) -> Dict:
         """
         Evaluate query results.
@@ -77,6 +91,7 @@ class Recall(EvalMetric):
         :param relevant_docs: A list with dicts where each dict contains a doc id a optionally a doc score.
         :param id_field: The Vespa field representing the document id.
         :param default_score: Score to assign to the additional documents that are not relevant. Default to 0.
+        :param detailed_metrics: Return intermediate computations if available.
         :return: Dict containing the recall value (_value).
         """
 
@@ -111,6 +126,7 @@ class ReciprocalRank(EvalMetric):
         relevant_docs: List[Dict],
         id_field: str,
         default_score: int,
+        detailed_metrics=False,
     ) -> Dict:
         """
         Evaluate query results.
@@ -119,6 +135,7 @@ class ReciprocalRank(EvalMetric):
         :param relevant_docs: A list with dicts where each dict contains a doc id a optionally a doc score.
         :param id_field: The Vespa field representing the document id.
         :param default_score: Score to assign to the additional documents that are not relevant. Default to 0.
+        :param detailed_metrics: Return intermediate computations if available.
         :return: Dict containing the reciprocal rank value (_value).
         """
 
@@ -154,6 +171,7 @@ class NormalizedDiscountedCumulativeGain(EvalMetric):
         relevant_docs: List[Dict],
         id_field: str,
         default_score: int,
+        detailed_metrics=False,
     ) -> Dict:
         """
         Evaluate query results.
@@ -162,6 +180,7 @@ class NormalizedDiscountedCumulativeGain(EvalMetric):
         :param relevant_docs: A list with dicts where each dict contains a doc id a optionally a doc score.
         :param id_field: The Vespa field representing the document id.
         :param default_score: Score to assign to the additional documents that are not relevant. Default to 0.
+        :param detailed_metrics: Return intermediate computations if available.
         :return: Dict containing the ideal discounted cumulative gain (_ideal_dcg), the discounted cumulative
             gain (_dcg) and the normalized discounted cumulative gain (_value).
         """
@@ -179,8 +198,14 @@ class NormalizedDiscountedCumulativeGain(EvalMetric):
         if ideal_dcg > 0:
             ndcg = dcg / ideal_dcg
 
-        return {
-            str(self.name) + "_ideal_dcg": ideal_dcg,
-            str(self.name) + "_dcg": dcg,
+        metrics = {
             str(self.name) + "_value": ndcg,
         }
+        if detailed_metrics:
+            metrics.update(
+                {
+                    str(self.name) + "_ideal_dcg": ideal_dcg,
+                    str(self.name) + "_dcg": dcg,
+                }
+            )
+        return metrics

--- a/vespa/query.py
+++ b/vespa/query.py
@@ -205,6 +205,7 @@ class RankProfile(object):
 class QueryModel(object):
     def __init__(
         self,
+        name: str = "default_name",
         query_properties: Optional[List[QueryProperty]] = None,
         match_phase: MatchFilter = AND(),
         rank_profile: RankProfile = RankProfile(),
@@ -213,11 +214,13 @@ class QueryModel(object):
         """
         Define a query model.
 
+        :param name: Name of the query model. Used to tag model related quantities, like evaluation metrics.
         :param query_properties: Optional list of QueryProperty.
         :param match_phase: Define the match criteria. One of the MatchFilter options available.
         :param rank_profile: Define the rank criteria.
         :param body_function: Function that take query as parameter and returns the body of a Vespa query.
         """
+        self.name = name
         self.query_properties = query_properties if query_properties is not None else []
         self.match_phase = match_phase
         self.rank_profile = rank_profile
@@ -272,7 +275,9 @@ def trec_format(
         records.append(
             {
                 "qid": qid,
-                "doc_id": hit["fields"][id_field] if id_field is not None else hit["id"],
+                "doc_id": hit["fields"][id_field]
+                if id_field is not None
+                else hit["id"],
                 "score": hit["relevance"],
                 "rank": rank,
             }

--- a/vespa/test_application.py
+++ b/vespa/test_application.py
@@ -545,5 +545,5 @@ class TestVespaEvaluate(unittest.TestCase):
             default_score=0,
         )
         assert_frame_equal(
-            evaluation, DataFrame.from_records([{"query_id": "0", "metric": 1, "model": "model_name"}])
+            evaluation, DataFrame.from_records([{"query_id": "0", "metric": 1, "model": "default_name"}])
         )

--- a/vespa/test_application.py
+++ b/vespa/test_application.py
@@ -540,10 +540,10 @@ class TestVespaEvaluate(unittest.TestCase):
         evaluation = self.app.evaluate(
             labeled_data=self.labeled_data,
             eval_metrics=[Mock()],
-            query_model=Mock(),
+            query_model=QueryModel(),
             id_field="mock",
             default_score=0,
         )
         assert_frame_equal(
-            evaluation, DataFrame.from_records([{"query_id": "0", "metric": 1}])
+            evaluation, DataFrame.from_records([{"query_id": "0", "metric": 1, "model": "model_name"}])
         )

--- a/vespa/test_application.py
+++ b/vespa/test_application.py
@@ -484,7 +484,7 @@ class TestVespaEvaluate(unittest.TestCase):
         self.assertEqual(eval_metric.evaluate_query.call_count, 1)
         eval_metric.evaluate_query.assert_has_calls(
             [
-                call({}, self.labeled_data[0]["relevant_docs"], "vespa_id_field", 0),
+                call({}, self.labeled_data[0]["relevant_docs"], "vespa_id_field", 0, False),
             ]
         )
         self.assertDictEqual(evaluation, {"query_id": "0", "metric": 1, "metric_2": 2})

--- a/vespa/test_application.py
+++ b/vespa/test_application.py
@@ -526,15 +526,24 @@ class TestVespaEvaluate(unittest.TestCase):
         self.assertEqual(eval_metric.evaluate_query.call_count, 1)
         eval_metric.evaluate_query.assert_has_calls(
             [
-                call({}, self.labeled_data[0]["relevant_docs"], "vespa_id_field", 0, False),
+                call(
+                    {},
+                    self.labeled_data[0]["relevant_docs"],
+                    "vespa_id_field",
+                    0,
+                    False,
+                ),
             ]
         )
-        self.assertDictEqual(evaluation, {"query_id": "0", "metric": 1, "metric_2": 2})
+        self.assertDictEqual(
+            evaluation,
+            {"model": "default_name", "query_id": "0", "metric": 1, "metric_2": 2},
+        )
 
     def test_evaluate(self):
         self.app.evaluate_query = Mock(
             side_effect=[
-                {"query_id": "0", "metric": 1},
+                {"model": "default_name", "query_id": "0", "metric": 1},
             ]
         )
         evaluation = self.app.evaluate(
@@ -544,6 +553,16 @@ class TestVespaEvaluate(unittest.TestCase):
             id_field="mock",
             default_score=0,
         )
+        print(evaluation)
         assert_frame_equal(
-            evaluation, DataFrame.from_records([{"query_id": "0", "metric": 1, "model": "default_name"}])
+            evaluation,
+            DataFrame.from_records(
+                [
+                    {
+                        "model": "default_name",
+                        "query_id": "0",
+                        "metric": 1,
+                    }
+                ]
+            ),
         )

--- a/vespa/test_evaluation.py
+++ b/vespa/test_evaluation.py
@@ -139,6 +139,21 @@ class TestEvalMetric(unittest.TestCase):
         self.assertDictEqual(
             evaluation,
             {
+                "match_ratio_value": 1083 / 62529,
+            },
+        )
+
+        evaluation = metric.evaluate_query(
+            query_results=VespaResult(self.query_results),
+            relevant_docs=self.labeled_data[0]["relevant_docs"],
+            id_field="vespa_id_field",
+            default_score=0,
+            detailed_metrics=True,
+        )
+
+        self.assertDictEqual(
+            evaluation,
+            {
                 "match_ratio_retrieved_docs": 1083,
                 "match_ratio_docs_available": 62529,
                 "match_ratio_value": 1083 / 62529,
@@ -170,6 +185,36 @@ class TestEvalMetric(unittest.TestCase):
         self.assertDictEqual(
             evaluation,
             {
+                "match_ratio_value": 0 / 62529,
+            },
+        )
+
+        evaluation = metric.evaluate_query(
+            query_results=VespaResult(
+                {
+                    "root": {
+                        "id": "toplevel",
+                        "relevance": 1.0,
+                        "coverage": {
+                            "coverage": 100,
+                            "documents": 62529,
+                            "full": True,
+                            "nodes": 2,
+                            "results": 1,
+                            "resultsFull": 1,
+                        },
+                    }
+                }
+            ),
+            relevant_docs=self.labeled_data[0]["relevant_docs"],
+            id_field="vespa_id_field",
+            default_score=0,
+            detailed_metrics=True,
+        )
+
+        self.assertDictEqual(
+            evaluation,
+            {
                 "match_ratio_retrieved_docs": 0,
                 "match_ratio_docs_available": 62529,
                 "match_ratio_value": 0 / 62529,
@@ -196,6 +241,36 @@ class TestEvalMetric(unittest.TestCase):
             relevant_docs=self.labeled_data[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
+        )
+
+        self.assertDictEqual(
+            evaluation,
+            {
+                "match_ratio_value": 0,
+            },
+        )
+
+        evaluation = metric.evaluate_query(
+            query_results=VespaResult(
+                {
+                    "root": {
+                        "id": "toplevel",
+                        "relevance": 1.0,
+                        "fields": {"totalCount": 1083},
+                        "coverage": {
+                            "coverage": 100,
+                            "full": True,
+                            "nodes": 2,
+                            "results": 1,
+                            "resultsFull": 1,
+                        },
+                    }
+                }
+            ),
+            relevant_docs=self.labeled_data[0]["relevant_docs"],
+            id_field="vespa_id_field",
+            default_score=0,
+            detailed_metrics=True,
         )
 
         self.assertDictEqual(
@@ -305,6 +380,21 @@ class TestEvalMetric(unittest.TestCase):
         expected_dcg = 0 / math.log2(2) + 1 / math.log2(3)
         expected_ideal_dcg = 1 / math.log2(2) + 0 / math.log2(3)
         expected_ndcg = expected_dcg / expected_ideal_dcg
+
+        self.assertDictEqual(
+            evaluation,
+            {
+                "ndcg_2_value": expected_ndcg,
+            },
+        )
+        evaluation = metric.evaluate_query(
+            query_results=VespaResult(self.query_results),
+            relevant_docs=self.labeled_data[0]["relevant_docs"],
+            id_field="vespa_id_field",
+            default_score=0,
+            detailed_metrics=True,
+        )
+
         self.assertDictEqual(
             evaluation,
             {
@@ -327,6 +417,20 @@ class TestEvalMetric(unittest.TestCase):
         self.assertDictEqual(
             evaluation,
             {
+                "ndcg_1_value": expected_ndcg,
+            },
+        )
+        evaluation = metric.evaluate_query(
+            query_results=VespaResult(self.query_results),
+            relevant_docs=self.labeled_data[0]["relevant_docs"],
+            id_field="vespa_id_field",
+            default_score=0,
+            detailed_metrics=True,
+        )
+
+        self.assertDictEqual(
+            evaluation,
+            {
                 "ndcg_1_ideal_dcg": expected_ideal_dcg,
                 "ndcg_1_dcg": expected_dcg,
                 "ndcg_1_value": expected_ndcg,
@@ -343,6 +447,21 @@ class TestEvalMetric(unittest.TestCase):
         expected_dcg = 1 / math.log2(2) + 0 / math.log2(3) + 2 / math.log2(4)
         expected_ideal_dcg = 2 / math.log2(2) + 1 / math.log2(3) + 0 / math.log2(4)
         expected_ndcg = expected_dcg / expected_ideal_dcg
+        self.assertDictEqual(
+            evaluation,
+            {
+                "ndcg_3_value": expected_ndcg,
+            },
+        )
+
+        evaluation = metric.evaluate_query(
+            query_results=VespaResult(self.query_results2),
+            relevant_docs=self.labeled_data2[0]["relevant_docs"],
+            id_field="vespa_id_field",
+            default_score=0,
+            detailed_metrics=True,
+        )
+
         self.assertDictEqual(
             evaluation,
             {

--- a/vespa/test_integration_running_instance.py
+++ b/vespa/test_integration_running_instance.py
@@ -98,7 +98,7 @@ class TestRunningInstance(unittest.TestCase):
             query_model=query_model,
             id_field="id",
         )
-        self.assertEqual(evaluation.shape, (2, 6))
+        self.assertEqual(evaluation.shape, (2, 4))
 
     def test_collect_training_data(self):
         app = Vespa(url="https://api.cord19.vespa.ai")

--- a/vespa/test_integration_running_instance.py
+++ b/vespa/test_integration_running_instance.py
@@ -120,6 +120,7 @@ class TestRunningInstance(unittest.TestCase):
             eval_metrics=eval_metrics,
             query_model=query_model,
             id_field="id",
+            detailed_metrics=True
         )
         self.assertEqual(evaluation.shape, (2, 6))
 

--- a/vespa/test_integration_running_instance.py
+++ b/vespa/test_integration_running_instance.py
@@ -113,7 +113,7 @@ class TestRunningInstance(unittest.TestCase):
             query_model=query_model,
             id_field="id",
         )
-        self.assertEqual(evaluation.shape, (2, 4))
+        self.assertEqual(evaluation.shape, (2, 5))
 
         evaluation = app.evaluate(
             labeled_data=labeled_data_df,
@@ -122,7 +122,7 @@ class TestRunningInstance(unittest.TestCase):
             id_field="id",
             detailed_metrics=True
         )
-        self.assertEqual(evaluation.shape, (2, 6))
+        self.assertEqual(evaluation.shape, (2, 7))
 
     def test_collect_training_data(self):
         app = Vespa(url="https://api.cord19.vespa.ai")

--- a/vespa/test_integration_running_instance.py
+++ b/vespa/test_integration_running_instance.py
@@ -36,6 +36,7 @@ class TestRunningInstance(unittest.TestCase):
         )
         rank_profile = Ranking(name="bm25", list_features=True)
         query_model = QueryModel(
+            name="ANN_bm25",
             query_properties=[
                 QueryRankingFeature(
                     name="title_vector",
@@ -115,12 +116,31 @@ class TestRunningInstance(unittest.TestCase):
         )
         self.assertEqual(evaluation.shape, (2, 5))
 
+        #
+        # AssertionError - two models with the same name
+        #
+        with self.assertRaises(AssertionError):
+            _ = app.evaluate(
+                labeled_data=labeled_data,
+                eval_metrics=eval_metrics,
+                query_model=[QueryModel(), QueryModel(), query_model],
+                id_field="id",
+            )
+
+        evaluation = app.evaluate(
+            labeled_data=labeled_data,
+            eval_metrics=eval_metrics,
+            query_model=[QueryModel(), query_model],
+            id_field="id",
+        )
+        self.assertEqual(evaluation.shape, (4, 5))
+
         evaluation = app.evaluate(
             labeled_data=labeled_data_df,
             eval_metrics=eval_metrics,
             query_model=query_model,
             id_field="id",
-            detailed_metrics=True
+            detailed_metrics=True,
         )
         self.assertEqual(evaluation.shape, (2, 7))
 


### PR DESCRIPTION
We can now give a name to QueryModel. This will be used to identify the model when computing metrics.

<img width="1013" alt="Skjermbilde 2021-04-28 kl  20 54 41" src="https://user-images.githubusercontent.com/2162939/116486491-27088d80-a864-11eb-95a8-29d9cf034a2b.png">

We can evaluate a single model as before.

<img width="1013" alt="Skjermbilde 2021-04-28 kl  21 00 43" src="https://user-images.githubusercontent.com/2162939/116486804-d6ddfb00-a864-11eb-9d62-bfc28d21fdd5.png">

Or compare multiple models:

<img width="1015" alt="Skjermbilde 2021-04-28 kl  21 06 56" src="https://user-images.githubusercontent.com/2162939/116487154-afd3f900-a865-11eb-849a-580160fb62ca.png">

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
