### PR TITLE
Remove redundant, link to same content

### DIFF
--- a/docs/sphinx/source/overview.ipynb
+++ b/docs/sphinx/source/overview.ipynb
@@ -33,120 +33,8 @@
    "id": "twelve-optimum",
    "metadata": {},
    "source": [
-    "Build a Vespa application from scratch - example:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "spiritual-brooklyn",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from vespa.package import ApplicationPackage, Field, RankProfile\n",
-    "\n",
-    "app_package = ApplicationPackage(name = \"sampleapp\")\n",
-    "app_package.schema.add_fields(\n",
-    "    Field(\n",
-    "        name=\"title\", \n",
-    "        type=\"string\", \n",
-    "        indexing=[\"index\", \"summary\"], \n",
-    "        index=\"enable-bm25\")\n",
-    ")\n",
-    "app_package.schema.add_rank_profile(\n",
-    "    RankProfile(\n",
-    "        name=\"bm25\", \n",
-    "        inherits=\"default\", \n",
-    "        first_phase=\"bm25(title)\"\n",
-    "    )\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "personalized-mercury",
-   "metadata": {},
-   "source": [
-    "Deploy `app_package` to a Docker container (or directly to [VespaCloud](https://pyvespa.readthedocs.io/en/latest/deploy-vespa-cloud.html)):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "twelve-installation",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Waiting for configuration server.\n",
-      "Waiting for configuration server.\n",
-      "Waiting for configuration server.\n",
-      "Waiting for configuration server.\n",
-      "Waiting for configuration server.\n",
-      "Waiting for application status.\n",
-      "Waiting for application status.\n",
-      "Finished deployment.\n"
-     ]
-    }
-   ],
-   "source": [
-    "import os\n",
-    "from vespa.deployment import VespaDocker\n",
-    "\n",
-    "vespa_docker = VespaDocker(port=8089)\n",
-    "app = vespa_docker.deploy(application_package=app_package)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "regulated-capability",
-   "metadata": {},
-   "source": [
-    "`app` holds an instance of the Vespa class, and can be used to feed and query the application just deployed.\n",
-    "\n",
-    "The generated Vespa configuration files are stored in the `disk_folder`, modify them and deploy them directly from the disk using the method discussed below. This can be useful when fine-tuning the application, possibly using Vespa features not available in the `pyvespa` API (pyvespa exposes a subset of the features)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "severe-patient",
-   "metadata": {},
-   "source": [
-    "There is also the possibility to explicitly export `app_package` to Vespa configuration files (without deploying them) using `export_application_package`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "skilled-sequence",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "vespa_docker.export_application_package(application_package=app_package)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "incident-choir",
-   "metadata": {},
-   "source": [
-    "Stop the Docker container and remove the generated application package:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "nearby-venice",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from shutil import rmtree\n",
-    "\n",
-    "rmtree(os.path.join(os.getcwd(), app_package.name), ignore_errors=True)\n",
-    "vespa_docker.container.stop()\n",
-    "vespa_docker.container.remove()"
+    "The [getting-started](https://pyvespa.readthedocs.io/en/latest/getting-started-pyvespa.html) notebook\n",
+    "is a good primer on how to create an application, feed data and run queries."
    ]
   },
   {
@@ -162,59 +50,10 @@
    "id": "upset-eligibility",
    "metadata": {},
    "source": [
-    "When a Vespa application is already running, one can instantiate the [Vespa](https://pyvespa.readthedocs.io/en/latest/reference-api.html#vespa.application.Vespa) class with the endpoint. The example below connects to the [cord19.vespa.ai](https://cord19.vespa.ai/) application:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "described-dance",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from vespa.application import Vespa\n",
+    "When a Vespa application is already running, one can instantiate the [Vespa](https://pyvespa.readthedocs.io/en/latest/reference-api.html#vespa.application.Vespa) class with the endpoint.\n",
     "\n",
-    "app = Vespa(url = \"https://api.cord19.vespa.ai\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "agricultural-bridges",
-   "metadata": {},
-   "source": [
-    "Query the application:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "endangered-given",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[{'id': 'index:content/2/ad8f0a6204288c0d497399a2',\n",
-       "  'relevance': 0.36940216922720703,\n",
-       "  'source': 'content',\n",
-       "  'fields': {'title': '<hi>Temperature</hi> <hi>Sensitivity</hi>: A Potential Method for the Generation of Vaccines against the Avian <hi>Coronavirus</hi> Infectious Bronchitis Virus'}}]"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "app.query(body = {\n",
-    "  'yql': 'select title from sources * where userQuery()',\n",
-    "  'hits': 1,\n",
-    "  'summary': 'short',\n",
-    "  'timeout': '1.0s',\n",
-    "  'query': 'coronavirus temperature sensitivity',\n",
-    "  'type': 'all',\n",
-    "  'ranking': 'default'\n",
-    "}).hits"
+    "Refer to [connect-to-vespa-instance](https://pyvespa.readthedocs.io/en/latest/connect-to-vespa-instance.html)\n",
+    "to connect to and application and run queries."
    ]
   },
   {


### PR DESCRIPTION
- ... or @jobergum 
- The _overview_ notebook now only has the step to init pyvespa from an existing app package. This is a great guide, so will rename this notebook in next PR to exactly that, and move the rest of the content to the index page.