### PR TITLE
Infer schema name whenever possible for batch document operations

### DIFF
--- a/vespa/application.py
+++ b/vespa/application.py
@@ -278,9 +278,13 @@ class Vespa(object):
         :param total_timeout: Total timeout in secs for each of the concurrent requests when using `asynchronous=True`.
         :return: List of HTTP POST responses
         """
-
         if not schema:
-            schema = self._infer_schema_name()
+            try:
+                schema = self._infer_schema_name()
+            except ValueError:
+                raise ValueError(
+                    "Not possible to infer schema name. Specify schema parameter."
+                )
 
         if asynchronous:
             coro = self._feed_batch_async(
@@ -334,6 +338,14 @@ class Vespa(object):
         :param total_timeout: Total timeout in secs for each of the concurrent requests when using `asynchronous=True`.
         :return: List of HTTP POST responses
         """
+        if not schema:
+            try:
+                schema = self._infer_schema_name()
+            except ValueError:
+                raise ValueError(
+                    "Not possible to infer schema name. Specify schema parameter."
+                )
+
         if asynchronous:
             coro = self._delete_batch_async(
                 schema=schema,
@@ -399,6 +411,14 @@ class Vespa(object):
         :param total_timeout: Total timeout in secs for each of the concurrent requests when using `asynchronous=True`.
         :return: List of HTTP POST responses
         """
+        if not schema:
+            try:
+                schema = self._infer_schema_name()
+            except ValueError:
+                raise ValueError(
+                    "Not possible to infer schema name. Specify schema parameter."
+                )
+
         if asynchronous:
             coro = self._get_batch_async(
                 schema=schema,
@@ -465,6 +485,14 @@ class Vespa(object):
         :param total_timeout: Total timeout in secs for each of the concurrent requests when using `asynchronous=True`.
         :return: List of HTTP POST responses
         """
+        if not schema:
+            try:
+                schema = self._infer_schema_name()
+            except ValueError:
+                raise ValueError(
+                    "Not possible to infer schema name. Specify schema parameter."
+                )
+
         if asynchronous:
             coro = self._update_batch_async(
                 schema=schema,

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -140,6 +140,26 @@ class Vespa(object):
         else:
             return "Vespa({})".format(self.url)
 
+    def _infer_schema_name(self):
+        if not self._application_package:
+            raise ValueError(
+                "Application Package not available. Not possible to infer schema name."
+            )
+
+        try:
+            schema = self._application_package.schema
+        except AssertionError:
+            raise ValueError(
+                "Application has more than one schema. Not possible to infer schema name."
+            )
+
+        if not schema:
+            raise ValueError(
+                "Application has no schema. Not possible to infer schema name."
+            )
+
+        return schema.name
+
     def get_application_status(self) -> Optional[Response]:
         """
         Get application status.
@@ -258,6 +278,9 @@ class Vespa(object):
         :param total_timeout: Total timeout in secs for each of the concurrent requests when using `asynchronous=True`.
         :return: List of HTTP POST responses
         """
+
+        if not schema:
+            schema = self._infer_schema_name()
 
         if asynchronous:
             coro = self._feed_batch_async(

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -149,9 +149,7 @@ class Vespa(object):
         with VespaSync(self) as sync_app:
             return sync_app.get_application_status()
 
-    def get_model_endpoint(
-        self, model_id: Optional[str] = None
-    ) -> Optional[Response]:
+    def get_model_endpoint(self, model_id: Optional[str] = None) -> Optional[Response]:
         """Get model evaluation endpoints."""
 
         with VespaSync(self) as sync_app:
@@ -243,8 +241,8 @@ class Vespa(object):
 
     def feed_batch(
         self,
-        schema: str,
         batch: List[Dict],
+        schema: Optional[str] = None,
         asynchronous=True,
         connections: Optional[int] = 100,
         total_timeout: int = 100,
@@ -252,8 +250,9 @@ class Vespa(object):
         """
         Feed a batch of data to a Vespa app.
 
-        :param schema: The schema that we are sending data to.
         :param batch: A list of dict containing the keys 'id' and 'fields' to be used in the :func:`feed_data_point`.
+        :param schema: The schema that we are sending data to. The schema is optional in case it is possible to infer
+            the schema from the application package.
         :param asynchronous: Set True to send data in async mode. Default to True.
         :param connections: Number of allowed concurrent connections, valid only if `asynchronous=True`.
         :param total_timeout: Total timeout in secs for each of the concurrent requests when using `asynchronous=True`.
@@ -295,8 +294,8 @@ class Vespa(object):
 
     def delete_batch(
         self,
-        schema: str,
         batch: List[Dict],
+        schema: Optional[str] = None,
         asynchronous=True,
         connections: Optional[int] = 100,
         total_timeout: int = 100,
@@ -304,8 +303,9 @@ class Vespa(object):
         """
         Delete a batch of data from a Vespa app.
 
-        :param schema: The schema that we are deleting data from.
         :param batch: A list of dict containing the key 'id'.
+        :param schema: The schema that we are deleting data from. The schema is optional in case it is possible to infer
+            the schema from the application package.
         :param asynchronous: Set True to get data in async mode. Default to True.
         :param connections: Number of allowed concurrent connections, valid only if `asynchronous=True`.
         :param total_timeout: Total timeout in secs for each of the concurrent requests when using `asynchronous=True`.
@@ -359,8 +359,8 @@ class Vespa(object):
 
     def get_batch(
         self,
-        schema: str,
         batch: List[Dict],
+        schema: Optional[str] = None,
         asynchronous=True,
         connections: Optional[int] = 100,
         total_timeout: int = 100,
@@ -368,8 +368,9 @@ class Vespa(object):
         """
         Get a batch of data from a Vespa app.
 
-        :param schema: The schema that we are getting data from.
         :param batch: A list of dict containing the key 'id'.
+        :param schema: The schema that we are getting data from. The schema is optional in case it is possible to infer
+            the schema from the application package.
         :param asynchronous: Set True to get data in async mode. Default to True.
         :param connections: Number of allowed concurrent connections, valid only if `asynchronous=True`.
         :param total_timeout: Total timeout in secs for each of the concurrent requests when using `asynchronous=True`.
@@ -424,8 +425,8 @@ class Vespa(object):
 
     def update_batch(
         self,
-        schema: str,
         batch: List[Dict],
+        schema: Optional[str] = None,
         asynchronous=True,
         connections: Optional[int] = 100,
         total_timeout: int = 100,
@@ -433,8 +434,9 @@ class Vespa(object):
         """
         Update a batch of data in a Vespa app.
 
-        :param schema: The schema that we are getting data from.
         :param batch: A list of dict containing the keys 'id', 'fields' and 'create' (create defaults to False).
+        :param schema: The schema that we are updating data to. The schema is optional in case it is possible to infer
+            the schema from the application package.
         :param asynchronous: Set True to update data in async mode. Default to True.
         :param connections: Number of allowed concurrent connections, valid only if `asynchronous=True`.
         :param total_timeout: Total timeout in secs for each of the concurrent requests when using `asynchronous=True`.

--- a/vespa/test_integration_vespa_cloud.py
+++ b/vespa/test_integration_vespa_cloud.py
@@ -93,6 +93,15 @@ class TestMsmarcoApplication(TestApplicationCommon):
             fields_to_update=self.fields_to_update,
         )
 
+    def test_batch_operations_default_mode_with_one_schema(self):
+        self.batch_operations_default_mode_with_one_schema(
+            app=self.app,
+            schema_name=self.app_package.name,
+            fields_to_send=self.fields_to_send,
+            expected_fields_from_get_operation=self.fields_to_send,
+            fields_to_update=self.fields_to_update,
+        )
+
     def tearDown(self) -> None:
         self.app.delete_all_docs(
             content_cluster_name="msmarco_content", schema="msmarco"
@@ -200,6 +209,15 @@ class TestCord19Application(TestApplicationCommon):
 
     def test_batch_operations_asynchronous_mode(self):
         self.batch_operations_asynchronous_mode(
+            app=self.app,
+            schema_name=self.app_package.name,
+            fields_to_send=self.fields_to_send,
+            expected_fields_from_get_operation=self.expected_fields_from_get_operation,
+            fields_to_update=self.fields_to_update,
+        )
+
+    def test_batch_operations_default_mode_with_one_schema(self):
+        self.batch_operations_default_mode_with_one_schema(
             app=self.app,
             schema_name=self.app_package.name,
             fields_to_send=self.fields_to_send,


### PR DESCRIPTION
When we have application package information containing just one schema, it is possible to simplify the batch document operations by not specifying the schema name. For those cases, we can for example use `app.feed_batch(docs)` instead of `app.feed_batch(docs, schema = "sentence")` when we know there is only one schema named "sentence".





I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
