### PR TITLE
Standardize sync and async output

### DIFF
--- a/docs/sphinx/source/use_cases/text_search/basic-text-search-simplified-api.ipynb
+++ b/docs/sphinx/source/use_cases/text_search/basic-text-search-simplified-api.ipynb
@@ -451,7 +451,7 @@
     }
    ],
    "source": [
-    "response.json()"
+    "response.json"
    ]
   },
   {

--- a/docs/sphinx/source/use_cases/text_search/basic-text-search-simplified-api.ipynb
+++ b/docs/sphinx/source/use_cases/text_search/basic-text-search-simplified-api.ipynb
@@ -27,7 +27,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As an example, we will build an application to search through [CORD19 sample data](https://ir.nist.gov/covidSubmit/data.html)."
+    "As an example, we will build an application to search through CORD19 sample data."
    ]
   },
   {

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -13,7 +13,7 @@ from requests.exceptions import ConnectionError
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 
-from vespa.query import QueryModel, VespaResult
+from vespa.query import QueryModel
 from vespa.evaluation import EvalMetric
 
 retry_strategy = Retry(
@@ -693,3 +693,72 @@ class VespaAsync(object):
 
     async def update_batch(self, batch):
         return await self._wait(self.update_data, batch)
+
+
+class VespaResult(object):
+    def __init__(self, vespa_result, request_body=None):
+        self._vespa_result = vespa_result
+        self._request_body = request_body
+
+    @property
+    def request_body(self) -> Optional[Dict]:
+        return self._request_body
+
+    @property
+    def json(self) -> Dict:
+        return self._vespa_result
+
+    @property
+    def hits(self) -> List:
+        return self._vespa_result.get("root", {}).get("children", [])
+
+    def get_hits(self, format_function=trec_format, **kwargs):
+        """
+        Get Vespa hits according to `format_function` format.
+
+        :param format_function: function to format the raw Vespa result. Should take raw vespa result as first argument.
+        :param kwargs: Extra arguments to be passed to `format_function`.
+        :return: Output of the `format_function`.
+        """
+        if not format_function:
+            return self.hits
+        return format_function(self._vespa_result, **kwargs)
+
+    @property
+    def number_documents_retrieved(self) -> int:
+        return self._vespa_result.get("root", {}).get("fields", {}).get("totalCount", 0)
+
+    @property
+    def number_documents_indexed(self) -> int:
+        return (
+            self._vespa_result.get("root", {}).get("coverage", {}).get("documents", 0)
+        )
+
+
+def trec_format(
+    vespa_result, id_field: Optional[str] = None, qid: int = 0
+) -> DataFrame:
+    """
+    Function to format Vespa output according to TREC format.
+
+    TREC format include qid, doc_id, score and rank.
+
+    :param vespa_result: raw Vespa result from query.
+    :param id_field: Name of the Vespa field to use as 'doc_id' value.
+    :param qid: custom query id.
+    :return: pandas DataFrame with columns qid, doc_id, score and rank.
+    """
+    hits = vespa_result.get("root", {}).get("children", [])
+    records = []
+    for rank, hit in enumerate(hits):
+        records.append(
+            {
+                "qid": qid,
+                "doc_id": hit["fields"][id_field]
+                if id_field is not None
+                else hit["id"],
+                "score": hit["relevance"],
+                "rank": rank,
+            }
+        )
+    return DataFrame.from_records(records)

--- a/vespa/evaluation.py
+++ b/vespa/evaluation.py
@@ -2,7 +2,7 @@
 
 import math
 from typing import Dict, List
-from vespa.io import VespaResult
+from vespa.io import VespaQueryResponse
 
 
 class EvalMetric(object):
@@ -30,7 +30,7 @@ class MatchRatio(EvalMetric):
 
     def evaluate_query(
         self,
-        query_results: VespaResult,
+        query_results: VespaQueryResponse,
         relevant_docs: List[Dict],
         id_field: str,
         default_score: int,
@@ -78,7 +78,7 @@ class Recall(EvalMetric):
 
     def evaluate_query(
         self,
-        query_results: VespaResult,
+        query_results: VespaQueryResponse,
         relevant_docs: List[Dict],
         id_field: str,
         default_score: int,
@@ -122,7 +122,7 @@ class ReciprocalRank(EvalMetric):
 
     def evaluate_query(
         self,
-        query_results: VespaResult,
+        query_results: VespaQueryResponse,
         relevant_docs: List[Dict],
         id_field: str,
         default_score: int,
@@ -169,7 +169,7 @@ class NormalizedDiscountedCumulativeGain(EvalMetric):
 
     def evaluate_query(
         self,
-        query_results: VespaResult,
+        query_results: VespaQueryResponse,
         relevant_docs: List[Dict],
         id_field: str,
         default_score: int,

--- a/vespa/evaluation.py
+++ b/vespa/evaluation.py
@@ -2,7 +2,7 @@
 
 import math
 from typing import Dict, List
-from vespa.application import VespaResult
+from vespa.io import VespaResult
 
 
 class EvalMetric(object):

--- a/vespa/evaluation.py
+++ b/vespa/evaluation.py
@@ -2,7 +2,7 @@
 
 import math
 from typing import Dict, List
-from vespa.query import VespaResult
+from vespa.application import VespaResult
 
 
 class EvalMetric(object):

--- a/vespa/io.py
+++ b/vespa/io.py
@@ -1,0 +1,90 @@
+from typing import Optional, Dict, List
+
+from pandas import DataFrame
+
+
+class VespaResponse(object):
+    def __init__(self, json, status_code, url, operation_type):
+        self.json = json
+        self.status_code = status_code
+        self.url = url
+        self.operation_type = operation_type
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        return (
+            self.json == other.json
+            and self.status_code == other.status_code
+            and self.url == other.url
+            and self.operation_type == other.operation_type
+        )
+
+
+def trec_format(
+    vespa_result, id_field: Optional[str] = None, qid: int = 0
+) -> DataFrame:
+    """
+    Function to format Vespa output according to TREC format.
+
+    TREC format include qid, doc_id, score and rank.
+
+    :param vespa_result: raw Vespa result from query.
+    :param id_field: Name of the Vespa field to use as 'doc_id' value.
+    :param qid: custom query id.
+    :return: pandas DataFrame with columns qid, doc_id, score and rank.
+    """
+    hits = vespa_result.get("root", {}).get("children", [])
+    records = []
+    for rank, hit in enumerate(hits):
+        records.append(
+            {
+                "qid": qid,
+                "doc_id": hit["fields"][id_field]
+                if id_field is not None
+                else hit["id"],
+                "score": hit["relevance"],
+                "rank": rank,
+            }
+        )
+    return DataFrame.from_records(records)
+
+
+class VespaResult(object):
+    def __init__(self, vespa_result, request_body=None):
+        self._vespa_result = vespa_result
+        self._request_body = request_body
+
+    @property
+    def request_body(self) -> Optional[Dict]:
+        return self._request_body
+
+    @property
+    def json(self) -> Dict:
+        return self._vespa_result
+
+    @property
+    def hits(self) -> List:
+        return self._vespa_result.get("root", {}).get("children", [])
+
+    def get_hits(self, format_function=trec_format, **kwargs):
+        """
+        Get Vespa hits according to `format_function` format.
+
+        :param format_function: function to format the raw Vespa result. Should take raw vespa result as first argument.
+        :param kwargs: Extra arguments to be passed to `format_function`.
+        :return: Output of the `format_function`.
+        """
+        if not format_function:
+            return self.hits
+        return format_function(self._vespa_result, **kwargs)
+
+    @property
+    def number_documents_retrieved(self) -> int:
+        return self._vespa_result.get("root", {}).get("fields", {}).get("totalCount", 0)
+
+    @property
+    def number_documents_indexed(self) -> int:
+        return (
+            self._vespa_result.get("root", {}).get("coverage", {}).get("documents", 0)
+        )

--- a/vespa/io.py
+++ b/vespa/io.py
@@ -50,9 +50,9 @@ def trec_format(
     return DataFrame.from_records(records)
 
 
-class VespaResult(object):
-    def __init__(self, vespa_result, request_body=None):
-        self._vespa_result = vespa_result
+class VespaQueryResponse(VespaResponse):
+    def __init__(self, json, status_code, url, request_body=None):
+        super().__init__(json=json, status_code=status_code, url=url, operation_type="query")
         self._request_body = request_body
 
     @property
@@ -60,12 +60,8 @@ class VespaResult(object):
         return self._request_body
 
     @property
-    def json(self) -> Dict:
-        return self._vespa_result
-
-    @property
     def hits(self) -> List:
-        return self._vespa_result.get("root", {}).get("children", [])
+        return self.json.get("root", {}).get("children", [])
 
     def get_hits(self, format_function=trec_format, **kwargs):
         """
@@ -77,14 +73,14 @@ class VespaResult(object):
         """
         if not format_function:
             return self.hits
-        return format_function(self._vespa_result, **kwargs)
+        return format_function(self.json, **kwargs)
 
     @property
     def number_documents_retrieved(self) -> int:
-        return self._vespa_result.get("root", {}).get("fields", {}).get("totalCount", 0)
+        return self.json.get("root", {}).get("fields", {}).get("totalCount", 0)
 
     @property
     def number_documents_indexed(self) -> int:
         return (
-            self._vespa_result.get("root", {}).get("coverage", {}).get("documents", 0)
+            self.json.get("root", {}).get("coverage", {}).get("documents", 0)
         )

--- a/vespa/query.py
+++ b/vespa/query.py
@@ -1,7 +1,6 @@
 # Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 from typing import Callable, List, Optional, Dict
-from pandas import DataFrame
 
 
 #
@@ -256,70 +255,3 @@ class QueryModel(object):
         return body
 
 
-def trec_format(
-    vespa_result, id_field: Optional[str] = None, qid: int = 0
-) -> DataFrame:
-    """
-    Function to format Vespa output according to TREC format.
-
-    TREC format include qid, doc_id, score and rank.
-
-    :param vespa_result: raw Vespa result from query.
-    :param id_field: Name of the Vespa field to use as 'doc_id' value.
-    :param qid: custom query id.
-    :return: pandas DataFrame with columns qid, doc_id, score and rank.
-    """
-    hits = vespa_result.get("root", {}).get("children", [])
-    records = []
-    for rank, hit in enumerate(hits):
-        records.append(
-            {
-                "qid": qid,
-                "doc_id": hit["fields"][id_field]
-                if id_field is not None
-                else hit["id"],
-                "score": hit["relevance"],
-                "rank": rank,
-            }
-        )
-    return DataFrame.from_records(records)
-
-
-class VespaResult(object):
-    def __init__(self, vespa_result, request_body=None):
-        self._vespa_result = vespa_result
-        self._request_body = request_body
-
-    @property
-    def request_body(self) -> Optional[Dict]:
-        return self._request_body
-
-    @property
-    def json(self) -> Dict:
-        return self._vespa_result
-
-    @property
-    def hits(self) -> List:
-        return self._vespa_result.get("root", {}).get("children", [])
-
-    def get_hits(self, format_function=trec_format, **kwargs):
-        """
-        Get Vespa hits according to `format_function` format.
-
-        :param format_function: function to format the raw Vespa result. Should take raw vespa result as first argument.
-        :param kwargs: Extra arguments to be passed to `format_function`.
-        :return: Output of the `format_function`.
-        """
-        if not format_function:
-            return self.hits
-        return format_function(self._vespa_result, **kwargs)
-
-    @property
-    def number_documents_retrieved(self) -> int:
-        return self._vespa_result.get("root", {}).get("fields", {}).get("totalCount", 0)
-
-    @property
-    def number_documents_indexed(self) -> int:
-        return (
-            self._vespa_result.get("root", {}).get("coverage", {}).get("documents", 0)
-        )

--- a/vespa/test_application.py
+++ b/vespa/test_application.py
@@ -6,7 +6,7 @@ from pandas import DataFrame
 from pandas.testing import assert_frame_equal
 
 from vespa.application import Vespa, parse_labeled_data
-from vespa.io import VespaResult
+from vespa.io import VespaQueryResponse
 from vespa.query import QueryModel, OR, RankProfile
 
 
@@ -216,8 +216,8 @@ class TestVespaCollectData(unittest.TestCase):
 
         self.app.query = Mock(
             side_effect=[
-                VespaResult(self.raw_vespa_result_recall),
-                VespaResult(self.raw_vespa_result_additional),
+                VespaQueryResponse(self.raw_vespa_result_recall, status_code=None, url=None),
+                VespaQueryResponse(self.raw_vespa_result_additional, status_code=None, url=None),
             ]
         )
         query_model = QueryModel(rank_profile=RankProfile(list_features=True))
@@ -281,8 +281,8 @@ class TestVespaCollectData(unittest.TestCase):
 
         self.app.query = Mock(
             side_effect=[
-                VespaResult(self.raw_vespa_result_recall),
-                VespaResult(self.raw_vespa_result_additional),
+                VespaQueryResponse(self.raw_vespa_result_recall, status_code=None, url=None),
+                VespaQueryResponse(self.raw_vespa_result_additional, status_code=None, url=None),
             ]
         )
         query_model = QueryModel(rank_profile=RankProfile(list_features=True))
@@ -358,8 +358,8 @@ class TestVespaCollectData(unittest.TestCase):
         }
         self.app.query = Mock(
             side_effect=[
-                VespaResult(self.raw_vespa_result_recall),
-                VespaResult(self.raw_vespa_result_additional),
+                VespaQueryResponse(self.raw_vespa_result_recall, status_code=None, url=None),
+                VespaQueryResponse(self.raw_vespa_result_additional, status_code=None, url=None),
             ]
         )
         query_model = QueryModel(rank_profile=RankProfile(list_features=True))

--- a/vespa/test_application.py
+++ b/vespa/test_application.py
@@ -5,7 +5,8 @@ from unittest.mock import Mock, call
 from pandas import DataFrame
 from pandas.testing import assert_frame_equal
 
-from vespa.application import Vespa, parse_labeled_data, VespaResult
+from vespa.application import Vespa, parse_labeled_data
+from vespa.io import VespaResult
 from vespa.query import QueryModel, OR, RankProfile
 
 

--- a/vespa/test_application.py
+++ b/vespa/test_application.py
@@ -5,8 +5,8 @@ from unittest.mock import Mock, call
 from pandas import DataFrame
 from pandas.testing import assert_frame_equal
 
-from vespa.application import Vespa, parse_labeled_data
-from vespa.query import QueryModel, OR, RankProfile, VespaResult
+from vespa.application import Vespa, parse_labeled_data, VespaResult
+from vespa.query import QueryModel, OR, RankProfile
 
 
 class TestVespa(unittest.TestCase):

--- a/vespa/test_evaluation.py
+++ b/vespa/test_evaluation.py
@@ -3,7 +3,7 @@
 import unittest
 import math
 
-from vespa.application import VespaResult
+from vespa.io import VespaResult
 from vespa.evaluation import (
     MatchRatio,
     Recall,

--- a/vespa/test_evaluation.py
+++ b/vespa/test_evaluation.py
@@ -3,7 +3,7 @@
 import unittest
 import math
 
-from vespa.io import VespaResult
+from vespa.io import VespaQueryResponse
 from vespa.evaluation import (
     MatchRatio,
     Recall,
@@ -200,7 +200,7 @@ class TestEvalMetric(unittest.TestCase):
         metric = MatchRatio()
 
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results),
+            query_results=VespaQueryResponse(self.query_results, status_code=None, url=None),
             relevant_docs=self.labeled_data[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -214,7 +214,7 @@ class TestEvalMetric(unittest.TestCase):
         )
 
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results),
+            query_results=VespaQueryResponse(self.query_results, status_code=None, url=None),
             relevant_docs=self.labeled_data[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -231,22 +231,20 @@ class TestEvalMetric(unittest.TestCase):
         )
 
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(
-                {
-                    "root": {
-                        "id": "toplevel",
-                        "relevance": 1.0,
-                        "coverage": {
-                            "coverage": 100,
-                            "documents": 62529,
-                            "full": True,
-                            "nodes": 2,
-                            "results": 1,
-                            "resultsFull": 1,
-                        },
-                    }
+            query_results=VespaQueryResponse({
+                "root": {
+                    "id": "toplevel",
+                    "relevance": 1.0,
+                    "coverage": {
+                        "coverage": 100,
+                        "documents": 62529,
+                        "full": True,
+                        "nodes": 2,
+                        "results": 1,
+                        "resultsFull": 1,
+                    },
                 }
-            ),
+            }, status_code=None, url=None),
             relevant_docs=self.labeled_data[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -260,22 +258,20 @@ class TestEvalMetric(unittest.TestCase):
         )
 
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(
-                {
-                    "root": {
-                        "id": "toplevel",
-                        "relevance": 1.0,
-                        "coverage": {
-                            "coverage": 100,
-                            "documents": 62529,
-                            "full": True,
-                            "nodes": 2,
-                            "results": 1,
-                            "resultsFull": 1,
-                        },
-                    }
+            query_results=VespaQueryResponse({
+                "root": {
+                    "id": "toplevel",
+                    "relevance": 1.0,
+                    "coverage": {
+                        "coverage": 100,
+                        "documents": 62529,
+                        "full": True,
+                        "nodes": 2,
+                        "results": 1,
+                        "resultsFull": 1,
+                    },
                 }
-            ),
+            }, status_code=None, url=None),
             relevant_docs=self.labeled_data[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -292,22 +288,20 @@ class TestEvalMetric(unittest.TestCase):
         )
 
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(
-                {
-                    "root": {
-                        "id": "toplevel",
-                        "relevance": 1.0,
-                        "fields": {"totalCount": 1083},
-                        "coverage": {
-                            "coverage": 100,
-                            "full": True,
-                            "nodes": 2,
-                            "results": 1,
-                            "resultsFull": 1,
-                        },
-                    }
+            query_results=VespaQueryResponse({
+                "root": {
+                    "id": "toplevel",
+                    "relevance": 1.0,
+                    "fields": {"totalCount": 1083},
+                    "coverage": {
+                        "coverage": 100,
+                        "full": True,
+                        "nodes": 2,
+                        "results": 1,
+                        "resultsFull": 1,
+                    },
                 }
-            ),
+            }, status_code=None, url=None),
             relevant_docs=self.labeled_data[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -321,22 +315,20 @@ class TestEvalMetric(unittest.TestCase):
         )
 
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(
-                {
-                    "root": {
-                        "id": "toplevel",
-                        "relevance": 1.0,
-                        "fields": {"totalCount": 1083},
-                        "coverage": {
-                            "coverage": 100,
-                            "full": True,
-                            "nodes": 2,
-                            "results": 1,
-                            "resultsFull": 1,
-                        },
-                    }
+            query_results=VespaQueryResponse({
+                "root": {
+                    "id": "toplevel",
+                    "relevance": 1.0,
+                    "fields": {"totalCount": 1083},
+                    "coverage": {
+                        "coverage": 100,
+                        "full": True,
+                        "nodes": 2,
+                        "results": 1,
+                        "resultsFull": 1,
+                    },
                 }
-            ),
+            }, status_code=None, url=None),
             relevant_docs=self.labeled_data[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -355,7 +347,7 @@ class TestEvalMetric(unittest.TestCase):
     def test_recall(self):
         metric = Recall(at=2)
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results),
+            query_results=VespaQueryResponse(self.query_results, status_code=None, url=None),
             relevant_docs=self.labeled_data[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -369,7 +361,7 @@ class TestEvalMetric(unittest.TestCase):
 
         metric = Recall(at=1)
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results),
+            query_results=VespaQueryResponse(self.query_results, status_code=None, url=None),
             relevant_docs=self.labeled_data[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -383,7 +375,7 @@ class TestEvalMetric(unittest.TestCase):
 
         metric = Recall(at=3)
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results2),
+            query_results=VespaQueryResponse(self.query_results2, status_code=None, url=None),
             relevant_docs=self.labeled_data2[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -397,7 +389,7 @@ class TestEvalMetric(unittest.TestCase):
 
         metric = Recall(at=3)
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results_int_id),
+            query_results=VespaQueryResponse(self.query_results_int_id, status_code=None, url=None),
             relevant_docs=self.labeled_data_int_id[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -413,7 +405,7 @@ class TestEvalMetric(unittest.TestCase):
 
         metric = Recall(at=1)
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results2),
+            query_results=VespaQueryResponse(self.query_results2, status_code=None, url=None),
             relevant_docs=self.labeled_data2_with_zero_score[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -427,7 +419,7 @@ class TestEvalMetric(unittest.TestCase):
 
         metric = Recall(at=2)
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results2),
+            query_results=VespaQueryResponse(self.query_results2, status_code=None, url=None),
             relevant_docs=self.labeled_data2_with_zero_score[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -441,7 +433,7 @@ class TestEvalMetric(unittest.TestCase):
 
         metric = Recall(at=3)
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results2),
+            query_results=VespaQueryResponse(self.query_results2, status_code=None, url=None),
             relevant_docs=self.labeled_data2_with_zero_score[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -455,7 +447,7 @@ class TestEvalMetric(unittest.TestCase):
 
         metric = Recall(at=3)
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results2),
+            query_results=VespaQueryResponse(self.query_results2, status_code=None, url=None),
             relevant_docs=[{"id": "ghi", "score": 0}, {"id": "abc", "score": 0}],
             id_field="vespa_id_field",
             default_score=0,
@@ -470,7 +462,7 @@ class TestEvalMetric(unittest.TestCase):
     def test_reciprocal_rank(self):
         metric = ReciprocalRank(at=2)
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results),
+            query_results=VespaQueryResponse(self.query_results, status_code=None, url=None),
             relevant_docs=self.labeled_data[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -484,7 +476,7 @@ class TestEvalMetric(unittest.TestCase):
 
         metric = ReciprocalRank(at=1)
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results),
+            query_results=VespaQueryResponse(self.query_results, status_code=None, url=None),
             relevant_docs=self.labeled_data[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -498,7 +490,7 @@ class TestEvalMetric(unittest.TestCase):
 
         metric = ReciprocalRank(at=3)
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results2),
+            query_results=VespaQueryResponse(self.query_results2, status_code=None, url=None),
             relevant_docs=self.labeled_data2[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -512,7 +504,7 @@ class TestEvalMetric(unittest.TestCase):
 
         metric = ReciprocalRank(at=3)
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results_int_id),
+            query_results=VespaQueryResponse(self.query_results_int_id, status_code=None, url=None),
             relevant_docs=self.labeled_data_int_id[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -528,7 +520,7 @@ class TestEvalMetric(unittest.TestCase):
 
         metric = ReciprocalRank(at=1)
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results2),
+            query_results=VespaQueryResponse(self.query_results2, status_code=None, url=None),
             relevant_docs=self.labeled_data2_with_zero_score[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -542,7 +534,7 @@ class TestEvalMetric(unittest.TestCase):
 
         metric = ReciprocalRank(at=2)
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results2),
+            query_results=VespaQueryResponse(self.query_results2, status_code=None, url=None),
             relevant_docs=self.labeled_data2_with_zero_score[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -556,7 +548,7 @@ class TestEvalMetric(unittest.TestCase):
 
         metric = ReciprocalRank(at=3)
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results2),
+            query_results=VespaQueryResponse(self.query_results2, status_code=None, url=None),
             relevant_docs=self.labeled_data2_with_zero_score[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -572,7 +564,7 @@ class TestEvalMetric(unittest.TestCase):
 
         metric = NormalizedDiscountedCumulativeGain(at=2)
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results),
+            query_results=VespaQueryResponse(self.query_results, status_code=None, url=None),
             relevant_docs=self.labeled_data[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -588,7 +580,7 @@ class TestEvalMetric(unittest.TestCase):
             },
         )
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results),
+            query_results=VespaQueryResponse(self.query_results, status_code=None, url=None),
             relevant_docs=self.labeled_data[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -606,7 +598,7 @@ class TestEvalMetric(unittest.TestCase):
 
         metric = NormalizedDiscountedCumulativeGain(at=1)
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results),
+            query_results=VespaQueryResponse(self.query_results, status_code=None, url=None),
             relevant_docs=self.labeled_data[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -621,7 +613,7 @@ class TestEvalMetric(unittest.TestCase):
             },
         )
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results),
+            query_results=VespaQueryResponse(self.query_results, status_code=None, url=None),
             relevant_docs=self.labeled_data[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -639,7 +631,7 @@ class TestEvalMetric(unittest.TestCase):
 
         metric = NormalizedDiscountedCumulativeGain(at=3)
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results2),
+            query_results=VespaQueryResponse(self.query_results2, status_code=None, url=None),
             relevant_docs=self.labeled_data2[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -655,7 +647,7 @@ class TestEvalMetric(unittest.TestCase):
         )
 
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results2),
+            query_results=VespaQueryResponse(self.query_results2, status_code=None, url=None),
             relevant_docs=self.labeled_data2[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -672,7 +664,7 @@ class TestEvalMetric(unittest.TestCase):
         )
 
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results_int_id),
+            query_results=VespaQueryResponse(self.query_results_int_id, status_code=None, url=None),
             relevant_docs=self.labeled_data_int_id[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,
@@ -688,7 +680,7 @@ class TestEvalMetric(unittest.TestCase):
         )
 
         evaluation = metric.evaluate_query(
-            query_results=VespaResult(self.query_results_int_id),
+            query_results=VespaQueryResponse(self.query_results_int_id, status_code=None, url=None),
             relevant_docs=self.labeled_data_int_id[0]["relevant_docs"],
             id_field="vespa_id_field",
             default_score=0,

--- a/vespa/test_evaluation.py
+++ b/vespa/test_evaluation.py
@@ -3,7 +3,7 @@
 import unittest
 import math
 
-from vespa.query import VespaResult
+from vespa.application import VespaResult
 from vespa.evaluation import (
     MatchRatio,
     Recall,

--- a/vespa/test_integration_docker.py
+++ b/vespa/test_integration_docker.py
@@ -160,14 +160,14 @@ class TestDockerDeployment(unittest.TestCase):
                 "body": "this is my first body",
             },
         )
-        self.assertEqual(response.json()["id"], "id:msmarco:msmarco::1")
+        self.assertEqual(response.json["id"], "id:msmarco:msmarco::1")
         #
         # Get data that exist
         #
         response = app.get_data(schema="msmarco", data_id="1")
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(
-            response.json(),
+            response.json,
             {
                 "fields": {
                     "id": "1",
@@ -184,14 +184,14 @@ class TestDockerDeployment(unittest.TestCase):
         response = app.update_data(
             schema="msmarco", data_id="1", fields={"title": "this is my updated title"}
         )
-        self.assertEqual(response.json()["id"], "id:msmarco:msmarco::1")
+        self.assertEqual(response.json["id"], "id:msmarco:msmarco::1")
         #
         # Get the updated data point
         #
         response = app.get_data(schema="msmarco", data_id="1")
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(
-            response.json(),
+            response.json,
             {
                 "fields": {
                     "id": "1",
@@ -206,7 +206,7 @@ class TestDockerDeployment(unittest.TestCase):
         # Delete a data point
         #
         response = app.delete_data(schema="msmarco", data_id="1")
-        self.assertEqual(response.json()["id"], "id:msmarco:msmarco::1")
+        self.assertEqual(response.json["id"], "id:msmarco:msmarco::1")
         #
         # Deleted data should be gone
         #
@@ -220,14 +220,14 @@ class TestDockerDeployment(unittest.TestCase):
             fields={"title": "this is my updated title"},
             create=True,
         )
-        self.assertEqual(response.json()["id"], "id:msmarco:msmarco::1")
+        self.assertEqual(response.json["id"], "id:msmarco:msmarco::1")
         #
         # Get the updated data point
         #
         response = app.get_data(schema="msmarco", data_id="1")
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(
-            response.json(),
+            response.json,
             {
                 "fields": {
                     "title": "this is my updated title",
@@ -293,7 +293,7 @@ class TestDockerDeployment(unittest.TestCase):
             #
             response = await async_app.delete_data(schema="msmarco", data_id="1")
             response = await async_app.get_data(schema="msmarco", data_id="1")
-            self.assertEqual(response.status, 404)
+            self.assertEqual(response.status_code, 404)
 
             #
             # Feed some data points
@@ -314,15 +314,36 @@ class TestDockerDeployment(unittest.TestCase):
                     )
                 )
             await asyncio.wait(feed, return_when=asyncio.ALL_COMPLETED)
-            result = await feed[0].result().json()
+            result = feed[0].result().json
             self.assertEqual(result["id"], "id:msmarco:msmarco::1")
+
+            self.assertEqual(
+                await async_app.feed_data_point(
+                    schema="msmarco",
+                    data_id="1",
+                    fields={
+                        "id": "1",
+                        "title": "this is title 1",
+                        "body": "this is body 1",
+                    },
+                ),
+                app.feed_data_point(
+                    schema="msmarco",
+                    data_id="1",
+                    fields={
+                        "id": "1",
+                        "title": "this is title 1",
+                        "body": "this is body 1",
+                    },
+                ),
+            )
 
             #
             # Get data that exists
             #
             response = await async_app.get_data(schema="msmarco", data_id="1")
-            self.assertEqual(response.status, 200)
-            result = await response.json()
+            self.assertEqual(response.status_code, 200)
+            result = response.json
             self.assertDictEqual(
                 result,
                 {
@@ -341,15 +362,15 @@ class TestDockerDeployment(unittest.TestCase):
             response = await async_app.update_data(
                 schema="msmarco", data_id="1", fields={"id": "this is my updated id"}
             )
-            result = await response.json()
+            result = response.json
             self.assertEqual(result["id"], "id:msmarco:msmarco::1")
 
             #
             # Get the updated data point
             #
             response = await async_app.get_data(schema="msmarco", data_id="1")
-            self.assertEqual(response.status, 200)
-            result = await response.json()
+            self.assertEqual(response.status_code, 200)
+            result = response.json
             self.assertDictEqual(
                 result,
                 {
@@ -366,13 +387,13 @@ class TestDockerDeployment(unittest.TestCase):
             # Delete a data point
             #
             response = await async_app.delete_data(schema="msmarco", data_id="1")
-            result = await response.json()
+            result = response.json
             self.assertEqual(result["id"], "id:msmarco:msmarco::1")
             #
             # Deleted data should be gone
             #
             response = await async_app.get_data(schema="msmarco", data_id="1")
-            self.assertEqual(response.status, 404)
+            self.assertEqual(response.status_code, 404)
 
             #
             # Issue a bunch of queries in parallel
@@ -497,7 +518,7 @@ class TestOnnxModelDockerDeployment(unittest.TestCase):
             data_id="1",
             fields=fields,
         )
-        self.assertEqual(response.json()["id"], "id:cord19:cord19::1")
+        self.assertEqual(response.json["id"], "id:cord19:cord19::1")
         #
         # Get data that exist
         #
@@ -505,7 +526,7 @@ class TestOnnxModelDockerDeployment(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         embedding_values = fields["pretrained_bert_tiny_doc_token_ids"]["values"]
         self.assertDictEqual(
-            response.json(),
+            response.json,
             {
                 "fields": {
                     "cord_uid": "1",
@@ -530,7 +551,7 @@ class TestOnnxModelDockerDeployment(unittest.TestCase):
         fields = {"title": "this is my updated title"}
         fields.update(self.bert_config.doc_fields(text=str(fields["title"])))
         response = self.app.update_data(schema="cord19", data_id="1", fields=fields)
-        self.assertEqual(response.json()["id"], "id:cord19:cord19::1")
+        self.assertEqual(response.json["id"], "id:cord19:cord19::1")
         #
         # Get the updated data point
         #
@@ -538,7 +559,7 @@ class TestOnnxModelDockerDeployment(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         embedding_values = fields["pretrained_bert_tiny_doc_token_ids"]["values"]
         self.assertDictEqual(
-            response.json(),
+            response.json,
             {
                 "fields": {
                     "cord_uid": "1",
@@ -561,7 +582,7 @@ class TestOnnxModelDockerDeployment(unittest.TestCase):
         # Delete a data point
         #
         response = self.app.delete_data(schema="cord19", data_id="1")
-        self.assertEqual(response.json()["id"], "id:cord19:cord19::1")
+        self.assertEqual(response.json["id"], "id:cord19:cord19::1")
         #
         # Deleted data should be gone
         #
@@ -586,7 +607,7 @@ class TestOnnxModelDockerDeployment(unittest.TestCase):
             data_id="1",
             fields=fields,
         )
-        self.assertEqual(response.json()["id"], "id:cord19:cord19::1")
+        self.assertEqual(response.json["id"], "id:cord19:cord19::1")
         #
         # Run a test query
         #

--- a/vespa/test_integration_vespa_cloud.py
+++ b/vespa/test_integration_vespa_cloud.py
@@ -74,7 +74,7 @@ class TestCloudDeployment(unittest.TestCase):
             application_package=app_package,
         )
         self.disk_folder = os.path.join(os.getenv("WORK_DIR"), "sample_application")
-        self.instance_name = "test"
+        self.instance_name = "msmarco"
         self.app = self.vespa_cloud.deploy(
             instance=self.instance_name, disk_folder=self.disk_folder
         )
@@ -102,14 +102,14 @@ class TestCloudDeployment(unittest.TestCase):
                 "body": "this is my first body",
             },
         )
-        self.assertEqual(response.json()["id"], "id:msmarco:msmarco::1")
+        self.assertEqual(response.json["id"], "id:msmarco:msmarco::1")
         #
         # Get data that exist
         #
         response = self.app.get_data(schema="msmarco", data_id="1")
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(
-            response.json(),
+            response.json,
             {
                 "fields": {
                     "id": "1",
@@ -126,14 +126,14 @@ class TestCloudDeployment(unittest.TestCase):
         response = self.app.update_data(
             schema="msmarco", data_id="1", fields={"title": "this is my updated title"}
         )
-        self.assertEqual(response.json()["id"], "id:msmarco:msmarco::1")
+        self.assertEqual(response.json["id"], "id:msmarco:msmarco::1")
         #
         # Get the updated data point
         #
         response = self.app.get_data(schema="msmarco", data_id="1")
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(
-            response.json(),
+            response.json,
             {
                 "fields": {
                     "id": "1",
@@ -148,7 +148,7 @@ class TestCloudDeployment(unittest.TestCase):
         # Delete a data point
         #
         response = self.app.delete_data(schema="msmarco", data_id="1")
-        self.assertEqual(response.json()["id"], "id:msmarco:msmarco::1")
+        self.assertEqual(response.json["id"], "id:msmarco:msmarco::1")
         #
         # Deleted data should be gone
         #
@@ -164,14 +164,14 @@ class TestCloudDeployment(unittest.TestCase):
             fields={"title": "this is my updated title"},
             create=True,
         )
-        self.assertEqual(response.json()["id"], "id:msmarco:msmarco::1")
+        self.assertEqual(response.json["id"], "id:msmarco:msmarco::1")
         #
         # Get the updated data point
         #
         response = self.app.get_data(schema="msmarco", data_id="1")
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(
-            response.json(),
+            response.json,
             {
                 "fields": {
                     "title": "this is my updated title",
@@ -230,7 +230,7 @@ class TestCloudDeployment(unittest.TestCase):
             #
             response = await async_app.delete_data(schema="msmarco", data_id="1")
             response = await async_app.get_data(schema="msmarco", data_id="1")
-            self.assertEqual(response.status, 404)
+            self.assertEqual(response.status_code, 404)
 
             #
             # Feed some data points
@@ -251,15 +251,36 @@ class TestCloudDeployment(unittest.TestCase):
                     )
                 )
             await asyncio.wait(feed, return_when=asyncio.ALL_COMPLETED)
-            result = await feed[0].result().json()
+            result = feed[0].result().json
             self.assertEqual(result["id"], "id:msmarco:msmarco::0")
+
+            self.assertEqual(
+                await async_app.feed_data_point(
+                    schema="msmarco",
+                    data_id="1",
+                    fields={
+                        "id": "1",
+                        "title": "this is title 1",
+                        "body": "this is body 1",
+                    },
+                ),
+                self.app.feed_data_point(
+                    schema="msmarco",
+                    data_id="1",
+                    fields={
+                        "id": "1",
+                        "title": "this is title 1",
+                        "body": "this is body 1",
+                    },
+                ),
+            )
 
             #
             # Get data that exists
             #
             response = await async_app.get_data(schema="msmarco", data_id="1")
-            self.assertEqual(response.status, 200)
-            result = await response.json()
+            self.assertEqual(response.status_code, 200)
+            result = response.json
             self.assertDictEqual(
                 result,
                 {
@@ -278,15 +299,15 @@ class TestCloudDeployment(unittest.TestCase):
             response = await async_app.update_data(
                 schema="msmarco", data_id="1", fields={"id": "this is my updated id"}
             )
-            result = await response.json()
+            result = response.json
             self.assertEqual(result["id"], "id:msmarco:msmarco::1")
 
             #
             # Get the updated data point
             #
             response = await async_app.get_data(schema="msmarco", data_id="1")
-            self.assertEqual(response.status, 200)
-            result = await response.json()
+            self.assertEqual(response.status_code, 200)
+            result = response.json
             self.assertDictEqual(
                 result,
                 {
@@ -303,13 +324,13 @@ class TestCloudDeployment(unittest.TestCase):
             # Delete a data point
             #
             response = await async_app.delete_data(schema="msmarco", data_id="99")
-            result = await response.json()
+            result = response.json
             self.assertEqual(result["id"], "id:msmarco:msmarco::99")
             #
             # Deleted data should be gone
             #
             response = await async_app.get_data(schema="msmarco", data_id="99")
-            self.assertEqual(response.status, 404)
+            self.assertEqual(response.status_code, 404)
 
             #
             # Issue a bunch of queries in parallel
@@ -377,7 +398,7 @@ class TestOnnxModelCloudDeployment(unittest.TestCase):
             application_package=self.app_package,
         )
         self.disk_folder = os.path.join(os.getenv("WORK_DIR"), "sample_application")
-        self.instance_name = "test"
+        self.instance_name = "cord19"
         self.app = self.vespa_cloud.deploy(
             instance=self.instance_name, disk_folder=self.disk_folder
         )
@@ -402,7 +423,7 @@ class TestOnnxModelCloudDeployment(unittest.TestCase):
             data_id="1",
             fields=fields,
         )
-        self.assertEqual(response.json()["id"], "id:cord19:cord19::1")
+        self.assertEqual(response.json["id"], "id:cord19:cord19::1")
         #
         # Get data that exist
         #
@@ -410,7 +431,7 @@ class TestOnnxModelCloudDeployment(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         embedding_values = fields["pretrained_bert_tiny_doc_token_ids"]["values"]
         self.assertDictEqual(
-            response.json(),
+            response.json,
             {
                 "fields": {
                     "cord_uid": "1",
@@ -435,7 +456,7 @@ class TestOnnxModelCloudDeployment(unittest.TestCase):
         fields = {"title": "this is my updated title"}
         fields.update(self.bert_config.doc_fields(text=str(fields["title"])))
         response = self.app.update_data(schema="cord19", data_id="1", fields=fields)
-        self.assertEqual(response.json()["id"], "id:cord19:cord19::1")
+        self.assertEqual(response.json["id"], "id:cord19:cord19::1")
         #
         # Get the updated data point
         #
@@ -443,7 +464,7 @@ class TestOnnxModelCloudDeployment(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         embedding_values = fields["pretrained_bert_tiny_doc_token_ids"]["values"]
         self.assertDictEqual(
-            response.json(),
+            response.json,
             {
                 "fields": {
                     "cord_uid": "1",
@@ -466,7 +487,7 @@ class TestOnnxModelCloudDeployment(unittest.TestCase):
         # Delete a data point
         #
         response = self.app.delete_data(schema="cord19", data_id="1")
-        self.assertEqual(response.json()["id"], "id:cord19:cord19::1")
+        self.assertEqual(response.json["id"], "id:cord19:cord19::1")
         #
         # Deleted data should be gone
         #
@@ -491,7 +512,7 @@ class TestOnnxModelCloudDeployment(unittest.TestCase):
             data_id="1",
             fields=fields,
         )
-        self.assertEqual(response.json()["id"], "id:cord19:cord19::1")
+        self.assertEqual(response.json["id"], "id:cord19:cord19::1")
         #
         # Run a test query
         #

--- a/vespa/test_query.py
+++ b/vespa/test_query.py
@@ -14,7 +14,7 @@ from vespa.query import (
     Union,
     RankProfile,
 )
-from vespa.io import VespaResult
+from vespa.io import VespaQueryResponse
 
 
 class TestQueryProperty(unittest.TestCase):
@@ -292,15 +292,13 @@ class TestVespaResult(unittest.TestCase):
         }
 
     def test_json(self):
-        vespa_result = VespaResult(vespa_result=self.raw_vespa_result)
+        vespa_result = VespaQueryResponse(json=self.raw_vespa_result, status_code=None, url=None)
         self.assertDictEqual(vespa_result.json, self.raw_vespa_result)
 
     def test_hits(self):
-        empty_hits_vespa_result = VespaResult(
-            vespa_result=self.raw_vespa_result_empty_hits
-        )
+        empty_hits_vespa_result = VespaQueryResponse(json=self.raw_vespa_result_empty_hits, status_code=None, url=None)
         self.assertEqual(empty_hits_vespa_result.hits, [])
-        vespa_result = VespaResult(vespa_result=self.raw_vespa_result)
+        vespa_result = VespaQueryResponse(json=self.raw_vespa_result, status_code=None, url=None)
         self.assertEqual(
             vespa_result.hits,
             [
@@ -318,25 +316,21 @@ class TestVespaResult(unittest.TestCase):
         )
 
     def test_get_hits_none(self):
-        empty_hits_vespa_result = VespaResult(
-            vespa_result=self.raw_vespa_result_empty_hits
-        )
+        empty_hits_vespa_result = VespaQueryResponse(json=self.raw_vespa_result_empty_hits, status_code=None, url=None)
         self.assertEqual(
             empty_hits_vespa_result.get_hits(format_function=None),
             empty_hits_vespa_result.hits,
         )
-        vespa_result = VespaResult(vespa_result=self.raw_vespa_result)
+        vespa_result = VespaQueryResponse(json=self.raw_vespa_result, status_code=None, url=None)
         self.assertEqual(
             vespa_result.get_hits(format_function=None),
             vespa_result.hits,
         )
 
     def test_get_hits_trec_format(self):
-        empty_hits_vespa_result = VespaResult(
-            vespa_result=self.raw_vespa_result_empty_hits
-        )
+        empty_hits_vespa_result = VespaQueryResponse(json=self.raw_vespa_result_empty_hits, status_code=None, url=None)
         self.assertTrue(empty_hits_vespa_result.get_hits().empty)
-        vespa_result = VespaResult(vespa_result=self.raw_vespa_result)
+        vespa_result = VespaQueryResponse(json=self.raw_vespa_result, status_code=None, url=None)
         assert_frame_equal(
             vespa_result.get_hits(),
             DataFrame(
@@ -349,7 +343,7 @@ class TestVespaResult(unittest.TestCase):
                 columns=["qid", "doc_id", "score", "rank"],
             ),
         )
-        vespa_result = VespaResult(vespa_result=self.raw_vespa_result_multiple)
+        vespa_result = VespaQueryResponse(json=self.raw_vespa_result_multiple, status_code=None, url=None)
         assert_frame_equal(
             vespa_result.get_hits(),
             DataFrame(

--- a/vespa/test_query.py
+++ b/vespa/test_query.py
@@ -14,7 +14,7 @@ from vespa.query import (
     Union,
     RankProfile,
 )
-from vespa.application import VespaResult
+from vespa.io import VespaResult
 
 
 class TestQueryProperty(unittest.TestCase):

--- a/vespa/test_query.py
+++ b/vespa/test_query.py
@@ -13,8 +13,8 @@ from vespa.query import (
     ANN,
     Union,
     RankProfile,
-    VespaResult,
 )
+from vespa.application import VespaResult
 
 
 class TestQueryProperty(unittest.TestCase):


### PR DESCRIPTION
Make sync and async operations return the same object. Required step to make running sync or async indifferent to the end-user.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
