### PR TITLE
Fix reciprocal rank metric computation when vespa id field is of type int

### DIFF
--- a/vespa/evaluation.py
+++ b/vespa/evaluation.py
@@ -142,7 +142,7 @@ class ReciprocalRank(EvalMetric):
         rr = 0
         hits = query_results.hits[: self.at]
         for index, hit in enumerate(hits):
-            if hit["fields"][id_field] in relevant_ids:
+            if str(hit["fields"][id_field]) in relevant_ids:
                 rr = 1 / (index + 1)
                 break
 

--- a/vespa/test_evaluation.py
+++ b/vespa/test_evaluation.py
@@ -126,6 +126,68 @@ class TestEvalMetric(unittest.TestCase):
             }
         }
 
+        self.labeled_data_int_id = [
+            {
+                "query_id": 0,
+                "query": "Intrauterine virus infections and congenital heart disease",
+                "relevant_docs": [{"id": 1, "score": 1}, {"id": 3, "score": 2}],
+            },
+        ]
+
+        self.query_results_int_id = {
+            "root": {
+                "id": "toplevel",
+                "relevance": 1.0,
+                "fields": {"totalCount": 1083},
+                "coverage": {
+                    "coverage": 100,
+                    "documents": 62529,
+                    "full": True,
+                    "nodes": 2,
+                    "results": 1,
+                    "resultsFull": 1,
+                },
+                "children": [
+                    {
+                        "id": "id:covid-19:doc::40216",
+                        "relevance": 10,
+                        "source": "content",
+                        "fields": {
+                            "vespa_id_field": 1,
+                            "sddocname": "doc",
+                            "body_text": "this is a body 2",
+                            "title": "this is a title 2",
+                            "rankfeatures": {"a": 3, "b": 4},
+                        },
+                    },
+                    {
+                        "id": "id:covid-19:doc::40217",
+                        "relevance": 8,
+                        "source": "content",
+                        "fields": {
+                            "vespa_id_field": 2,
+                            "sddocname": "doc",
+                            "body_text": "this is a body 3",
+                            "title": "this is a title 3",
+                            "rankfeatures": {"a": 5, "b": 6},
+                        },
+                    },
+                    {
+                        "id": "id:covid-19:doc::40218",
+                        "relevance": 6,
+                        "source": "content",
+                        "fields": {
+                            "vespa_id_field": 3,
+                            "sddocname": "doc",
+                            "body_text": "this is a body 4",
+                            "title": "this is a title 4",
+                            "rankfeatures": {"a": 7, "b": 8},
+                        },
+                    },
+                ],
+            }
+        }
+
     def test_match_ratio(self):
         metric = MatchRatio()
 
@@ -325,6 +387,21 @@ class TestEvalMetric(unittest.TestCase):
             },
         )
 
+        metric = Recall(at=3)
+        evaluation = metric.evaluate_query(
+            query_results=VespaResult(self.query_results_int_id),
+            relevant_docs=self.labeled_data_int_id[0]["relevant_docs"],
+            id_field="vespa_id_field",
+            default_score=0,
+        )
+        self.assertDictEqual(
+            evaluation,
+            {
+                "recall_3": 1,
+            },
+        )
+
+
     def test_reciprocal_rank(self):
         metric = ReciprocalRank(at=2)
         evaluation = metric.evaluate_query(
@@ -358,6 +435,20 @@ class TestEvalMetric(unittest.TestCase):
         evaluation = metric.evaluate_query(
             query_results=VespaResult(self.query_results2),
             relevant_docs=self.labeled_data2[0]["relevant_docs"],
+            id_field="vespa_id_field",
+            default_score=0,
+        )
+        self.assertDictEqual(
+            evaluation,
+            {
+                "reciprocal_rank_3": 1.0,
+            },
+        )
+
+        metric = ReciprocalRank(at=3)
+        evaluation = metric.evaluate_query(
+            query_results=VespaResult(self.query_results_int_id),
+            relevant_docs=self.labeled_data_int_id[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
         )
@@ -457,6 +548,39 @@ class TestEvalMetric(unittest.TestCase):
         evaluation = metric.evaluate_query(
             query_results=VespaResult(self.query_results2),
             relevant_docs=self.labeled_data2[0]["relevant_docs"],
+            id_field="vespa_id_field",
+            default_score=0,
+            detailed_metrics=True,
+        )
+
+        self.assertDictEqual(
+            evaluation,
+            {
+                "ndcg_3_ideal_dcg": expected_ideal_dcg,
+                "ndcg_3_dcg": expected_dcg,
+                "ndcg_3": expected_ndcg,
+            },
+        )
+
+        evaluation = metric.evaluate_query(
+            query_results=VespaResult(self.query_results_int_id),
+            relevant_docs=self.labeled_data_int_id[0]["relevant_docs"],
+            id_field="vespa_id_field",
+            default_score=0,
+        )
+        expected_dcg = 1 / math.log2(2) + 0 / math.log2(3) + 2 / math.log2(4)
+        expected_ideal_dcg = 2 / math.log2(2) + 1 / math.log2(3) + 0 / math.log2(4)
+        expected_ndcg = expected_dcg / expected_ideal_dcg
+        self.assertDictEqual(
+            evaluation,
+            {
+                "ndcg_3": expected_ndcg,
+            },
+        )
+
+        evaluation = metric.evaluate_query(
+            query_results=VespaResult(self.query_results_int_id),
+            relevant_docs=self.labeled_data_int_id[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
             detailed_metrics=True,


### PR DESCRIPTION
Fix a bug where reciprocal rank metric would be wrong with the vespa id field was of type int.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
