### PR TITLE
Make async operations more robust and add tune parameters

### DIFF
--- a/vespa/application.py
+++ b/vespa/application.py
@@ -226,7 +226,8 @@ class Vespa(object):
         :param batch: A list of dict containing the keys 'id' and 'fields' to be used in the :func:`feed_data_point`.
         :param asynchronous: Set True to send data in async mode. Default to False. Create and execute the coroutine if
             there is no active running loop. Otherwise it returns the coroutine and requires await to be executed.
-        :param connections: Number of allowed concurrent connections, valid only if asynchronous=True.
+        :param connections: Number of allowed concurrent connections, valid only if `asynchronous=True`.
+        :param total_timeout: Total timeout in secs for each of the concurrent requests when using `asynchronous=True`.
         :return: List of HTTP POST responses
         """
 

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -102,6 +102,7 @@ class Vespa(object):
         Access Vespa asynchronous connection layer
 
         :param connections: Number of allowed concurrent connections
+        :param total_timeout: Total timeout in secs.
         :return: Instance of Vespa asynchronous layer.
         """
         return VespaAsync(

--- a/vespa/test_integration_docker.py
+++ b/vespa/test_integration_docker.py
@@ -624,7 +624,13 @@ class TestApplicationCommon(unittest.TestCase):
         schema = schema_name
         for fields in fields_to_send:
             docs.append({"id": fields["id"], "fields": fields})
-        app.feed_batch(schema=schema, batch=docs, asynchronous=True)
+        app.feed_batch(
+            schema=schema,
+            batch=docs,
+            asynchronous=True,
+            connections=120,
+            total_timeout=50,
+        )
 
         # Verify that all documents are fed
         result = app.query(

--- a/vespa/test_integration_docker.py
+++ b/vespa/test_integration_docker.py
@@ -426,7 +426,7 @@ class TestApplicationCommon(unittest.TestCase):
             There are cases where fields returned from Vespa are different than inputs, e.g. when dealing with Tensors.
         :return:
         """
-        async with app.asyncio() as async_app:
+        async with app.asyncio(connections=120, total_timeout=50) as async_app:
             #
             # Get data that does not exist
             #


### PR DESCRIPTION
* Add Retry capabilities to async operation
* Add Semaphore to ensure we don't start all concurrent operations at the same time
* Allow tunning of async operations through number of concurrent connections and total timeout.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
