### PR TITLE
Ignore notebook error in link check

### DIFF
--- a/docs/sphinx/source/deploy-vespa-cloud.ipynb
+++ b/docs/sphinx/source/deploy-vespa-cloud.ipynb
@@ -43,7 +43,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Sign up and create a tenant: Run steps 1 and 2 in [getting started](https://cloud.vespa.ai/en/getting-started), then enter the tenant name used:"
+    "Sign up and create a tenant: Run steps 1 and 2 in [getting started](https://cloud.vespa.ai/en/getting-startedd), then enter the tenant name used:"
    ]
   },
   {

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -23,7 +23,7 @@ jobs:
           python3 -m pip install -r docs/sphinx/source/requirements.txt
           python3 -m pip install -r docs/sphinx/source/notebook_requirements.txt
       - run-doc-linkcheck: |
-          sphinx-build -E -b linkcheck docs/sphinx/source docs/sphinx/build
+          sphinx-build -E -D nbsphinx_allow_errors=True -b linkcheck docs/sphinx/source docs/sphinx/build
           sphinx-build -E docs/sphinx/source docs/sphinx/build
           rm -fr docs/sphinx/build
       - run-doc-tests: |


### PR DESCRIPTION
- also temporarily injecting a broken link to validate that the check still works as intended - will revert that in next PR
- Fixes "StdinNotImplementedError: raw_input was called, but this frontend does not support input requests."

@jobergum 