### PR TITLE
API to enable parent-child relationship

### DIFF
--- a/vespa/package.py
+++ b/vespa/package.py
@@ -211,7 +211,7 @@ class ImportedField(ToJson, FromJson["ImportedField"]):
         ...     reference_field="category_ctr_ref",
         ...     field_to_import="ctrs",
         ... )
-        ImportField('global_category_ctrs', 'category_ctr_ref', 'ctrs')
+        ImportedField('global_category_ctrs', 'category_ctr_ref', 'ctrs')
 
         """
         self.name = name
@@ -747,7 +747,7 @@ class Schema(ToJson, FromJson["Schema"]):
         To create a Schema:
 
         >>> Schema(name="schema_name", document=Document())
-        Schema('schema_name', Document(None, None), None, None, [])
+        Schema('schema_name', Document(None, None), None, None, [], False, None)
         """
         self.name = name
         self.document = document
@@ -1155,7 +1155,7 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
         The easiest way to get started is to create a default application package:
 
         >>> ApplicationPackage(name="test_app")
-        ApplicationPackage('test_app', [Schema('test_app', Document(None, None), None, None, [])], QueryProfile(None), QueryProfileType(None))
+        ApplicationPackage('test_app', [Schema('test_app', Document(None, None), None, None, [], False, None)], QueryProfile(None), QueryProfileType(None))
 
         It will create a default :class:`Schema`, :class:`QueryProfile` and :class:`QueryProfileType` that you can then
         populate with specifics of your application.

--- a/vespa/templates/schema.txt
+++ b/vespa/templates/schema.txt
@@ -31,6 +31,9 @@ schema {{ schema_name }} {
         }
         {% endfor %}
     }
+{% for key, value in imported_fields.items() %}
+    import field {{ value.reference_field }}.{{ value.field_to_import }} as {{ key }} {}
+{% endfor %}
 {% for key, value in fieldsets.items() %}
     fieldset {{ key }} {
         fields: {{ value.fields_to_text }}

--- a/vespa/templates/services.xml
+++ b/vespa/templates/services.xml
@@ -8,7 +8,11 @@
         <redundancy reply-after="1">1</redundancy>
         <documents>
         {% for schema in schemas %}
+            {% if schema.global_document %}
+            <document type="{{ schema.name }}" mode="index" global="true"></document>
+            {% else %}
             <document type="{{ schema.name }}" mode="index"></document>
+            {% endif %}
         {% endfor %}
         </documents>
         <nodes>


### PR DESCRIPTION
Work address #123.

* Add `global_document` argument for `Schema`

<img width="1016" alt="Skjermbilde 2021-05-14 kl  11 05 16" src="https://user-images.githubusercontent.com/2162939/118282178-652cc080-b4a4-11eb-9bbe-73b6bb87a354.png">

* Allow `imported_fields` for`Schema`

<img width="1012" alt="Skjermbilde 2021-05-14 kl  11 12 13" src="https://user-images.githubusercontent.com/2162939/118283073-5abef680-b4a5-11eb-8111-be8747a4bd6b.png">

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
