### PR TITLE
SequenceClassification task in Vespa

### DIFF
--- a/vespa/application.py
+++ b/vespa/application.py
@@ -152,10 +152,8 @@ class Vespa(object):
     def get_model_endpoint(
         self, model_name: Optional[str] = None
     ) -> Optional[Response]:
-        """
-        Get model evaluation endpoints
-        :return:
-        """
+        """Get model evaluation endpoints."""
+
         with VespaSync(self) as sync_app:
             return sync_app.get_model_endpoint(model_name=model_name)
 
@@ -731,17 +729,27 @@ class Vespa(object):
 
     @property
     def application_package(self):
+        """Get application package definition, if available."""
         if not self._application_package:
             raise ValueError("Application package not available.")
         else:
             return self._application_package
 
     def get_model_from_application_package(self, model_name: str):
+        """Get model definition from application package, if available."""
         app_package = self.application_package
         model = app_package.get_model(model_name=model_name)
         return model
 
     def predict(self, x, model_name, function_name="output_0"):
+        """
+        Obtain a stateless model evaluation.
+
+        :param x: Input where the format depends on the task that the model is serving.
+        :param model_name: The name of the model used to serve the prediction.
+        :param function_name: The name of the output function to be evaluated.
+        :return: Model prediction.
+        """
         model = self.get_model_from_application_package(model_name)
         encoded_tokens = model.create_url_encoded_tokens(x=x)
         with VespaSync(self) as sync_app:
@@ -797,10 +805,7 @@ class VespaSync(object):
         return response
 
     def get_model_endpoint(self, model_name: Optional[str] = None) -> Optional[dict]:
-        """
-        Get model evaluation endpoints.
-        :return:
-        """
+        """Get model evaluation endpoints."""
         end_point = "{}/model-evaluation/v1/".format(self.app.end_point)
         if model_name:
             end_point = end_point + model_name
@@ -815,6 +820,14 @@ class VespaSync(object):
         return response
 
     def predict(self, model_name, function_name, encoded_tokens):
+        """
+        Obtain a stateless model evaluation.
+
+        :param model_name: The name of the model used to serve the prediction.
+        :param function_name: The name of the output function to be evaluated.
+        :param encoded_tokens: URL-encoded input to the model
+        :return: Model prediction.
+        """
         end_point = "{}/model-evaluation/v1/{}/{}/eval?{}".format(
             self.app.end_point, model_name, function_name, encoded_tokens
         )

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -1173,7 +1173,11 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
         """
         self.name = name
         if not schema:
-            schema = [Schema(name=self.name, document=Document())] if create_schema_by_default else []
+            schema = (
+                [Schema(name=self.name, document=Document())]
+                if create_schema_by_default
+                else []
+            )
         self._schema = OrderedDict([(x.name, x) for x in schema])
         if not query_profile and create_query_profile_by_default:
             query_profile = QueryProfile()
@@ -1512,3 +1516,35 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
             repr(self.query_profile_type),
         )
 
+
+class ModelServer(ApplicationPackage):
+    def __init__(
+        self,
+        name: str,
+        models: Optional[List[SequenceClassification]] = None,
+    ):
+        """
+        Create a Vespa stateless model evaluation server.
+        A Vespa stateless model evaluation server is a simplified Vespa application without content clusters.
+        :param name: Application name.
+        :param models: List of models to be used in sequence classification tasks.
+        """
+        super().__init__(
+            name=name,
+            schema=None,
+            query_profile=None,
+            query_profile_type=None,
+            stateless_model_evaluation=True,
+            create_schema_by_default=False,
+            create_query_profile_by_default=False,
+            models=models,
+        )
+
+    @staticmethod
+    def from_dict(mapping: Mapping) -> "ModelServer":
+        return ModelServer(name=mapping["name"])
+
+    @property
+    def to_dict(self) -> Mapping:
+        map = {"name": self.name}
+        return map

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -1,30 +1,12 @@
-import warnings
-import sys
-import http.client
-import json
 import os
-import re
-import zipfile
-from base64 import standard_b64encode
-from datetime import datetime, timedelta
-from io import BytesIO
 from pathlib import Path
-from time import sleep, strftime, gmtime
 from typing import List, Mapping, Optional, IO, Union, Dict
-from shutil import copyfile
 from collections import OrderedDict
 
-import docker
-from cryptography import x509
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives import serialization
 from jinja2 import Environment, PackageLoader, select_autoescape
 
 from vespa.json_serialization import ToJson, FromJson
-from vespa.application import Vespa
-from vespa.ml import ModelConfig, BertModelConfig
+from vespa.ml import ModelConfig, BertModelConfig, TextTask
 
 
 class HNSW(ToJson, FromJson["HNSW"]):
@@ -1141,7 +1123,7 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
         stateless_model_evaluation: bool = False,
         create_schema_by_default: bool = True,
         create_query_profile_by_default: bool = True,
-        models: Optional[List[SequenceClassification]] = None,
+        models: Optional[List[TextTask]] = None,
     ) -> None:
         """
         Create a Vespa Application Package.
