### PR TITLE
Fix name

### DIFF
--- a/vespa/test_integration_docker.py
+++ b/vespa/test_integration_docker.py
@@ -121,7 +121,7 @@ def create_qa_application_package():
 
 def create_sequence_classification_task():
     app_package = ModelServer(
-        name="bert-model-server",
+        name="bertModelServer",
         tasks=[
             SequenceClassification(
                 model_id="bert_tiny", model="google/bert_uncased_L-2_H-128_A-2"


### PR DESCRIPTION
From test: 
```
ValueError: Application package name can only contain [a-zA-Z0-9], was 'bert-model-server'
```