### PR TITLE
Clean up notebooks to fix the CI pipeline

### DIFF
--- a/docs/sphinx/source/howto/deploy_app_package/deploy-docker.ipynb
+++ b/docs/sphinx/source/howto/deploy_app_package/deploy-docker.ipynb
@@ -65,9 +65,10 @@
     "import os\n",
     "from vespa.package import VespaDocker\n",
     "\n",
+    "disk_folder = os.path.join(os.getenv(\"WORK_DIR\"), \"sample_application\") # specify your desired absolute path here\n",
     "vespa_docker = VespaDocker(\n",
     "    port=8080,\n",
-    "    disk_folder=os.path.join(os.getenv(\"WORK_DIR\"), \"sample_application\") # specify your desired absolute path here\n",
+    "    disk_folder=disk_folder\n",
     ")\n",
     "\n",
     "app = vespa_docker.deploy(\n",
@@ -154,9 +155,26 @@
     "    application_folder=\"application\"\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# this is a hidden cell. It will not show on the documentation HTML.\n",
+    "from shutil import rmtree\n",
+    "\n",
+    "rmtree(disk_folder, ignore_errors=True)\n",
+    "vespa_docker.container.stop()\n",
+    "vespa_docker.container.remove()"
+   ]
   }
  ],
  "metadata": {
+  "celltoolbar": "Edit Metadata",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/docs/sphinx/source/howto/exchange_data_with_app/feed-data.ipynb
+++ b/docs/sphinx/source/howto/exchange_data_with_app/feed-data.ipynb
@@ -92,7 +92,7 @@
    "id": "incident-discovery",
    "metadata": {},
    "source": [
-    "We can either feed a batch of data for convenience or feed individual data points for increased control. We can also choose between synchronous and asynchronous feeding. Given that feeding is I/O bound, we expect the asynchronous method to speed up most cases."
+    "We can either feed a batch of data for convenience or feed individual data points for increased control."
    ]
   },
   {
@@ -137,10 +137,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "creative-plate",
+   "id": "hybrid-dominant",
    "metadata": {},
    "source": [
-    "### Synchronous"
+    "We then feed the batch to the desired schema."
    ]
   },
   {
@@ -151,36 +151,6 @@
    "outputs": [],
    "source": [
     "response = app.feed_batch(schema=\"sentence\", batch=batch_feed)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "juvenile-principle",
-   "metadata": {},
-   "source": [
-    "### Asynchronous"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "stunning-scientist",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "response = await app.feed_batch(schema=\"sentence\", batch=batch_feed, asynchronous=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "southern-expert",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**Note**: The **await** keyword is required when batch feeding asynchronously from Jupyter Notebooks because it already has its async event loop running in the background. You can skip the **await** keyword when using it on an environment with no running event loop, and pyvespa will take care of the rest.\n",
-    "\n",
-    "</div>"
    ]
   },
   {

--- a/docs/sphinx/source/howto/exchange_data_with_app/feed-data.ipynb
+++ b/docs/sphinx/source/howto/exchange_data_with_app/feed-data.ipynb
@@ -47,7 +47,6 @@
     "disk_folder = os.path.join(os.getenv(\"WORK_DIR\"), \"sample_application\")\n",
     "vespa_docker = VespaDocker(\n",
     "    port=8081, \n",
-    "    container_memory=\"8G\", \n",
     "    disk_folder=disk_folder # requires absolute path\n",
     ")\n",
     "app = vespa_docker.deploy(application_package=app_package)"

--- a/docs/sphinx/source/use_cases/qa/semantic-retrieval-for-question-answering-applications.ipynb
+++ b/docs/sphinx/source/use_cases/qa/semantic-retrieval-for-question-answering-applications.ipynb
@@ -599,7 +599,6 @@
     "disk_folder = os.path.join(os.getenv(\"WORK_DIR\"), \"sample_application\")\n",
     "vespa_docker = VespaDocker(\n",
     "    port=8081, \n",
-    "    container_memory=\"8G\", \n",
     "    disk_folder=disk_folder # requires absolute path\n",
     ")\n",
     "app = vespa_docker.deploy(application_package=app_package)"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -72,6 +72,7 @@ jobs:
       DOCKER_HOST: "localhost:2375"
     steps:
       - setup: |
+          set -e
           dnf install -y git
           export WORK_DIR=$SD_DIND_SHARE_PATH
           export RESOURCES_DIR=$(pwd)/vespa/resources

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -72,7 +72,6 @@ jobs:
       DOCKER_HOST: "localhost:2375"
     steps:
       - setup: |
-          set -e
           dnf install -y git
           export WORK_DIR=$SD_DIND_SHARE_PATH
           export RESOURCES_DIR=$(pwd)/vespa/resources
@@ -90,6 +89,7 @@ jobs:
           python3 -m pip install -r docs/sphinx/source/requirements.txt
           python3 -m pip install -r docs/sphinx/source/notebook_requirements.txt
       - run-notebooks-except-cloud-related: |
+          set -e
           dnf install -y tree
           dnf install -y wget
           find docs -name '*.ipynb' ! -name '*cloud*.ipynb'

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -92,7 +92,7 @@ jobs:
           dnf install -y tree
           dnf install -y wget
           find docs -name '*.ipynb' ! -name '*cloud*.ipynb'
-          find docs -name '*.ipynb' ! -name '*cloud*.ipynb' -exec runnb --allow-not-trusted {} \;
+          find docs -name '*.ipynb' ! -name '*cloud*.ipynb' -exec ls {} \; -name '*.ipynb' ! -name '*cloud*.ipynb' -exec runnb --allow-not-trusted {} \;
           find docs -name '*.nbconvert.ipynb' -exec rm {} +
   integration-cloud:
     requires: [~commit]

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -84,7 +84,7 @@ jobs:
       - install-python: |
           dnf install -y python38-pip
           python3 -m pip install --upgrade pip
-          python3 -m pip install pytest notebook nbconvert
+          python3 -m pip install pytest notebook nbconvert runnb
           python3 -m pip install -e .[full]
           python3 -m pip install -r docs/sphinx/source/requirements.txt
           python3 -m pip install -r docs/sphinx/source/notebook_requirements.txt
@@ -92,7 +92,7 @@ jobs:
           dnf install -y tree
           dnf install -y wget
           find docs -name '*.ipynb' ! -name '*cloud*.ipynb'
-          find docs -name '*.ipynb' ! -name '*cloud*.ipynb' -exec jupyter nbconvert --to notebook --ExecutePreprocessor.timeout=6000 --execute {} +
+          find docs -name '*.ipynb' ! -name '*cloud*.ipynb' -exec runnb --allow-not-trusted {} \;
           find docs -name '*.nbconvert.ipynb' -exec rm {} +
   integration-cloud:
     requires: [~commit]

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -94,7 +94,6 @@ jobs:
           dnf install -y wget
           find docs -name '*.ipynb' ! -name '*cloud*.ipynb'
           find docs -name '*.ipynb' ! -name '*cloud*.ipynb' -exec ls {} \; -name '*.ipynb' ! -name '*cloud*.ipynb' -exec runnb --allow-not-trusted {} \;
-          find docs -name '*.nbconvert.ipynb' -exec rm {} +
   integration-cloud:
     requires: [~commit]
     annotations:
@@ -133,14 +132,13 @@ jobs:
       - install-python: |
           dnf install -y python38-pip
           python3 -m pip install --upgrade pip
-          python3 -m pip install pytest notebook nbconvert
+          python3 -m pip install pytest notebook nbconvert runnb
           python3 -m pip install -e .[full]
           python3 -m pip install -r docs/sphinx/source/requirements.txt
           python3 -m pip install -r docs/sphinx/source/notebook_requirements.txt
       - run-notebooks-except-cloud-related: |
           find docs -name '*cloud*.ipynb'
-          find docs -name '*cloud*.ipynb' -exec jupyter nbconvert --to notebook --ExecutePreprocessor.timeout=600 --execute {} +
-          find docs -name '*.nbconvert.ipynb' -exec rm {} +
+          find docs -name '*cloud*.ipynb' ls {} \; -name '*cloud*.ipynb' -exec runnb --allow-not-trusted {} \;
   deploy-test-server:
     requires: [unit-tests, integration-except-cloud, notebooks-except-cloud, notebooks-cloud]
     annotations:

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -222,7 +222,7 @@ class Vespa(object):
         batch: List[Dict],
         asynchronous=True,
         connections: Optional[int] = 100,
-        total_timeout: int = 10,
+        total_timeout: int = 100,
     ):
         """
         Feed a batch of data to a Vespa app.


### PR DESCRIPTION
* remove unnecessary await keyword from notebook
* remove docker container increased memory requirement
* clean up docker env from one of the notebooks
* Use runnb instead of nbconvert to facilitate debugging
* Increase default timeout for async feeding

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
