### PR TITLE
Clean up reference

### DIFF
--- a/docs/sphinx/source/reference-api.rst
+++ b/docs/sphinx/source/reference-api.rst
@@ -1,349 +1,191 @@
 Reference API
 =============
 
-Define stateful application
-***************************
-
-Create an Application Package
------------------------------
-
-The first step to create a Vespa application is to create an instance of :class:`ApplicationPackage`.
 
 ApplicationPackage
-++++++++++++++++++
-
+******************
 .. autoclass:: vespa.package.ApplicationPackage
    :members:
    :special-members: __init__
 
-Schema and Document
--------------------
-
-An :class:`ApplicationPackage` instance comes with a default :class:`Schema` that contains a default :class:`Document`,
-meaning that you usually do not need to create those yourself.
 
 Schema
-++++++
-
+******
 .. autoclass:: vespa.package.Schema
    :members:
    :special-members: __init__
 
-Document
-++++++++
 
+Document
+********
 .. autoclass:: vespa.package.Document
    :members:
    :special-members: __init__
 
+
 Field
-+++++
-
-Once we have an :class:`ApplicationPackage` instance containing a :class:`Schema` and a :class:`Document` we usually
-want to add fields so that we can store our data in a structured manner. We can accomplish that by creating
-:class:`Field` instances and adding those to the :class:`ApplicationPackage` instance via :class:`Schema` and
-:class:`Document` methods.
-
+*****
 .. autoclass:: vespa.package.Field
    :members:
    :special-members: __init__
 
-FieldSet
-++++++++
 
+FieldSet
+********
 .. autoclass:: vespa.package.FieldSet
    :members:
    :special-members: __init__
 
-RankProfile
-+++++++++++
 
+RankProfile
+***********
 .. autoclass:: vespa.package.RankProfile
    :members:
    :special-members: __init__
 
-Query Profile
--------------
-
-A :class:`QueryProfile` is a named collection of search request parameters given in the configuration. The search
-request can specify a query profile whose parameters will be used as parameters of that request. The query profiles may
-optionally be type checked. Type checking is turned on by referencing a :class:`QueryProfileType` from the query
-profile.
-
-An :class:`ApplicationPackage` instance comes with a default :class:`QueryProfile` named `default` that is associated
-with a :class:`QueryProfileType` named `root`, meaning that you usually do not need to create those yourself, only add
-fields to them when required.
-
-Create a QueryProfileType
-+++++++++++++++++++++++++
-
-QueryTypeField
-~~~~~~~~~~~~~~
-
-.. autoclass:: vespa.package.QueryTypeField
-   :members:
-   :special-members: __init__
-
-QueryProfileType
-~~~~~~~~~~~~~~~~
-
-.. autoclass:: vespa.package.QueryProfileType
-   :members:
-   :special-members: __init__
-
-Create a QueryProfile
-+++++++++++++++++++++
-
-QueryField
-~~~~~~~~~~
-
-.. autoclass:: vespa.package.QueryField
-   :members:
-   :special-members: __init__
 
 QueryProfile
-~~~~~~~~~~~~
-
+************
 .. autoclass:: vespa.package.QueryProfile
    :members:
    :special-members: __init__
 
-Define stateless application
-****************************
 
-Create tasks
-------------
+QueryField
+**********
+.. autoclass:: vespa.package.QueryField
+   :members:
+   :special-members: __init__
+
+
+QueryProfileType
+****************
+.. autoclass:: vespa.package.QueryProfileType
+   :members:
+   :special-members: __init__
+
+
+QueryTypeField
+**************
+.. autoclass:: vespa.package.QueryTypeField
+   :members:
+   :special-members: __init__
+
 
 SequenceClassification
-++++++++++++++++++++++
-
+**********************
 .. autoclass:: vespa.ml.SequenceClassification
    :members:
    :special-members: __init__
 
-Create model server
--------------------
 
 ModelServer
-+++++++++++
-
+***********
 .. autoclass:: vespa.package.ModelServer
    :members:
    :special-members: __init__
 
-Deploy your application
-***********************
-
-Deploy your stateful or stateless applications.
 
 VespaDocker
------------
-
+***********
 .. autoclass:: vespa.deployment.VespaDocker
    :members:
    :special-members: __init__
 
-VespaCloud
-----------
 
