### PR TITLE
Experiment with HTTP/2 via HTTPX library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setuptools.setup(
         "docker",
         "jinja2",
         "cryptography",
-        "aiohttp"
+        "aiohttp",
+        "httpx[http2]"
     ],
     extras_require={
         "ml": ["transformers", "torch"],

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setuptools.setup(
         "jinja2",
         "cryptography",
         "aiohttp",
-        "httpx[http2]"
+        "httpx[http2]",
+        "tenacity"
     ],
     extras_require={
         "ml": ["transformers", "torch"],

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -13,6 +13,7 @@ from requests.exceptions import ConnectionError
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 import httpx
+from tenacity import retry, wait_exponential, stop_after_attempt
 
 from vespa.io import VespaQueryResponse, VespaResponse
 from vespa.query import QueryModel
@@ -997,6 +998,7 @@ class VespaHTTPX(object):
         print(response.http_version)
         return result
 
+    @retry(wait=wait_exponential(multiplier=1), stop=stop_after_attempt(3))
     async def feed_data_point_async_with_client(
         self,
         client: httpx.AsyncClient,

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -12,6 +12,7 @@ from requests.models import Response
 from requests.exceptions import ConnectionError
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
+import httpx
 
 from vespa.io import VespaQueryResponse, VespaResponse
 from vespa.query import QueryModel
@@ -882,3 +883,166 @@ class VespaAsync(object):
 
     async def update_batch(self, batch):
         return await self._wait(self.update_data, batch)
+
+
+class VespaHTTPX(object):
+    def __init__(self, app: Vespa) -> None:
+        self.app = app
+
+    def feed_data_point(
+        self, schema: str, data_id: str, fields: Dict, http2: bool = False
+    ) -> VespaResponse:
+        """
+        Feed a data point to a Vespa app.
+
+        :param schema: The schema that we are sending data to.
+        :param data_id: Unique id associated with this data point.
+        :param fields: Dict containing all the fields required by the `schema`.
+        :return: Response of the HTTP POST request.
+        """
+        end_point = "{}/document/v1/{}/{}/docid/{}".format(
+            self.app.end_point, schema, schema, str(data_id)
+        )
+        vespa_format = {"fields": fields}
+        with httpx.Client(cert=self.app.cert, http2=http2) as client:
+            response = client.post(
+                end_point,
+                json=vespa_format,
+            )
+        print(response.http_version)
+        return VespaResponse(
+            json=response.json(),
+            status_code=response.status_code,
+            url=str(response.url),
+            operation_type="feed",
+        )
+
+    def feed_batch(self, schema: str, batch: List[Dict], http2: bool = False):
+        result = []
+        with httpx.Client(
+            cert=self.app.cert, http2=http2, timeout=httpx.Timeout(10.0)
+        ) as client:
+            for data_point in batch:
+                end_point = "{}/document/v1/{}/{}/docid/{}".format(
+                    self.app.end_point, schema, schema, str(data_point["id"])
+                )
+                vespa_format = {"fields": data_point["fields"]}
+                response = client.post(
+                    end_point,
+                    json=vespa_format,
+                )
+                result.append(
+                    VespaResponse(
+                        json=response.json(),
+                        status_code=response.status_code,
+                        url=str(response.url),
+                        operation_type="feed",
+                    )
+                )
+        print(response.http_version)
+        return result
+
+    async def feed_data_point_async(
+        self, schema: str, data_id: str, fields: Dict, http2: bool = False
+    ) -> VespaResponse:
+        """
+        Feed a data point to a Vespa app.
+
+        :param schema: The schema that we are sending data to.
+        :param data_id: Unique id associated with this data point.
+        :param fields: Dict containing all the fields required by the `schema`.
+        :return: Response of the HTTP POST request.
+        """
+        end_point = "{}/document/v1/{}/{}/docid/{}".format(
+            self.app.end_point, schema, schema, str(data_id)
+        )
+        vespa_format = {"fields": fields}
+        async with httpx.AsyncClient(cert=self.app.cert, http2=http2) as client:
+            response = await client.post(
+                end_point,
+                json=vespa_format,
+            )
+        print(response.http_version)
+        return VespaResponse(
+            json=response.json(),
+            status_code=response.status_code,
+            url=str(response.url),
+            operation_type="feed",
+        )
+
+    async def feed_batch_async(
+        self, schema: str, batch: List[Dict], http2: bool = False
+    ):
+        result = []
+        async with httpx.AsyncClient(
+            cert=self.app.cert, http2=http2, timeout=httpx.Timeout(10.0)
+        ) as client:
+            for data_point in batch:
+                end_point = "{}/document/v1/{}/{}/docid/{}".format(
+                    self.app.end_point, schema, schema, str(data_point["id"])
+                )
+                vespa_format = {"fields": data_point["fields"]}
+                response = await client.post(
+                    end_point,
+                    json=vespa_format,
+                )
+                result.append(
+                    VespaResponse(
+                        json=response.json(),
+                        status_code=response.status_code,
+                        url=str(response.url),
+                        operation_type="feed",
+                    )
+                )
+        print(response.http_version)
+        return result
+
+    async def feed_data_point_async_with_client(
+        self,
+        client: httpx.AsyncClient,
+        schema: str,
+        data_id: str,
+        fields: Dict,
+    ) -> VespaResponse:
+        """
+        Feed a data point to a Vespa app.
+
+        :param schema: The schema that we are sending data to.
+        :param data_id: Unique id associated with this data point.
+        :param fields: Dict containing all the fields required by the `schema`.
+        :return: Response of the HTTP POST request.
+        """
+        end_point = "{}/document/v1/{}/{}/docid/{}".format(
+            self.app.end_point, schema, schema, str(data_id)
+        )
+        vespa_format = {"fields": fields}
+        response = await client.post(
+            end_point,
+            json=vespa_format,
+        )
+        return VespaResponse(
+            json=response.json(),
+            status_code=response.status_code,
+            url=str(response.url),
+            operation_type="feed",
+        )
+
+    async def _wait(self, f, args):
+        tasks = [asyncio.create_task(f(*arg)) for arg in args]
+        await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
+        return [result for result in map(lambda task: task.result(), tasks)]
+
+    async def feed_batch_wait_async(
+        self, schema: str, batch: List[Dict], http2: bool = False
+    ):
+        async with httpx.AsyncClient(
+            cert=self.app.cert, http2=http2, timeout=httpx.Timeout(10.0, connect=200.0)
+        ) as client:
+            responses = await self._wait(
+                self.feed_data_point_async_with_client,
+                [
+                    (client, schema, data_point["id"], data_point["fields"])
+                    for data_point in batch
+                ],
+            )
+        return responses

--- a/vespa/test_integration_vespa_cloud.py
+++ b/vespa/test_integration_vespa_cloud.py
@@ -80,7 +80,7 @@ class TestMsmarcoApplication(TestApplicationCommon):
         fields_to_send = [
             {
                 "id": f"{i}",
-                "title": f"this is title {i}",
+                "title": "a" * 100,
                 "body": f"this is body {i}",
             }
             for i in range(1000)
@@ -95,38 +95,38 @@ class TestMsmarcoApplication(TestApplicationCommon):
             docs.append({"id": fields["id"], "fields": fields})
         vespa_httpx = VespaHTTPX(app=self.app)
 
-        # start = time.time()
-        # response = vespa_httpx.feed_batch(schema=schema, batch=docs)
-        # print(time.time() - start)
-        # print([x.status_code for x in response])
-
-        # start = time.time()
-        # response = vespa_httpx.feed_batch(schema=schema, batch=docs, http2=True)
-        # print(time.time() - start)
-        # print([x.status_code for x in response])
-
-        # start = time.time()
-        # response = asyncio.run(vespa_httpx.feed_batch_async(schema=schema, batch=docs))
-        # print(time.time() - start)
-        # print([x.status_code for x in response])
         #
-        # start = time.time()
-        # response = asyncio.run(
-        #     vespa_httpx.feed_batch_async(schema=schema, batch=docs, http2=True)
-        # )
-        # print(time.time() - start)
-        # print([x.status_code for x in response])
+        # Synchronous feed batch with Requests
+        #
+        start = time.time()
+        response = self.app.feed_batch(schema=schema, batch=docs)
+        print(time.time() - start)
+        print([x.status_code for x in response])
 
+        #
+        # Asynchronous feed batch with aiohttp
+        #
+        start = time.time()
+        response = self.app.feed_batch(schema=schema, batch=docs, asynchronous=True)
+        print(time.time() - start)
+        print([x.status_code for x in response])
+
+        #
+        # Asynchronous feed batch with HTTPX and HTTP/1.1
+        #
         start = time.time()
         response = asyncio.run(
-            vespa_httpx.feed_batch_wait_async(schema=schema, batch=docs)
+            vespa_httpx.feed_batch_async(schema=schema, batch=docs)
         )
         print(time.time() - start)
         print([x.status_code for x in response])
 
+        #
+        # Asynchronous feed batch with HTTPX and HTTP/2
+        #
         start = time.time()
         response = asyncio.run(
-            vespa_httpx.feed_batch_wait_async(schema=schema, batch=docs, http2=True)
+            vespa_httpx.feed_batch_async(schema=schema, batch=docs, http2=True)
         )
         print(time.time() - start)
         print([x.status_code for x in response])


### PR DESCRIPTION
My preliminary results showed that HTTP/2 is much faster than HTTP/1.1 when both are implemented using HTTPX library. However, using aiohttp library with HTTP/1.1 is faster than HTTPX implementation across all scenarios, similarly to what was found in https://github.com/encode/httpx/issues/838.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
