### PR TITLE
Implement get_batch with async mode as default

### DIFF
--- a/vespa/test_integration_docker.py
+++ b/vespa/test_integration_docker.py
@@ -840,6 +840,7 @@ class TestMsmarcoApplication(TestApplicationCommon):
             app=self.app,
             schema_name=self.app_package.name,
             fields_to_send=self.fields_to_send,
+            expected_fields_from_get_operation=self.fields_to_send,
         )
 
     def test_batch_operations_asynchronous_mode(self):
@@ -847,6 +848,7 @@ class TestMsmarcoApplication(TestApplicationCommon):
             app=self.app,
             schema_name=self.app_package.name,
             fields_to_send=self.fields_to_send,
+            expected_fields_from_get_operation=self.fields_to_send,
         )
 
     def tearDown(self) -> None:
@@ -923,6 +925,7 @@ class TestCord19Application(TestApplicationCommon):
             app=self.app,
             schema_name=self.app_package.name,
             fields_to_send=self.fields_to_send,
+            expected_fields_from_get_operation=self.expected_fields_from_get_operation,
         )
 
     def test_batch_operations_asynchronous_mode(self):
@@ -930,6 +933,7 @@ class TestCord19Application(TestApplicationCommon):
             app=self.app,
             schema_name=self.app_package.name,
             fields_to_send=self.fields_to_send,
+            expected_fields_from_get_operation=self.expected_fields_from_get_operation,
         )
 
     def test_bert_model_input_and_output(self):

--- a/vespa/test_integration_docker.py
+++ b/vespa/test_integration_docker.py
@@ -579,7 +579,7 @@ class TestApplicationCommon(unittest.TestCase):
                 queries[0].result().number_documents_indexed, len(fields_to_send) - 1
             )
 
-    def feed_batch_synchronous_mode(self, app, schema_name, fields_to_send):
+    def batch_operations_synchronous_mode(self, app, schema_name, fields_to_send):
         """
         Sync feed a batch of data to the application
 
@@ -600,13 +600,22 @@ class TestApplicationCommon(unittest.TestCase):
             docs.append({"id": fields["id"], "fields": fields})
         app.feed_batch(schema=schema, batch=docs, asynchronous=False)
 
+        #
         # Verify that all documents are fed
+        #
         result = app.query(
             query="sddocname:{}".format(schema_name), query_model=QueryModel()
         )
         self.assertEqual(result.number_documents_indexed, num_docs)
 
-    def feed_batch_asynchronous_mode(self, app, schema_name, fields_to_send):
+        #
+        # get batch data
+        #
+        result = app.get_batch(schema=schema, batch=docs, asynchronous=False)
+        for idx, response in enumerate(result):
+            self.assertEqual(response.json["fields"], fields_to_send[idx])
+
+    def batch_operations_asynchronous_mode(self, app, schema_name, fields_to_send):
         """
         Async feed a batch of data to the application
 
@@ -632,11 +641,20 @@ class TestApplicationCommon(unittest.TestCase):
             total_timeout=50,
         )
 
+        #
         # Verify that all documents are fed
+        #
         result = app.query(
             query="sddocname:{}".format(schema_name), query_model=QueryModel()
         )
         self.assertEqual(result.number_documents_indexed, num_docs)
+
+        #
+        # get batch data
+        #
+        result = app.get_batch(schema=schema, batch=docs, asynchronous=True)
+        for idx, response in enumerate(result):
+            self.assertEqual(response.json["fields"], fields_to_send[idx])
 
     @staticmethod
     def _parse_vespa_tensor(hit, feature):
@@ -813,15 +831,15 @@ class TestMsmarcoApplication(TestApplicationCommon):
             )
         )
 
