### PR TITLE
Port travis clean

### DIFF
--- a/docs/sphinx/source/howto/deploy_app_package/deploy-docker.ipynb
+++ b/docs/sphinx/source/howto/deploy_app_package/deploy-docker.ipynb
@@ -65,9 +65,10 @@
     "import os\n",
     "from vespa.package import VespaDocker\n",
     "\n",
+    "disk_folder = os.path.join(os.getenv(\"WORK_DIR\"), \"sample_application\") # specify your desired absolute path here\n",
     "vespa_docker = VespaDocker(\n",
     "    port=8080,\n",
-    "    disk_folder=os.path.join(os.getenv(\"WORK_DIR\"), \"sample_application\") # specify your desired absolute path here\n",
+    "    disk_folder=disk_folder\n",
     ")\n",
     "\n",
     "app = vespa_docker.deploy(\n",
@@ -80,6 +81,26 @@
    "metadata": {},
    "source": [
     "`app` now holds a [Vespa](../../reference-api.rst#vespa.application.Vespa) instance, which we are going to use to interact with our application. Congratulations, you now have a Vespa application up and running."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Clean up the environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from shutil import rmtree\n",
+    "\n",
+    "rmtree(disk_folder, ignore_errors=True)\n",
+    "vespa_docker.container.stop()\n",
+    "vespa_docker.container.remove()"
    ]
   },
   {

--- a/docs/sphinx/source/howto/deploy_app_package/deploy-docker.ipynb
+++ b/docs/sphinx/source/howto/deploy_app_package/deploy-docker.ipynb
@@ -65,10 +65,9 @@
     "import os\n",
     "from vespa.package import VespaDocker\n",
     "\n",
-    "disk_folder = os.path.join(os.getenv(\"WORK_DIR\"), \"sample_application\") # specify your desired absolute path here\n",
     "vespa_docker = VespaDocker(\n",
     "    port=8080,\n",
-    "    disk_folder=disk_folder\n",
+    "    disk_folder=os.path.join(os.getenv(\"WORK_DIR\"), \"sample_application\") # specify your desired absolute path here\n",
     ")\n",
     "\n",
     "app = vespa_docker.deploy(\n",
@@ -81,26 +80,6 @@
    "metadata": {},
    "source": [
     "`app` now holds a [Vespa](../../reference-api.rst#vespa.application.Vespa) instance, which we are going to use to interact with our application. Congratulations, you now have a Vespa application up and running."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Clean up the environment"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from shutil import rmtree\n",
-    "\n",
-    "rmtree(disk_folder, ignore_errors=True)\n",
-    "vespa_docker.container.stop()\n",
-    "vespa_docker.container.remove()"
    ]
   },
   {

--- a/docs/sphinx/source/three-ways-to-get-started-with-pyvespa.ipynb
+++ b/docs/sphinx/source/three-ways-to-get-started-with-pyvespa.ipynb
@@ -178,7 +178,6 @@
     "disk_folder = os.path.join(os.getenv(\"WORK_DIR\"), \"sample_application\")\n",
     "vespa_docker = VespaDocker(\n",
     "    disk_folder=disk_folder, # chose your absolute folder\n",
-    "    container_memory=\"8G\",\n",
     "    port=8089\n",
     ")\n",
     "app = vespa_docker.deploy(application_package=app_package)"
@@ -350,7 +349,6 @@
     "disk_folder_news = os.path.join(os.getenv(\"WORK_DIR\"), \"sample-apps/news/app-3-searching/\")\n",
     "vespa_docker_news = VespaDocker(\n",
     "    disk_folder=disk_folder_news, \n",
-    "    container_memory=\"8G\", \n",
     "    port=8090\n",
     ")\n",
     "app = vespa_docker_news.deploy_from_disk(application_name=\"news\")"

--- a/docs/sphinx/source/three-ways-to-get-started-with-pyvespa.ipynb
+++ b/docs/sphinx/source/three-ways-to-get-started-with-pyvespa.ipynb
@@ -212,6 +212,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "incident-choir",
+   "metadata": {},
+   "source": [
+    "### Clean up environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "nearby-venice",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from shutil import rmtree\n",
+    "\n",
+    "rmtree(disk_folder, ignore_errors=True)\n",
+    "vespa_docker.container.stop()\n",
+    "vespa_docker.container.remove()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "scientific-parameter",
    "metadata": {},
    "source": [
@@ -363,7 +385,7 @@
    "id": "arbitrary-balance",
    "metadata": {},
    "source": [
-    "## Clean up environment"
+    "### Clean up environment"
    ]
   },
   {
@@ -374,10 +396,6 @@
    "outputs": [],
    "source": [
     "from shutil import rmtree\n",
-    "\n",
-    "rmtree(disk_folder, ignore_errors=True)\n",
-    "vespa_docker.container.stop()\n",
-    "vespa_docker.container.remove()\n",
     "\n",
     "rmtree(disk_folder_news, ignore_errors=True)\n",
     "vespa_docker_news.container.stop()\n",

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -28,9 +28,10 @@ jobs:
       - install-python: |
           dnf install -y python38-pip
           dnf install -y --enablerepo=powertools pandoc
-          python3 -m pip install pytest
+          python3 -m pip install pytest notebook nbconvert
           python3 -m pip install -e .[full]
           python3 -m pip install -r docs/sphinx/source/requirements.txt
+          python3 -m pip install -r docs/sphinx/source/notebook_requirements.txt
       - run-doc-linkcheck: |
           sphinx-build -E -b linkcheck docs/sphinx/source docs/sphinx/build
           sphinx-build -E docs/sphinx/source docs/sphinx/build
@@ -38,4 +39,8 @@ jobs:
           pytest --doctest-modules --ignore-glob=vespa/test_*.py
       - run-unit-tests: |
           pytest --ignore-glob=vespa/test_integration*.py
+      - run-notebooks-except-cloud-related: |
+          find docs -name '*.ipynb' ! -name '*cloud*.ipynb'
+          find docs -name '*.ipynb' ! -name '*cloud*.ipynb' -exec jupyter nbconvert --to notebook --ExecutePreprocessor.timeout=600 --execute {} +
+          find docs -name '*.nbconvert.ipynb' -exec rm {} +
 

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -39,6 +39,10 @@ jobs:
           pytest --doctest-modules --ignore-glob=vespa/test_*.py
       - run-unit-tests: |
           pytest --ignore-glob=vespa/test_integration*.py
+      - run-notebooks-except-cloud-related: |
+          find docs -name '*.ipynb' ! -name '*cloud*.ipynb'
+          find docs -name '*.ipynb' ! -name '*cloud*.ipynb' -exec jupyter nbconvert --to notebook --ExecutePreprocessor.timeout=6000 --execute {} +
+          find docs -name '*.nbconvert.ipynb' -exec rm {} +
       - run-integration-docker: |
           pytest vespa/test_integration_docker.py
 

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -29,5 +29,5 @@ jobs:
           dnf install -y python38-pip
           dnf install -y --enablerepo=powertools pandoc
       - run-doc-tests: |
-          pip install -e .[full]
+          python3 -m pip install -e .[full]
           pytest --doctest-modules --ignore-glob=vespa/test_*.py

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -29,10 +29,13 @@ jobs:
           dnf install -y python38-pip
           dnf install -y --enablerepo=powertools pandoc
           python3 -m pip install pytest
-      - run-doc-linkcheck: |
+          python3 -m pip install -e .[full]
           python3 -m pip install -r docs/sphinx/source/requirements.txt
+      - run-doc-linkcheck: |
           sphinx-build -E -b linkcheck docs/sphinx/source docs/sphinx/build
           sphinx-build -E docs/sphinx/source docs/sphinx/build
       - run-doc-tests: |
-          python3 -m pip install -e .[full]
           pytest --doctest-modules --ignore-glob=vespa/test_*.py
+      - run-unit-tests: |
+          pytest --ignore-glob=vespa/test_integration*.py
+

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -39,8 +39,11 @@ jobs:
           pytest --doctest-modules --ignore-glob=vespa/test_*.py
       - run-unit-tests: |
           pytest --ignore-glob=vespa/test_integration*.py
-      - run-notebooks-except-cloud-related: |
-          find docs -name '*.ipynb' ! -name '*cloud*.ipynb'
-          find docs -name '*.ipynb' ! -name '*cloud*.ipynb' -exec jupyter nbconvert --to notebook --ExecutePreprocessor.timeout=600 --execute {} +
-          find docs -name '*.nbconvert.ipynb' -exec rm {} +
+#      - run-notebooks-except-cloud-related: |
+#          find docs -name '*.ipynb' ! -name '*cloud*.ipynb'
+#          find docs -name '*.ipynb' ! -name '*cloud*.ipynb' -exec jupyter nbconvert --to notebook --ExecutePreprocessor.timeout=600 --execute {} +
+#          find docs -name '*.nbconvert.ipynb' -exec rm {} +
+      - run-integration-docker: |
+#          docker pull vespaengine/vespa
+          pytest vespa/test_integration_docker.py
 

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -29,6 +29,10 @@ jobs:
           dnf install -y python38-pip
           dnf install -y --enablerepo=powertools pandoc
           python3 -m pip install pytest
+      - run-doc-linkcheck: |
+          - python3 -m pip install -r docs/sphinx/source/requirements.txt
+          - sphinx-build -E -b linkcheck docs/sphinx/source docs/sphinx/build
+          - sphinx-build -E docs/sphinx/source docs/sphinx/build
       - run-doc-tests: |
           python3 -m pip install -e .[full]
           pytest --doctest-modules --ignore-glob=vespa/test_*.py

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -28,6 +28,7 @@ jobs:
       - install-python: |
           dnf install -y python38-pip
           dnf install -y --enablerepo=powertools pandoc
+          python3 -m pip install pytest
       - run-doc-tests: |
           python3 -m pip install -e .[full]
           pytest --doctest-modules --ignore-glob=vespa/test_*.py

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -28,3 +28,6 @@ jobs:
       - install-python: |
           dnf install -y python38-pip
           dnf install -y --enablerepo=powertools pandoc
+      - run-doc-tests: |
+          pip install -e .[full]
+          pytest --doctest-modules --ignore-glob=vespa/test_*.py

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -3,7 +3,7 @@ jobs:
     requires: [~commit,~pr]
     image: docker.io/centos:8
     annotations:
-      screwdriver.cd/timeout: 10
+      screwdriver.cd/timeout: 120
       screwdriver.cd/cpu: HIGH
       screwdriver.cd/ram: HIGH
       screwdriver.cd/dockerEnabled: true

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -13,6 +13,7 @@ jobs:
       DOCKER_HOST: "localhost:2375"
     steps:
       - setup: |
+          dnf install -y git
           export WORK_DIR=$SD_DIND_SHARE_PATH
           export RESOURCES_DIR=$(pwd)/vespa/resources
           export VESPA_CLOUD_USER_KEY=$VESPA_TEAM_API_KEY

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -12,8 +12,7 @@ jobs:
     environment:
       DOCKER_HOST: "localhost:2375"
     steps:
-      - clone: |
-          dnf install -y git
+      - setup: |
           export WORK_DIR=$SD_DIND_SHARE_PATH
           export RESOURCES_DIR=$(pwd)/vespa/resources
           export VESPA_CLOUD_USER_KEY=$VESPA_TEAM_API_KEY
@@ -44,6 +43,8 @@ jobs:
           find docs -name '*.ipynb' ! -name '*cloud*.ipynb'
           find docs -name '*.ipynb' ! -name '*cloud*.ipynb' -exec jupyter nbconvert --to notebook --ExecutePreprocessor.timeout=6000 --execute {} +
           find docs -name '*.nbconvert.ipynb' -exec rm {} +
+      - run-integration-running-instance: |
+          pytest vespa/test_integration_running_instance.py
       - run-integration-docker: |
           pytest vespa/test_integration_docker.py
 

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -30,18 +30,17 @@ jobs:
           python3 -m pip install -e .[full]
           python3 -m pip install -r docs/sphinx/source/requirements.txt
           python3 -m pip install -r docs/sphinx/source/notebook_requirements.txt
-      - run-specific-notebook: |
-          find docs -name '*.ipynb' ! -name '*cloud*.ipynb'
-          jupyter nbconvert --to notebook --ExecutePreprocessor.timeout=6000 --allow-errors --execute docs/sphinx/source/use_cases/cord19/cord19_download_parse_trec_covid.ipynb
-          cat docs/sphinx/source/use_cases/cord19/cord19_download_parse_trec_covid.nbconvert.ipynb
       - run-doc-linkcheck: |
           sphinx-build -E -b linkcheck docs/sphinx/source docs/sphinx/build
           sphinx-build -E docs/sphinx/source docs/sphinx/build
+          rm -fr docs/sphinx/build
       - run-doc-tests: |
           pytest --doctest-modules --ignore-glob=vespa/test_*.py
       - run-unit-tests: |
           pytest --ignore-glob=vespa/test_integration*.py
       - run-notebooks-except-cloud-related: |
+          dnf install -y tree
+          dnf install -y wget
           find docs -name '*.ipynb' ! -name '*cloud*.ipynb'
           find docs -name '*.ipynb' ! -name '*cloud*.ipynb' -exec jupyter nbconvert --to notebook --ExecutePreprocessor.timeout=6000 --execute {} +
           find docs -name '*.nbconvert.ipynb' -exec rm {} +

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -30,6 +30,10 @@ jobs:
           python3 -m pip install -e .[full]
           python3 -m pip install -r docs/sphinx/source/requirements.txt
           python3 -m pip install -r docs/sphinx/source/notebook_requirements.txt
+      - run-specific-notebook: |
+          find docs -name '*.ipynb' ! -name '*cloud*.ipynb'
+          jupyter nbconvert --to notebook --ExecutePreprocessor.timeout=6000 --allow-errors --execute docs/sphinx/source/use_cases/cord19/cord19_download_parse_trec_covid.ipynb
+          cat docs/sphinx/source/use_cases/cord19/cord19_download_parse_trec_covid.nbconvert.ipynb
       - run-doc-linkcheck: |
           sphinx-build -E -b linkcheck docs/sphinx/source docs/sphinx/build
           sphinx-build -E docs/sphinx/source docs/sphinx/build

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -30,9 +30,9 @@ jobs:
           dnf install -y --enablerepo=powertools pandoc
           python3 -m pip install pytest
       - run-doc-linkcheck: |
-          - python3 -m pip install -r docs/sphinx/source/requirements.txt
-          - sphinx-build -E -b linkcheck docs/sphinx/source docs/sphinx/build
-          - sphinx-build -E docs/sphinx/source docs/sphinx/build
+          python3 -m pip install -r docs/sphinx/source/requirements.txt
+          sphinx-build -E -b linkcheck docs/sphinx/source docs/sphinx/build
+          sphinx-build -E docs/sphinx/source docs/sphinx/build
       - run-doc-tests: |
           python3 -m pip install -e .[full]
           pytest --doctest-modules --ignore-glob=vespa/test_*.py

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - clone: |
           dnf install -y git
-          git clone https://github.com/vespa-engine/pyvespa
-          cd pyvespa
           export WORK_DIR=$SD_DIND_SHARE_PATH
           export RESOURCES_DIR=$(pwd)/vespa/resources
           export VESPA_CLOUD_USER_KEY=$VESPA_TEAM_API_KEY

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -39,11 +39,7 @@ jobs:
           pytest --doctest-modules --ignore-glob=vespa/test_*.py
       - run-unit-tests: |
           pytest --ignore-glob=vespa/test_integration*.py
-#      - run-notebooks-except-cloud-related: |
-#          find docs -name '*.ipynb' ! -name '*cloud*.ipynb'
-#          find docs -name '*.ipynb' ! -name '*cloud*.ipynb' -exec jupyter nbconvert --to notebook --ExecutePreprocessor.timeout=600 --execute {} +
-#          find docs -name '*.nbconvert.ipynb' -exec rm {} +
       - run-integration-docker: |
-#          docker pull vespaengine/vespa
           pytest vespa/test_integration_docker.py
+
 


### PR DESCRIPTION
Port code from Travis up to Docker integration tests. I will port the cloud-related integration tests in a separate PR.

@aressem Can you take a look at the `screwdriver.yaml`? Anything you would change?

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
