### PR TITLE
Fix Docker in SD pipeline

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -38,8 +38,6 @@ jobs:
       screwdriver.cd/dockerEnabled: true
       screwdriver.cd/dockerCpu: TURBO
       screwdriver.cd/dockerRam: TURBO
-    environment:
-      DOCKER_HOST: "localhost:2375"
     steps:
       - setup: |
           export WORK_DIR=$SD_DIND_SHARE_PATH
@@ -68,8 +66,6 @@ jobs:
       screwdriver.cd/dockerEnabled: true
       screwdriver.cd/dockerCpu: TURBO
       screwdriver.cd/dockerRam: TURBO
-    environment:
-      DOCKER_HOST: "localhost:2375"
     steps:
       - setup: |
           dnf install -y git


### PR DESCRIPTION
DOCKER_HOST has changed to localhost:2376: https://github.com/screwdriver-cd/executor-k8s/pull/169/files

In addition, it is not necessary to set DOCKER_HOST in the screwdriver.yaml

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
