### PR TITLE
Use Vespa CLI for keys

### DIFF
--- a/docs/sphinx/source/deploy-vespa-cloud.ipynb
+++ b/docs/sphinx/source/deploy-vespa-cloud.ipynb
@@ -6,7 +6,11 @@
    "source": [
     "# Deploy to Vespa Cloud\n",
     "\n",
-    "> How to host your Vespa application in the cloud\n",
+    "![Vespa Cloud logo](https://cloud.vespa.ai/assets/logos/vespa-cloud-logo-full-black.png)\n",
+    "\n",
+    "This notebook deploys a Vespa.ai sample application to Vespa Cloud.\n",
+    "\n",
+    "Refer to the [sample apps](https://github.com/vespa-engine/sample-apps) site for more applications.\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vespa-engine/pyvespa/blob/master/docs/sphinx/source/deploy-vespa-cloud.ipynb)"
    ]
@@ -15,7 +19,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Install pyvespa"
+    "## Install pyvespa and the Vespa CLI"
    ]
   },
   {
@@ -24,55 +28,102 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install pyvespa"
+    "!pip install pyvespa\n",
+    "!brew install vespa-cli"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Define your application package"
+    "## Create a Vespa Cloud tenant"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This tutorial assumes that a [Vespa application package](https://pyvespa.readthedocs.io/en/latest/create-text-app.html) was defined and stored in the variable `app_package`. To illustrate this tutorial, we will use a basic question answering app from our gallery."
+    "Sign up and create a tenant: Run steps 1 and 2 in [getting started](https://cloud.vespa.ai/en/getting-started), then enter the tenant name used:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "tenant_name = input(\"Tenant name: \")\n",
+    "os.environ[\"TENANT_NAME\"] = tenant_name"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up security credentials"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!vespa config set target cloud\n",
+    "!vespa config set application $TENANT_NAME.myapp.default\n",
+    "!vespa auth cert -N\n",
+    "!vespa auth api-key"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set API key location. The `vespa` command stores the credentials in ~/.vespa, like:\n",
+    "\n",
+    "      /Users/me/.vespa/mytenant.api-key.pem\n",
+    "      /Users/me/.vespa/mytenant.myapp.default/data-plane-public-cert.pem\n",
+    "      /Users/me/.vespa/mytenant.myapp.default/data-plane-private-key.pem\n",
+    "\n",
+    "Enter full path to the api key (like `/Users/me/.vespa/mytenant.api-key.pem`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api_key_path = input(\"API key path: \")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create an application package"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "An [application package](https://pyvespa.readthedocs.io/en/latest/create-text-app.html)\n",
+    "is the application's configuration, like schema.\n",
+    "Here, using a basic question answering app from the app gallery."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "from vespa.gallery import QuestionAnswering\n",
     "\n",
-    "app_package = QuestionAnswering()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Setup your Vespa Cloud account"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "1. Sign-in or sign-up:\n",
-    "  * To deploy `app_package` on Vespa Cloud, you need to [login into your account](https://cloud.vespa.ai/) first. You can create one and give it a try for free.\n",
-    "2. Choose a tenant:\n",
-    "  *  You either create a new tenant or use an existing one. That will be the `TENANT_NAME` env variable in the example below. \n",
-    "3. Get your user key:\n",
-    "  * Once you are on your chosen tenant dashboard, you can generate and download a user key under the key tab. Set the `USER_KEY` env variable to be the path to the downloaded user key. \n",
-    "4. Create a new application under your tenant\n",
-    "  * Within the tenant dashboard, you can also create a new application associated with that tenant and set the `APPLICATION_NAME` env variable below to the name of the application. \n",
-    "  \n",
-    "That is all that needs to be setup on the Vespa Cloud dashboard before deployment."
+    "app = QuestionAnswering()"
    ]
   },
   {
@@ -84,36 +135,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "nbsphinx": "hidden"
-   },
-   "outputs": [],
-   "source": [
-    "# this is a hidden cell, not shown on the final html\n",
-    "import os\n",
-    "\n",
-    "os.environ[\"TENANT_NAME\"] = \"vespa-team\"\n",
-    "os.environ[\"APPLICATION_NAME\"] = \"pyvespa-integration\"\n",
-    "with open(os.path.join(os.getenv(\"WORK_DIR\"), \"key.pem\"), \"w\") as f:\n",
-    "    f.write(os.getenv(\"VESPA_CLOUD_USER_KEY\").replace(r\"\\n\", \"\\n\"))\n",
-    "os.environ[\"USER_KEY\"] = os.path.join(os.getenv(\"WORK_DIR\"), \"key.pem\")\n",
-    "os.environ[\"INSTANCE_NAME\"] = \"test\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "from vespa.deployment import VespaCloud\n",
     "\n",
+    "api_key_path = \"~/.vespa/\" + tenant_name + \".api-key.pem\"\n",
     "vespa_cloud = VespaCloud(\n",
-    "    tenant=os.getenv(\"TENANT_NAME\"),\n",
-    "    application=os.getenv(\"APPLICATION_NAME\"),\n",
-    "    key_location=os.getenv(\"USER_KEY\"),\n",
-    "    application_package=app_package,\n",
+    "    tenant=tenant_name,\n",
+    "    application=\"myapp\",\n",
+    "    key_location=api_key_path,\n",
+    "    application_package=app,\n",
     ")"
    ]
   },
@@ -121,14 +154,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Deploy to the Cloud"
+    "## Deploy to Vespa Cloud"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can have multiple instances of the same application, we can then chose a valid `INSTANCE_NAME` to identify the instance created here and set the `DISK_FOLDER` to a local path to hold deployment related files such as certifications and Vespa config files."
+    "Refer to [tenants, applications and instances](https://cloud.vespa.ai/en/tenant-apps-instances) for details - here creating an instance named `default`:"
    ]
   },
   {
@@ -138,8 +171,7 @@
    "outputs": [],
    "source": [
     "app = vespa_cloud.deploy(\n",
-    "    instance=os.getenv(\"INSTANCE_NAME\")\n",
-    ")"
+    "    instance=\"default\")"
    ]
   },
   {
@@ -152,7 +184,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -166,7 +198,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- or @jobergum please merge
- this could be even easier if pyvespa supported ~ in the path ( os.path.expanduser('~') ) - the we could be default look after the api key as we know the tenant name
- next step is to make work in colab for the vespa cli install + add a few more steps to feed data / queries