+VespaCloud
+**********
 .. autoclass:: vespa.deployment.VespaCloud
    :members:
    :special-members: __init__
 
-Connect to existing application
-*******************************
 
 Vespa
------
-
+*****
 .. autoclass:: vespa.application.Vespa
+   :members:
    :special-members: __init__
 
-Interact to existing application
-********************************
 
-Feed data
----------
-
-feed_batch
-++++++++++
-
-.. automethod:: vespa.application.Vespa.feed_batch
-
-feed_data_point
-+++++++++++++++
-
-.. automethod:: vespa.application.Vespa.feed_data_point
-
-Get, update and delete data
----------------------------
-
-get_data
-++++++++
-
-.. automethod:: vespa.application.Vespa.get_data
-
-get_batch
-+++++++++
-
-.. automethod:: vespa.application.Vespa.get_batch
-
-update_data
-+++++++++++
-
-.. automethod:: vespa.application.Vespa.update_data
-
-update_batch
-++++++++++++
-
-.. automethod:: vespa.application.Vespa.update_batch
-
-delete_data
-+++++++++++
-
-.. automethod:: vespa.application.Vespa.delete_data
-
-delete_batch
-++++++++++++
-
-.. automethod:: vespa.application.Vespa.delete_batch
-
-delete_all_docs
-+++++++++++++++
-
-.. automethod:: vespa.application.Vespa.delete_all_docs
-
-Query
------
-
-.. automethod:: vespa.application.Vespa.query
-
-Run experiments
----------------
-
-evaluate
-++++++++
-
-.. automethod:: vespa.application.Vespa.evaluate
-
-evaluate_query
-++++++++++++++
-
-.. automethod:: vespa.application.Vespa.evaluate_query
-
-Collect training data
----------------------
-
-collect_training_data
-+++++++++++++++++++++
-
-.. automethod:: vespa.application.Vespa.collect_training_data
-
-collect_training_data_point
-+++++++++++++++++++++++++++
-
-.. automethod:: vespa.application.Vespa.collect_training_data_point
-
-Query Model
+QueryModel
 ***********
-
-A :class:`~vespa.query.QueryModel` is an abstraction that encapsulates all the relevant information controlling
-how your app match and rank documents. A `QueryModel` can be used for querying (:func:`~vespa.application.Vespa.query`),
-evaluating (:func:`~vespa.application.Vespa.evaluate`) and collecting data
-(:func:`~vespa.application.Vespa.collect_training_data`) from your app.
-
-Create a QueryModel
--------------------
-
 .. autoclass:: vespa.query.QueryModel
    :members:
    :special-members: __init__
 
-Match phase
------------
 
 Union
-+++++
-
+*****
 .. autoclass:: vespa.query.Union
    :members:
    :special-members: __init__
 
-AND
-+++
 
+AND
+***
 .. autoclass:: vespa.query.AND
    :members:
    :special-members: __init__
 
-OR
-++
 
+OR
+**
 .. autoclass:: vespa.query.OR
    :members:
    :special-members: __init__
 
-WeakAnd
-+++++++
 
+WeakAnd
+*******
 .. autoclass:: vespa.query.WeakAnd
    :members:
    :special-members: __init__
 
-ANN
-+++
 
+ANN
+***
 .. autoclass:: vespa.query.ANN
    :members:
    :special-members: __init__
 
-Rank Profile
-------------
 
 RankProfile
-+++++++++++
-
+***********
 .. autoclass:: vespa.query.RankProfile
    :members:
    :special-members: __init__
 
-Query Properties
-----------------
 
 QueryRankingFeature
-+++++++++++++++++++
-
+*******************
 .. autoclass:: vespa.query.QueryRankingFeature
    :members:
    :special-members: __init__
 
-Evaluation Metrics
-******************
 
 MatchRatio
-----------
-
+**********
 .. autoclass:: vespa.evaluation.MatchRatio
    :members:
    :special-members: __init__
 
-Recall
-------
 
+Recall
+******
 .. autoclass:: vespa.evaluation.Recall
    :members:
    :special-members: __init__
 
-ReciprocalRank
---------------
 
+ReciprocalRank
+**************
 .. autoclass:: vespa.evaluation.ReciprocalRank
    :members:
    :special-members: __init__
 
-NormalizedDiscountedCumulativeGain
-----------------------------------
 
