### PR TITLE
Improve naming of parameters associated with stateless model evaluation

### DIFF
--- a/vespa/application.py
+++ b/vespa/application.py
@@ -741,21 +741,21 @@ class Vespa(object):
         model = app_package.get_model(model_id=model_name)
         return model
 
-    def predict(self, x, model_name, function_name="output_0"):
+    def predict(self, x, model_id, function_name="output_0"):
         """
         Obtain a stateless model evaluation.
 
         :param x: Input where the format depends on the task that the model is serving.
-        :param model_name: The name of the model used to serve the prediction.
+        :param model_id: The id of the model used to serve the prediction.
         :param function_name: The name of the output function to be evaluated.
         :return: Model prediction.
         """
-        model = self.get_model_from_application_package(model_name)
+        model = self.get_model_from_application_package(model_id)
         encoded_tokens = model.create_url_encoded_tokens(x=x)
         with VespaSync(self) as sync_app:
             return model.parse_vespa_prediction(
                 sync_app.predict(
-                    model_name=model_name,
+                    model_id=model_id,
                     function_name=function_name,
                     encoded_tokens=encoded_tokens,
                 )
@@ -819,17 +819,17 @@ class VespaSync(object):
             response = None
         return response
 
-    def predict(self, model_name, function_name, encoded_tokens):
+    def predict(self, model_id, function_name, encoded_tokens):
         """
         Obtain a stateless model evaluation.
 
-        :param model_name: The name of the model used to serve the prediction.
+        :param model_id: The id of the model used to serve the prediction.
         :param function_name: The name of the output function to be evaluated.
         :param encoded_tokens: URL-encoded input to the model
         :return: Model prediction.
         """
         end_point = "{}/model-evaluation/v1/{}/{}/eval?{}".format(
-            self.app.end_point, model_name, function_name, encoded_tokens
+            self.app.end_point, model_id, function_name, encoded_tokens
         )
         try:
             response = self.http_session.get(end_point, cert=self.app.cert)

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -150,12 +150,12 @@ class Vespa(object):
             return sync_app.get_application_status()
 
     def get_model_endpoint(
-        self, model_name: Optional[str] = None
+        self, model_id: Optional[str] = None
     ) -> Optional[Response]:
         """Get model evaluation endpoints."""
 
         with VespaSync(self) as sync_app:
-            return sync_app.get_model_endpoint(model_name=model_name)
+            return sync_app.get_model_endpoint(model_id=model_id)
 
     def _build_query_body(
         self,
@@ -804,11 +804,11 @@ class VespaSync(object):
             response = None
         return response
 
-    def get_model_endpoint(self, model_name: Optional[str] = None) -> Optional[dict]:
+    def get_model_endpoint(self, model_id: Optional[str] = None) -> Optional[dict]:
         """Get model evaluation endpoints."""
         end_point = "{}/model-evaluation/v1/".format(self.app.end_point)
-        if model_name:
-            end_point = end_point + model_name
+        if model_id:
+            end_point = end_point + model_id
         try:
             response = self.http_session.get(end_point, cert=self.app.cert)
             if response.status_code == 200:

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -738,7 +738,7 @@ class Vespa(object):
     def get_model_from_application_package(self, model_name: str):
         """Get model definition from application package, if available."""
         app_package = self.application_package
-        model = app_package.get_model(model_name=model_name)
+        model = app_package.get_model(model_id=model_name)
         return model
 
     def predict(self, x, model_name, function_name="output_0"):

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -1201,13 +1201,13 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
         for schema in schemas:
             self._schema.update({schema.name: schema})
 
-    def get_model(self, model_name: str):
+    def get_model(self, model_id: str):
         try:
-            return self.models[model_name]
+            return self.models[model_id]
         except KeyError:
             raise ValueError(
                 "Model named {} not defined in the application package.".format(
-                    model_name
+                    model_id
                 )
             )
 

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -1123,7 +1123,7 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
         stateless_model_evaluation: bool = False,
         create_schema_by_default: bool = True,
         create_query_profile_by_default: bool = True,
-        models: Optional[List[TextTask]] = None,
+        tasks: Optional[List[TextTask]] = None,
     ) -> None:
         """
         Create a Vespa Application Package.
@@ -1143,7 +1143,7 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
             is provided in the `schema` argument.
         :param create_query_profile_by_default: Include a default :class:`QueryProfile` and :class:`QueryProfileType`
             in case it is not explicitly defined by the user in the `query_profile` and `query_profile_type` parameters.
-        :param models: List of models to be used in sequence classification tasks.
+        :param tasks: List of tasks to be served.
 
         The easiest way to get started is to create a default application package:
 
@@ -1170,7 +1170,7 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
         self.model_ids = []
         self.model_configs = {}
         self.stateless_model_evaluation = stateless_model_evaluation
-        self.models = {} if not models else {model.model_id: model for model in models}
+        self.models = {} if not tasks else {model.model_id: model for model in tasks}
 
     @property
     def schemas(self) -> List[Schema]:
@@ -1503,13 +1503,15 @@ class ModelServer(ApplicationPackage):
     def __init__(
         self,
         name: str,
-        models: Optional[List[TextTask]] = None,
+        tasks: Optional[List[TextTask]] = None,
     ):
         """
         Create a Vespa stateless model evaluation server.
+
         A Vespa stateless model evaluation server is a simplified Vespa application without content clusters.
+
         :param name: Application name.
-        :param models: List of models to be used in sequence classification tasks.
+        :param tasks: List of tasks to be served.
         """
         super().__init__(
             name=name,
@@ -1519,7 +1521,7 @@ class ModelServer(ApplicationPackage):
             stateless_model_evaluation=True,
             create_schema_by_default=False,
             create_query_profile_by_default=False,
-            models=models,
+            tasks=tasks,
         )
 
     @staticmethod

--- a/vespa/test_integration_docker.py
+++ b/vespa/test_integration_docker.py
@@ -120,7 +120,7 @@ def create_qa_application_package():
 def create_sequence_classification_task():
     app_package = ModelServer(
         name="bert-model-server",
-        models=[
+        tasks=[
             SequenceClassification(
                 model_id="bert_tiny", model="google/bert_uncased_L-2_H-128_A-2"
             )
@@ -782,7 +782,7 @@ class TestApplicationCommon(unittest.TestCase):
             },
         )
         self.assertEqual(
-            app.get_model_endpoint(model_name="bert_tiny"),
+            app.get_model_endpoint(model_id="bert_tiny"),
             {
                 "status_code": 404,
                 "message": "No binding for URI '{}bert_tiny'.".format(
@@ -797,11 +797,11 @@ class TestApplicationCommon(unittest.TestCase):
             {"bert_tiny": "{}bert_tiny".format(expected_model_endpoint)},
         )
         self.assertEqual(
-            app.get_model_endpoint(model_name="bert_tiny")["model"], "bert_tiny"
+            app.get_model_endpoint(model_id="bert_tiny")["model"], "bert_tiny"
         )
 
     def get_stateless_prediction(self, app, application_package):
-        prediction = app.predict("this is a test", model_name="bert_tiny")
+        prediction = app.predict("this is a test", model_id="bert_tiny")
         expected_values = application_package.models["bert_tiny"].predict(
             "this is a test"
         )
@@ -812,7 +812,7 @@ class TestApplicationCommon(unittest.TestCase):
         with self.assertRaisesRegex(
             ValueError, "Model named bert_tiny not defined in the application package"
         ) as exc:
-            _ = app.predict("this is a test", model_name="bert_tiny")
+            _ = app.predict("this is a test", model_id="bert_tiny")
 
     @staticmethod
     def _parse_vespa_tensor(hit, feature):


### PR DESCRIPTION
* Use `tasks` instead of `models` as argument name for `ModelServer` to align with the fact this argument take instances of type `TextTask`.
* Use `model_id` instead of `model_name` to identify a model since `model_id` is what we use when defining a Task.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
