### PR TITLE
CentOS 8 is EOL and mirrors are dissapearing. Switch to CentOS Stream 8.

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-  image: docker.io/centos:8
+  image: quay.io/centos/centos:stream8
   environment:
     PYVESPA_VERSION: 0.7
 jobs:


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
