### PR TITLE
Kkraune/misc

### DIFF
--- a/vespa/templates/hosts.xml
+++ b/vespa/templates/hosts.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<!-- Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
 <hosts>
     <host name="localhost">
         <alias>node1</alias>

--- a/vespa/test_integration_docker.py
+++ b/vespa/test_integration_docker.py
@@ -121,7 +121,7 @@ def create_qa_application_package():
 
 def create_sequence_classification_task():
     app_package = ModelServer(
-        name="bertModelServer",
+        name="bertmodelserver",
         tasks=[
             SequenceClassification(
                 model_id="bert_tiny", model="google/bert_uncased_L-2_H-128_A-2"

--- a/vespa/test_package.py
+++ b/vespa/test_package.py
@@ -743,7 +743,7 @@ class TestApplicationPackage(unittest.TestCase):
     def test_hosts_to_text(self):
         expected_result = (
             '<?xml version="1.0" encoding="utf-8" ?>\n'
-            "<!-- Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->\n"
+            "<!-- Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->\n"
             "<hosts>\n"
             '    <host name="localhost">\n'
             "        <alias>node1</alias>\n"
@@ -1076,7 +1076,7 @@ class TestApplicationPackageAddBertRankingWithMultipleSchemas(unittest.TestCase)
     def test_hosts_to_text(self):
         expected_result = (
             '<?xml version="1.0" encoding="utf-8" ?>\n'
-            "<!-- Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->\n"
+            "<!-- Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->\n"
             "<hosts>\n"
             '    <host name="localhost">\n'
             "        <alias>node1</alias>\n"
@@ -1242,7 +1242,7 @@ class TestSimplifiedApplicationPackage(unittest.TestCase):
     def test_hosts_to_text(self):
         expected_result = (
             '<?xml version="1.0" encoding="utf-8" ?>\n'
-            "<!-- Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->\n"
+            "<!-- Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->\n"
             "<hosts>\n"
             '    <host name="localhost">\n'
             "        <alias>node1</alias>\n"
@@ -1533,7 +1533,7 @@ class TestSimplifiedApplicationPackageAddBertRanking(unittest.TestCase):
     def test_hosts_to_text(self):
         expected_result = (
             '<?xml version="1.0" encoding="utf-8" ?>\n'
-            "<!-- Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->\n"
+            "<!-- Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->\n"
             "<hosts>\n"
             '    <host name="localhost">\n'
             "        <alias>node1</alias>\n"
@@ -1621,7 +1621,7 @@ class TestModelServer(unittest.TestCase):
     def test_hosts_to_text(self):
         expected_result = (
             '<?xml version="1.0" encoding="utf-8" ?>\n'
-            "<!-- Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->\n"
+            "<!-- Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->\n"
             "<hosts>\n"
             '    <host name="localhost">\n'
             "        <alias>node1</alias>\n"


### PR DESCRIPTION
endpoints are lowercased, it seems. not sure if using capital letters is a good idea, lowercase for now

````
14:25:37 vespa/test_integration_docker.py:935: in get_model_endpoints
14:25:37     self.assertEqual(
14:25:37 E   AssertionError: {'ber[17 chars]/bertmodelserver-container.classification-task[95 chars]iny'} != {'ber[17 chars]/bertModelServer-container.classification-task[95 chars]iny'}
14:25:37 E   - {'bert_tiny': 'https://bertmodelserver-container.classification-task.pyvespa-integration.vespa-team.aws-us-east-1c.dev.z.vespa-app.cloud/model-evaluation/v1/bert_tiny'}
14:25:37 E   ?                            ^    ^
14:25:37 E   
14:25:37 E   + {'bert_tiny': 'https://bertModelServer-container.classification-task.pyvespa-integration.vespa-team.aws-us-east-1c.dev.z.vespa-app.cloud/model-evaluation/v1/bert_tiny'}
````