-    def test_feed_batch_synchronous_mode(self):
-        self.feed_batch_synchronous_mode(
+    def test_batch_operations_synchronous_mode(self):
+        self.batch_operations_synchronous_mode(
             app=self.app,
             schema_name=self.app_package.name,
             fields_to_send=self.fields_to_send,
         )
 
-    def test_feed_batch_asynchronous_mode(self):
-        self.feed_batch_asynchronous_mode(
+    def test_batch_operations_asynchronous_mode(self):
+        self.batch_operations_asynchronous_mode(
             app=self.app,
             schema_name=self.app_package.name,
             fields_to_send=self.fields_to_send,
@@ -896,15 +914,15 @@ class TestCord19Application(TestApplicationCommon):
             )
         )
 
-    def test_feed_batch_synchronous_mode(self):
-        self.feed_batch_synchronous_mode(
+    def test_batch_operations_synchronous_mode(self):
+        self.batch_operations_synchronous_mode(
             app=self.app,
             schema_name=self.app_package.name,
             fields_to_send=self.fields_to_send,
         )
 
-    def test_feed_batch_asynchronous_mode(self):
-        self.feed_batch_asynchronous_mode(
+    def test_batch_operations_asynchronous_mode(self):
+        self.batch_operations_asynchronous_mode(
             app=self.app,
             schema_name=self.app_package.name,
             fields_to_send=self.fields_to_send,
@@ -997,15 +1015,15 @@ class TestQaApplication(TestApplicationCommon):
             )
         )
 
-    def test_feed_batch_synchronous_mode(self):
-        self.feed_batch_synchronous_mode(
+    def test_batch_operations_synchronous_mode(self):
+        self.batch_operations_synchronous_mode(
             app=self.app,
             schema_name="sentence",
             fields_to_send=self.fields_to_send_sentence,
         )
 
-    def test_feed_batch_asynchronous_mode(self):
-        self.feed_batch_asynchronous_mode(
+    def test_batch_operations_asynchronous_mode(self):
+        self.batch_operations_asynchronous_mode(
             app=self.app,
             schema_name="sentence",
             fields_to_send=self.fields_to_send_sentence,

--- a/vespa/test_integration_vespa_cloud.py
+++ b/vespa/test_integration_vespa_cloud.py
@@ -58,15 +58,15 @@ class TestMsmarcoApplication(TestApplicationCommon):
             )
         )
 
-    def test_feed_batch_synchronous_mode(self):
-        self.feed_batch_synchronous_mode(
+    def test_batch_operations_synchronous_mode(self):
+        self.batch_operations_synchronous_mode(
             app=self.app,
             schema_name=self.app_package.name,
             fields_to_send=self.fields_to_send,
         )
 
-    def test_feed_batch_asynchronous_mode(self):
-        self.feed_batch_asynchronous_mode(
+    def test_batch_operations_asynchronous_mode(self):
+        self.batch_operations_asynchronous_mode(
             app=self.app,
             schema_name=self.app_package.name,
             fields_to_send=self.fields_to_send,
@@ -150,15 +150,15 @@ class TestCord19Application(TestApplicationCommon):
             )
         )
 
-    def test_feed_batch_synchronous_mode(self):
-        self.feed_batch_synchronous_mode(
+    def test_batch_operations_synchronous_mode(self):
+        self.batch_operations_synchronous_mode(
             app=self.app,
             schema_name=self.app_package.name,
             fields_to_send=self.fields_to_send,
         )
 
-    def test_feed_batch_asynchronous_mode(self):
-        self.feed_batch_asynchronous_mode(
+    def test_batch_operations_asynchronous_mode(self):
+        self.batch_operations_asynchronous_mode(
             app=self.app,
             schema_name=self.app_package.name,
             fields_to_send=self.fields_to_send,
@@ -252,15 +252,15 @@ class TestQaApplication(TestApplicationCommon):
             )
         )
 
-    def test_feed_batch_synchronous_mode(self):
-        self.feed_batch_synchronous_mode(
+    def test_batch_operations_synchronous_mode(self):
+        self.batch_operations_synchronous_mode(
             app=self.app,
             schema_name="sentence",
             fields_to_send=self.fields_to_send_sentence,
         )
 
-    def test_feed_batch_asynchronous_mode(self):
-        self.feed_batch_asynchronous_mode(
+    def test_batch_operations_asynchronous_mode(self):
+        self.batch_operations_asynchronous_mode(
             app=self.app,
             schema_name="sentence",
             fields_to_send=self.fields_to_send_sentence,

--- a/vespa/test_integration_vespa_cloud.py
+++ b/vespa/test_integration_vespa_cloud.py
@@ -63,6 +63,7 @@ class TestMsmarcoApplication(TestApplicationCommon):
             app=self.app,
             schema_name=self.app_package.name,
             fields_to_send=self.fields_to_send,
+            expected_fields_from_get_operation=self.fields_to_send,
         )
 
     def test_batch_operations_asynchronous_mode(self):
@@ -70,6 +71,7 @@ class TestMsmarcoApplication(TestApplicationCommon):
             app=self.app,
             schema_name=self.app_package.name,
             fields_to_send=self.fields_to_send,
+            expected_fields_from_get_operation=self.fields_to_send,
         )
 
     def tearDown(self) -> None:
@@ -155,6 +157,7 @@ class TestCord19Application(TestApplicationCommon):
             app=self.app,
             schema_name=self.app_package.name,
             fields_to_send=self.fields_to_send,
+            expected_fields_from_get_operation=self.expected_fields_from_get_operation,
         )
 
     def test_batch_operations_asynchronous_mode(self):
@@ -162,6 +165,7 @@ class TestCord19Application(TestApplicationCommon):
             app=self.app,
             schema_name=self.app_package.name,
             fields_to_send=self.fields_to_send,
+            expected_fields_from_get_operation=self.expected_fields_from_get_operation,
         )
 
     def test_bert_model_input_and_output(self):

--- a/vespa/test_integration_vespa_cloud.py
+++ b/vespa/test_integration_vespa_cloud.py
@@ -203,7 +203,6 @@ class TestQaApplication(TestApplicationCommon):
                 "id": d["id"],
                 "text": d["text"],
                 "dataset": d["dataset"],
-                "questions": d["questions"],
                 "context_id": d["context_id"],
                 "sentence_embedding": {
                     "cells": [
@@ -212,6 +211,8 @@ class TestQaApplication(TestApplicationCommon):
                     ]
                 },
             }
+            if len(d["questions"]) > 0:
+                expected_d.update({"questions": d["questions"]})
             self.expected_fields_from_sentence_get_operation.append(expected_d)
         with open(
             os.path.join(os.environ["RESOURCES_DIR"], "qa_sample_context_data.json"),
@@ -257,6 +258,7 @@ class TestQaApplication(TestApplicationCommon):
             app=self.app,
             schema_name="sentence",
             fields_to_send=self.fields_to_send_sentence,
+            expected_fields_from_get_operation=self.expected_fields_from_sentence_get_operation,
         )
 
     def test_batch_operations_asynchronous_mode(self):
@@ -264,6 +266,7 @@ class TestQaApplication(TestApplicationCommon):
             app=self.app,
             schema_name="sentence",
             fields_to_send=self.fields_to_send_sentence,
+            expected_fields_from_get_operation=self.expected_fields_from_sentence_get_operation,
         )
 
     def tearDown(self) -> None:


### PR DESCRIPTION
Now that we got `app.feed_batch` to work as expected, we will replicate the same behavior for other operations. This PR starts with `get_batch`.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
