### PR TITLE
Remove ml module dependency from package module

### DIFF
--- a/vespa/ml.py
+++ b/vespa/ml.py
@@ -6,6 +6,7 @@ from urllib.parse import urlencode
 
 from vespa.package import (
     ModelConfig,
+    Task,
     OnnxModel,
     QueryTypeField,
     Field,
@@ -31,7 +32,7 @@ except ModuleNotFoundError:
     raise Exception("Use pip install pyvespa[ml] to install ml dependencies.")
 
 
-class TextTask(object):
+class TextTask(Task):
     def __init__(
         self,
         model_id: str,
@@ -47,7 +48,7 @@ class TextTask(object):
         :param tokenizer: Id of the tokenizer as used by the model hub.
         :param output_file: Output file to write output messages.
         """
-        self.model_id = model_id
+        super().__init__(model_id=model_id)
         self.model = model
         self.tokenizer = tokenizer
         if not self.tokenizer:

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -1,12 +1,12 @@
 import os
 from pathlib import Path
-from typing import List, Mapping, Optional, IO, Union, Dict
+from typing import List, Mapping, Optional, Union, Dict
 from collections import OrderedDict
 
 from jinja2 import Environment, PackageLoader, select_autoescape
 
 from vespa.json_serialization import ToJson, FromJson
-from vespa.ml import ModelConfig, BertModelConfig, TextTask
+from vespa.ml import TextTask
 
 
 class HNSW(ToJson, FromJson["HNSW"]):
@@ -1113,6 +1113,23 @@ class QueryProfile(ToJson, FromJson["QueryProfile"]):
         )
 
 
+class ModelConfig(object):
+    def __init__(self, model_id) -> None:
+        self.model_id = model_id
+
+    def onnx_model(self):
+        raise NotImplementedError
+
+    def query_profile_type_fields(self):
+        raise NotImplementedError
+
+    def document_fields(self, document_field_indexing):
+        raise NotImplementedError
+
+    def rank_profile(self, include_model_summary_features, **kwargs):
+        raise NotImplementedError
+
+
 class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
     def __init__(
         self,
@@ -1216,6 +1233,7 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
         model_config: ModelConfig,
         schema=None,
         include_model_summary_features=False,
+        document_field_indexing=None,
         **kwargs
     ) -> None:
         """
@@ -1226,6 +1244,8 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
         :param include_model_summary_features: True to include model specific summary features, such as
             inputs and outputs that are useful for debugging. Default to False as this requires an extra model
             evaluation when fetching summary features.
+        :param document_field_indexing: List of indexing attributes for the document fields required by the ranking
+            model.
         :param kwargs: Further arguments to be passed to RankProfile.
         :return: None
         """
@@ -1238,153 +1258,28 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
             raise ValueError("model_id must be unique: {}".format(model_id))
         self.model_ids.append(model_id)
         self.model_configs[model_id] = model_config
-
-        if isinstance(model_config, BertModelConfig):
-            self._add_bert_rank_profile(
-                model_config=model_config,
-                include_model_summary_features=include_model_summary_features,
-                schema=schema,
-                **kwargs
-            )
-        else:
-            raise ValueError("Unknown model configuration type")
-
-    def _add_bert_rank_profile(
-        self,
-        model_config: BertModelConfig,
-        include_model_summary_features,
-        schema=None,
-        doc_token_ids_indexing=None,
-        **kwargs
-    ) -> None:
-
-        model_id = model_config.model_id
-
         #
-        # export model
+        # Export ONNX model
         #
-        model_file_path = model_id + ".onnx"
-        model_config.export_to_onnx(output_path=model_file_path)
-
-        self.get_schema(schema).add_model(
-            OnnxModel(
-                model_name=model_id,
-                model_file_path=model_file_path,
-                inputs={
-                    "input_ids": "input_ids",
-                    "token_type_ids": "token_type_ids",
-                    "attention_mask": "attention_mask",
-                },
-                outputs={"output_0": "logits"},
-            )
-        )
-
+        self.get_schema(schema).add_model(model_config.onnx_model())
         #
-        # Add query profile type for query token ids
+        # Add query profile type fields
         #
-        self.query_profile_type.add_fields(
-            QueryTypeField(
-                name="ranking.features.query({})".format(
-                    model_config.query_token_ids_name
-                ),
-                type="tensor<float>(d0[{}])".format(
-                    int(model_config.actual_query_input_size)
-                ),
-            )
-        )
-
+        self.query_profile_type.add_fields(*model_config.query_profile_type_fields())
         #
         # Add field for doc token ids
         #
-        if not doc_token_ids_indexing:
-            doc_token_ids_indexing = ["attribute", "summary"]
         self.get_schema(schema).add_fields(
-            Field(
-                name=model_config.doc_token_ids_name,
-                type="tensor<float>(d0[{}])".format(
-                    int(model_config.actual_doc_input_size)
-                ),
-                indexing=doc_token_ids_indexing,
-            ),
+            *model_config.document_fields(
+                document_field_indexing=document_field_indexing
+            )
         )
-
         #
         # Add rank profiles
         #
-        constants = {"TOKEN_NONE": 0, "TOKEN_CLS": 101, "TOKEN_SEP": 102}
-        if "contants" in kwargs:
-            constants.update(kwargs.pop("contants"))
-
-        functions = [
-            Function(
-                name="question_length",
-                expression="sum(map(query({}), f(a)(a > 0)))".format(
-                    model_config.query_token_ids_name
-                ),
-            ),
-            Function(
-                name="doc_length",
-                expression="sum(map(attribute({}), f(a)(a > 0)))".format(
-                    model_config.doc_token_ids_name
-                ),
-            ),
-            Function(
-                name="input_ids",
-                expression="tokenInputIds({}, query({}), attribute({}))".format(
-                    model_config.input_size,
-                    model_config.query_token_ids_name,
-                    model_config.doc_token_ids_name,
-                ),
-            ),
-            Function(
-                name="attention_mask",
-                expression="tokenAttentionMask({}, query({}), attribute({}))".format(
-                    model_config.input_size,
-                    model_config.query_token_ids_name,
-                    model_config.doc_token_ids_name,
-                ),
-            ),
-            Function(
-                name="token_type_ids",
-                expression="tokenTypeIds({}, query({}), attribute({}))".format(
-                    model_config.input_size,
-                    model_config.query_token_ids_name,
-                    model_config.doc_token_ids_name,
-                ),
-            ),
-            Function(
-                name="logit0",
-                expression="onnx(" + model_id + ").logits{d0:0,d1:0}",
-            ),
-            Function(
-                name="logit1",
-                expression="onnx(" + model_id + ").logits{d0:0,d1:1}",
-            ),
-        ]
-        if "functions" in kwargs:
-            functions.extend(kwargs.pop("functions"))
-
-        summary_features = []
-        if include_model_summary_features:
-            summary_features.extend(
-                [
-                    "logit0",
-                    "logit1",
-                    "input_ids",
-                    "attention_mask",
-                    "token_type_ids",
-                ]
-            )
-        if "summary_features" in kwargs:
-            summary_features.extend(kwargs.pop("summary_features"))
-
         self.get_schema(schema).add_rank_profile(
-            RankProfile(
-                name=model_id,
-                constants=constants,
-                functions=functions,
-                summary_features=summary_features,
-                **kwargs
+            model_config.rank_profile(
+                include_model_summary_features=include_model_summary_features, **kwargs
             )
         )
 

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -6,7 +6,6 @@ from collections import OrderedDict
 from jinja2 import Environment, PackageLoader, select_autoescape
 
 from vespa.json_serialization import ToJson, FromJson
-from vespa.ml import TextTask
 
 
 class HNSW(ToJson, FromJson["HNSW"]):
@@ -1130,6 +1129,19 @@ class ModelConfig(object):
         raise NotImplementedError
 
 
+class Task(object):
+    def __init__(
+        self,
+        model_id: str,
+    ):
+        """
+        Base class for ML Tasks.
+
+        :param model_id: Id used to identify the model on Vespa applications.
+        """
+        self.model_id = model_id
+
+
 class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
     def __init__(
         self,
@@ -1140,7 +1152,7 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
         stateless_model_evaluation: bool = False,
         create_schema_by_default: bool = True,
         create_query_profile_by_default: bool = True,
-        tasks: Optional[List[TextTask]] = None,
+        tasks: Optional[List[Task]] = None,
     ) -> None:
         """
         Create a Vespa Application Package.
@@ -1398,7 +1410,7 @@ class ModelServer(ApplicationPackage):
     def __init__(
         self,
         name: str,
-        tasks: Optional[List[TextTask]] = None,
+        tasks: Optional[List[Task]] = None,
     ):
         """
         Create a Vespa stateless model evaluation server.


### PR DESCRIPTION
This PR removes `vespa.package` module dependency on the `vespa.ml` module. The main goal is to avoid installing `vespa.ml` specific dependencies through `pip install pyvespa[ml]` unless the user explicitly wants to use `vespa.ml` classes.


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