+NormalizedDiscountedCumulativeGain
+**********************************
 .. autoclass:: vespa.evaluation.NormalizedDiscountedCumulativeGain
    :members:
    :special-members: __init__

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -96,7 +96,7 @@ class Vespa(object):
         application_package: Optional[ApplicationPackage] = None,
     ) -> None:
         """
-        Establish a connection with a Vespa application.
+        Establish a connection with an existing Vespa application.
 
         :param url: Vespa instance URL.
         :param port: Vespa instance port.

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -81,6 +81,11 @@ class Field(ToJson, FromJson["Field"]):
         Check the `Vespa documentation <https://docs.vespa.ai/documentation/reference/schema-reference.html#field>`__
         for more detailed information about fields.
 
+        Once we have an :class:`ApplicationPackage` instance containing a :class:`Schema` and a :class:`Document`,
+        we usually want to add fields so that we can store our data in a structured manner.
+        We can accomplish that by creating :class:`Field` instances
+        and adding those to the :class:`ApplicationPackage` instance via :class:`Schema` and :class:`Document` methods.
+
         :param name: Field name.
         :param type: Field data type.
         :param indexing: Configures how to process data of a field during indexing.
@@ -963,6 +968,10 @@ class QueryProfileType(ToJson, FromJson["QueryProfileType"]):
         Check the `Vespa documentation <https://docs.vespa.ai/documentation/query-profiles.html#query-profile-types>`__
         for more detailed information about query profile types.
 
+        An :class:`ApplicationPackage` instance comes with a default :class:`QueryProfile` named `default`
+        that is associated with a :class:`QueryProfileType` named `root`,
+        meaning that you usually do not need to create those yourself, only add fields to them when required.
+
         :param fields: A list of :class:`QueryTypeField`.
 
         >>> QueryProfileType(
@@ -1071,6 +1080,11 @@ class QueryProfile(ToJson, FromJson["QueryProfile"]):
         Check the `Vespa documentation <https://docs.vespa.ai/documentation/query-profiles.html>`__
         for more detailed information about query profiles.
 
+        A :class:`QueryProfile` is a named collection of query request parameters given in the configuration.
+        The query request can specify a query profile whose parameters will be used as parameters of that request.
+        The query profiles may optionally be type checked.
+        Type checking is turned on by referencing a :class:`QueryProfileType` from the query profile.
+
         :param fields: A list of :class:`QueryField`.
 
         >>> QueryProfile(fields=[QueryField(name="maxHits", value=1000)])
@@ -1161,6 +1175,9 @@ class ApplicationPackage(ToJson, FromJson["ApplicationPackage"]):
 
         Check the `Vespa documentation <https://docs.vespa.ai/documentation/cloudconfig/application-packages.html>`__
         for more detailed information about application packages.
+
+        An :class:`ApplicationPackage` instance comes with a default :class:`Schema`
+        that contains a default :class:`Document`
 
         :param name: Application name.
         :param schema: List of :class:`Schema`s of the application. If `None`, an empty :class:`Schema` with the same name of the

--- a/vespa/query.py
+++ b/vespa/query.py
@@ -213,6 +213,12 @@ class QueryModel(object):
         """
         Define a query model.
 
+        A :class:`~vespa.query.QueryModel` is an abstraction that encapsulates all the relevant information
+        controlling how an app matches and ranks documents.
+        A `QueryModel` can be used for querying (:func:`~vespa.application.Vespa.query`),
+        evaluating (:func:`~vespa.application.Vespa.evaluate`) and collecting data
+        (:func:`~vespa.application.Vespa.collect_training_data`) from an app.
+
         :param name: Name of the query model. Used to tag model related quantities, like evaluation metrics.
         :param query_properties: Optional list of QueryProperty.
         :param match_phase: Define the match criteria. One of the MatchFilter options available.


### PR DESCRIPTION
- This PR moves the text from the .rst overview file to the python classes themselves, more or less unchanged
- It also removes some structure - this is OK as a reference doc is used for _lookups_ from other guides/notebooks/doc. It also makes the look and feel cleaner with only one level of headings. We should link into the reference to a higher degree than we do now, and iterate on the docstrings of the classes
- The structure lost is however useful information - it is about how to use pyvespa. This will be added to the index/overview pages in the next PR, as this is good intro info
