### PR TITLE
remove underscore

### DIFF
--- a/docs/sphinx/source/use_cases/sequence-classification-task.ipynb
+++ b/docs/sphinx/source/use_cases/sequence-classification-task.ipynb
@@ -55,7 +55,7 @@
     "from vespa.package import ModelServer\n",
     "\n",
     "model_server = ModelServer(\n",
-    "    name=\"bert_model_server\",\n",
+    "    name=\"bertModelServer\",\n",
     "    tasks=[task],\n",
     ")"
    ]


### PR DESCRIPTION
- this will map to a hostname in the Docker run command, and _ is not allowed in hostnames
- we should put validation in pyvespa code for this
