### PR TITLE
Manually create a valid unix path to avoid breaking docker deployment in Windows

### DIFF
--- a/vespa/package.py
+++ b/vespa/package.py
@@ -1567,7 +1567,7 @@ class VespaDocker(ToJson, FromJson["VespaDocker"]):
                     name=application_name,
                     hostname=application_name,
                     privileged=True,
-                    volumes={disk_folder: {"bind": "/app", "mode": "rw"}},
+                    volumes={disk_folder: {"bind": "app", "mode": "rw"}},
                     ports={8080: self.local_port},
                 )
             self.container_name = self.container.name
@@ -1664,7 +1664,7 @@ class VespaDocker(ToJson, FromJson["VespaDocker"]):
             print("Waiting for configuration server.", file=self.output)
             sleep(5)
 
-        _application_folder = "/app"
+        _application_folder = "app"
         if application_folder:
             _application_folder = os.path.join(_application_folder, application_folder)
         deployment = self.container.exec_run(

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -1567,7 +1567,7 @@ class VespaDocker(ToJson, FromJson["VespaDocker"]):
                     name=application_name,
                     hostname=application_name,
                     privileged=True,
-                    volumes={disk_folder: {"bind": "app", "mode": "rw"}},
+                    volumes={disk_folder: {"bind": "/app", "mode": "rw"}},
                     ports={8080: self.local_port},
                 )
             self.container_name = self.container.name
@@ -1664,9 +1664,11 @@ class VespaDocker(ToJson, FromJson["VespaDocker"]):
             print("Waiting for configuration server.", file=self.output)
             sleep(5)
 
-        _application_folder = "app"
+        _application_folder = "/app"
         if application_folder:
-            _application_folder = os.path.join(_application_folder, application_folder)
+            _application_folder = (
+                _application_folder + "/" + application_folder
+            )  # using os.path.join break on windows
         deployment = self.container.exec_run(
             "bash -c '/opt/vespa/bin/vespa-deploy prepare {} && /opt/vespa/bin/vespa-deploy activate'".format(
                 _application_folder
@@ -1719,8 +1721,8 @@ class VespaDocker(ToJson, FromJson["VespaDocker"]):
         """
         Deploy disk-based application package into a Vespa container.
         :param application_name: Name of the application.
-        :param application_folder: The folder inside `disk_folder` containing the application files. If None,
-            we assume `disk_folder` to be the application folder.
+        :param application_folder: Relative path to the folder inside `disk_folder` containing the application files.
+            If None, we assume `disk_folder` to be the application folder.
         :return: a Vespa connection instance.
         """
 


### PR DESCRIPTION
@lesters The context here is that Docker needs path like `/app/application` to work but os.path.join("/app", "application") becomes `/app\\application` on windows. It turns out to be hard to create a valid unix type path on windows using python.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
