### PR TITLE
Print error message at deploy error

### DIFF
--- a/vespa/deployment.py
+++ b/vespa/deployment.py
@@ -228,7 +228,8 @@ class VespaDocker(ToJson, FromJson["VespaDocker"]):
                           verify=False)
         logging.debug("Deploy status code: {}".format(r.status_code))
         if r.status_code != 200:
-            raise RuntimeError("Deployment failed, code: {}".format(r.status_code))
+            raise RuntimeError("Deployment failed, code: {}, message: {}".format(r.status_code,
+                                                                                 json.loads(r.content.decode('utf8'))))
 
         app = Vespa(
             url=self.url,


### PR DESCRIPTION
A deployment error will now look like:

````
RuntimeError: Deployment failed, code: 400, message: {'error-code': 'BAD_REQUEST', 'message': 'Error preprocessing application package for default.default, session 9: Error preprocessing /opt/vespa/var/db/vespa/config_server/serverdb/tenants/default/sessions/9/services.xml: The element type "ccontainer" must be terminated by the matching end-tag "</ccontainer>".: The element type "ccontainer" must be terminated by the matching end-tag "</ccontainer>".'}
````