@@ -1521,7 +1503,7 @@ class ModelServer(ApplicationPackage):
     def __init__(
         self,
         name: str,
-        models: Optional[List[SequenceClassification]] = None,
+        models: Optional[List[TextTask]] = None,
     ):
         """
         Create a Vespa stateless model evaluation server.

--- a/vespa/templates/query_profile.xml
+++ b/vespa/templates/query_profile.xml
@@ -1,5 +1,5 @@
 <query-profile id="default" type="root">
-{% for field in fields %}
+    {% for field in query_profile.fields %}
     <field name="{{ field.name }}">{{ field.value }}</field>
-{% endfor %}
+    {% endfor %}
 </query-profile>

--- a/vespa/templates/query_profile_type.xml
+++ b/vespa/templates/query_profile_type.xml
@@ -1,5 +1,5 @@
 <query-profile-type id="root">
-{% for field in fields %}
+    {% for field in query_profile_type.fields %}
     <field name="{{ field.name }}" type="{{ field.type }}" />
-{% endfor %}
+    {% endfor %}
 </query-profile-type>

--- a/vespa/templates/services.xml
+++ b/vespa/templates/services.xml
@@ -1,22 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <services version="1.0">
     <container id="{{ application_name }}_container" version="1.0">
+        {% if schemas %}
         <search></search>
         <document-api></document-api>
+        {% endif %}
+        {% if stateless_model_evaluation %}
+        <model-evaluation/>
+        {% endif %}
     </container>
+    {% if schemas %}
     <content id="{{ application_name }}_content" version="1.0">
         <redundancy reply-after="1">1</redundancy>
         <documents>
-        {% for schema in schemas %}
+            {% for schema in schemas %}
             {% if schema.global_document %}
             <document type="{{ schema.name }}" mode="index" global="true"></document>
             {% else %}
             <document type="{{ schema.name }}" mode="index"></document>
             {% endif %}
-        {% endfor %}
+            {% endfor %}
         </documents>
         <nodes>
             <node distribution-key="0" hostalias="node1"></node>
         </nodes>
     </content>
+    {% endif %}
 </services>

--- a/vespa/test_integration_docker.py
+++ b/vespa/test_integration_docker.py
@@ -1267,7 +1267,7 @@ class TestSequenceClassification(TestApplicationCommon):
     def test_model_endpoints(self):
         self.get_model_endpoints(
             app=self.app,
-            expected_model_endpoint="http://localhost:8080/model-evaluation/v1/",
+            expected_model_endpoint="http://localhost:8089/model-evaluation/v1/",
         )
 
     def test_prediction(self):

--- a/vespa/test_integration_vespa_cloud.py
+++ b/vespa/test_integration_vespa_cloud.py
@@ -47,7 +47,7 @@ class TestMsmarcoApplication(TestApplicationCommon):
         # The port should not be 4443, see https://jira.vzbuilders.com/browse/VESPA-21365
         self.get_model_endpoints_when_no_model_is_available(
             app=self.app,
-            expected_model_endpoint="https://msmarco-container.msmarco.pyvespa-integration.vespa-team.aws-us-east-1c.dev.z.vespa-app.cloud:4443/model-evaluation/v1/",
+            expected_model_endpoint="https://{}-container.{}.pyvespa-integration.vespa-team.aws-us-east-1c.dev.z.vespa-app.cloud:4443/model-evaluation/v1/".format(self.app_package.name, self.instance_name),
         )
 
     def test_prediction_when_model_not_defined(self):
@@ -159,7 +159,7 @@ class TestCord19Application(TestApplicationCommon):
         # The port should not be 4443, see https://jira.vzbuilders.com/browse/VESPA-21365
         self.get_model_endpoints_when_no_model_is_available(
             app=self.app,
-            expected_model_endpoint="https://msmarco-container.msmarco.pyvespa-integration.vespa-team.aws-us-east-1c.dev.z.vespa-app.cloud:4443/model-evaluation/v1/",
+            expected_model_endpoint="https://{}-container.{}.pyvespa-integration.vespa-team.aws-us-east-1c.dev.z.vespa-app.cloud:4443/model-evaluation/v1/".format(self.app_package.name, self.instance_name),
         )
 
     def test_prediction_when_model_not_defined(self):
@@ -272,7 +272,7 @@ class TestQaApplication(TestApplicationCommon):
         # The port should not be 4443, see https://jira.vzbuilders.com/browse/VESPA-21365
         self.get_model_endpoints_when_no_model_is_available(
             app=self.app,
-            expected_model_endpoint="https://msmarco-container.msmarco.pyvespa-integration.vespa-team.aws-us-east-1c.dev.z.vespa-app.cloud:4443/model-evaluation/v1/",
+            expected_model_endpoint="https://{}-container.{}.pyvespa-integration.vespa-team.aws-us-east-1c.dev.z.vespa-app.cloud:4443/model-evaluation/v1/".format(self.app_package.name, self.instance_name),
         )
 
     def test_prediction_when_model_not_defined(self):

--- a/vespa/test_package.py
+++ b/vespa/test_package.py
@@ -17,6 +17,7 @@ from vespa.package import (
     QueryField,
     QueryProfile,
     ApplicationPackage,
+    ModelServer
 )
 from vespa.ml import BertModelConfig
 
@@ -1588,3 +1589,54 @@ class TestSimplifiedApplicationPackageAddBertRanking(unittest.TestCase):
 
     def tearDown(self) -> None:
         rmtree(self.disk_folder, ignore_errors=True)
+
+
+class TestModelServer(unittest.TestCase):
+    def setUp(self) -> None:
+        self.server_name = "test_server"
+        self.model_server = ModelServer(
+            name=self.server_name,
+        )
+
+    def test_model_server_serialization(self):
+        self.assertEqual(
+            self.model_server, ModelServer.from_dict(self.model_server.to_dict)
+        )
+
+    def test_get_schema(self):
+        self.assertIsNone(self.model_server.schema)
+        self.assertEqual(self.model_server.schema, self.model_server.get_schema())
+
+    def test_hosts_to_text(self):
+        expected_result = (
+            '<?xml version="1.0" encoding="utf-8" ?>\n'
+            "<!-- Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->\n"
+            "<hosts>\n"
+            '    <host name="localhost">\n'
+            "        <alias>node1</alias>\n"
+            "    </host>\n"
+            "</hosts>"
+        )
+        self.assertEqual(self.model_server.hosts_to_text, expected_result)
+
+    def test_services_to_text(self):
+        expected_result = (
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<services version="1.0">\n'
+            '    <container id="test_server_container" version="1.0">\n'
+            "        <model-evaluation/>\n"
+            "    </container>\n"
+            "</services>"
+        )
+
+        self.assertEqual(self.model_server.services_to_text, expected_result)
+
+    def test_query_profile_to_text(self):
+        expected_result = (
+            '<query-profile id="default" type="root">\n' "</query-profile>"
+        )
+        self.assertEqual(self.model_server.query_profile_to_text, expected_result)
+
+    def test_query_profile_type_to_text(self):
+        expected_result = '<query-profile-type id="root">\n' "</query-profile-type>"
+        self.assertEqual(self.model_server.query_profile_type_to_text, expected_result)


### PR DESCRIPTION
* Adapt `ApplicationPackage` to allow for simpler configurations, e.g. no schema. 
* Implement `ModelServer`, which is a simplified `ApplicationPackage` focused on stateless model evaluation.
* `ApplicationPackage` is now included on the `Vespa` instance when deploying apps with pyvespa.
  * This helps to process input/output involved when using stateless model evaluations through `app.predict`. 
* `Vespa` now has `get_model_endpoint` and `predict` to use for stateless model evaluation mode.
* Both `VespaDocker` and `VespaCloud` now work with `ModelServer` deployment to deploy stateless model evaluation apps.
* Created `SequenceClassification` task that inherits from the base class `TextTask`.


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
