### PR TITLE
Use query batch to speed up vespa feature collection MERGEOK

### DIFF
--- a/vespa/application.py
+++ b/vespa/application.py
@@ -1119,7 +1119,7 @@ class Vespa(object):
         df = df.drop_duplicates(["document_id", "query_id", "label"])
         return df
 
-    def store_rank_features(
+    def store_vespa_features(
         self,
         output_file_path: str,
         labeled_data: Union[List[Dict], DataFrame],
@@ -1146,7 +1146,7 @@ class Vespa(object):
         :param default_score: Score to assign to the additional documents that are not relevant. Default to 0.
         :param batch_size: The size of the batch of labeled data points to be processed.
         :param kwargs: Extra keyword arguments to be included in the Vespa Query.
-        :return: returns 0 upon success.    
+        :return: returns 0 upon success.
         """
 
         if isinstance(labeled_data, DataFrame):

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -1016,6 +1016,7 @@ class Vespa(object):
         query_model: QueryModel,
         number_additional_docs: int,
         fields: List[str],
+        keep_features: Optional[List[str]] = None,
         relevant_score: int = 1,
         default_score: int = 0,
         **kwargs,
@@ -1051,6 +1052,9 @@ class Vespa(object):
         :param id_field: The Vespa field representing the document id.
         :param query_model: Query model.
         :param number_additional_docs: Number of additional documents to retrieve for each relevant document.
+        :param fields: List of Vespa fields to collect, e.g. ["rankfeatures", "summaryfeatures"]
+        :param keep_features: List containing the names of the features that should be returned. Default to None,
+            which return all the features contained in the 'fields' argument.
         :param relevant_score: Score to assign to relevant documents. Default to 1.
         :param default_score: Score to assign to the additional documents that are not relevant. Default to 0.
         :param kwargs: Extra keyword arguments to be included in the Vespa Query.
@@ -1118,6 +1122,8 @@ class Vespa(object):
         df = DataFrame.from_records(result)
         df = df.drop_duplicates(["document_id", "query_id", "label"])
         df = df.sort_values("query_id")
+        if keep_features:
+            df = df[["document_id", "query_id", "label"] + keep_features]
         return df
 
     def store_vespa_features(
@@ -1128,6 +1134,7 @@ class Vespa(object):
         query_model: QueryModel,
         number_additional_docs: int,
         fields: List[str],
+        keep_features: Optional[List[str]] = None,
         relevant_score: int = 1,
         default_score: int = 0,
         batch_size=1000,
@@ -1142,7 +1149,9 @@ class Vespa(object):
         :param id_field: The Vespa field representing the document id.
         :param query_model: Query model.
         :param number_additional_docs: Number of additional documents to retrieve for each relevant document.
-        :param fields: Vespa fields to be included in the data-frame.
+        :param fields: List of Vespa fields to collect, e.g. ["rankfeatures", "summaryfeatures"]
+        :param keep_features: List containing the names of the features that should be returned. Default to None,
+            which return all the features contained in the 'fields' argument.
         :param relevant_score: Score to assign to relevant documents. Default to 1.
         :param default_score: Score to assign to the additional documents that are not relevant. Default to 0.
         :param batch_size: The size of the batch of labeled data points to be processed.
@@ -1164,6 +1173,7 @@ class Vespa(object):
                 query_model=query_model,
                 number_additional_docs=number_additional_docs,
                 fields=fields,
+                keep_features=keep_features,
                 relevant_score=relevant_score,
                 default_score=default_score,
                 **kwargs,

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -1117,6 +1117,7 @@ class Vespa(object):
                 )
         df = DataFrame.from_records(result)
         df = df.drop_duplicates(["document_id", "query_id", "label"])
+        df = df.sort_values("query_id")
         return df
 
     def store_vespa_features(

--- a/vespa/test_integration_docker.py
+++ b/vespa/test_integration_docker.py
@@ -1247,7 +1247,7 @@ class TestCord19Application(TestApplicationCommon):
         self.assertTrue(rank_features.shape[0] > 2)
         # at least one feature besides document_id, query_id and label
         self.assertTrue(rank_features.shape[1] > 3)
-    
+
     def test_model_endpoints_when_no_model_is_available(self):
         self.get_model_endpoints_when_no_model_is_available(
             app=self.app,

--- a/vespa/test_integration_docker.py
+++ b/vespa/test_integration_docker.py
@@ -4,7 +4,7 @@ import os
 import re
 import asyncio
 import json
-from pandas import DataFrame
+from pandas import DataFrame, read_csv
 from vespa.package import (
     HNSW,
     Document,
@@ -1203,6 +1203,51 @@ class TestCord19Application(TestApplicationCommon):
         document_ids = [x["document_id"] for x in data]
         self.assertEqual(len(document_ids), len(set(document_ids)))
 
+    def test_store_vespa_features(self):
+        schema = "cord19"
+        docs = [
+            {"id": fields["id"], "fields": fields} for fields in self.fields_to_send
+        ]
+        self.app.feed_batch(
+            schema=schema,
+            batch=docs,
+            asynchronous=True,
+            connections=120,
+            total_timeout=50,
+        )
+        labeled_data = [
+            {
+                "query_id": 0,
+                "query": "give me title 1",
+                "relevant_docs": [{"id": "1", "score": 1}],
+            },
+            {
+                "query_id": 1,
+                "query": "give me title 3",
+                "relevant_docs": [{"id": "3", "score": 1}],
+            },
+        ]
+
+        self.app.store_vespa_features(
+            output_file_path=os.path.join(
+                os.environ["RESOURCES_DIR"], "vespa_features.csv"
+            ),
+            labeled_data=labeled_data,
+            id_field="id",
+            query_model=QueryModel(
+                match_phase=OR(), rank_profile=Ranking(name="bm25", list_features=True)
+            ),
+            number_additional_docs=2,
+            fields=["rankfeatures", "summaryfeatures"],
+        )
+        rank_features = read_csv(
+            os.path.join(os.environ["RESOURCES_DIR"], "vespa_features.csv")
+        )
+        # at least two relevant docs
+        self.assertTrue(rank_features.shape[0] > 2)
+        # at least one feature besides document_id, query_id and label
+        self.assertTrue(rank_features.shape[1] > 3)
+    
     def test_model_endpoints_when_no_model_is_available(self):
         self.get_model_endpoints_when_no_model_is_available(
             app=self.app,
@@ -1274,6 +1319,10 @@ class TestCord19Application(TestApplicationCommon):
     def tearDown(self) -> None:
         self.vespa_docker.container.stop()
         self.vespa_docker.container.remove()
+        try:
+            os.remove(os.path.join(os.environ["RESOURCES_DIR"], "vespa_features.csv"))
+        except OSError:
+            pass
 
 
 class TestQaApplication(TestApplicationCommon):

--- a/vespa/test_integration_running_instance.py
+++ b/vespa/test_integration_running_instance.py
@@ -181,6 +181,17 @@ class TestRunningInstance(unittest.TestCase):
         self.assertTrue(rank_features.shape[0] > 4)
         # It should have at least one rank feature in addition to document_id, query_id and	label
         self.assertTrue(rank_features.shape[1] > 3)
+        rank_features = app.collect_vespa_features(
+            labeled_data=labeled_data,
+            id_field="id",
+            query_model=query_model,
+            number_additional_docs=2,
+            fields=["rankfeatures"],
+            keep_features=["textSimilarity(title).score"]
+        )
+        self.assertTrue(rank_features.shape[0] > 4)
+        # It should have at least one rank feature in addition to document_id, query_id and	label
+        self.assertTrue(rank_features.shape[1] == 4)
         training_data_batch = app.collect_training_data(
             labeled_data=labeled_data,
             id_field="id",

--- a/vespa/test_integration_running_instance.py
+++ b/vespa/test_integration_running_instance.py
@@ -154,7 +154,6 @@ class TestRunningInstance(unittest.TestCase):
         )
         self.assertEqual(evaluation.shape, (2, 7))
 
-
     def test_collect_training_data(self):
         app = Vespa(url="https://api.cord19.vespa.ai")
         query_model = QueryModel(
@@ -172,6 +171,16 @@ class TestRunningInstance(unittest.TestCase):
                 "relevant_docs": [{"id": 1, "score": 1}, {"id": 5, "score": 1}],
             },
         ]
+        rank_features = app.collect_vespa_features(
+            labeled_data=labeled_data,
+            id_field="id",
+            query_model=query_model,
+            number_additional_docs=2,
+            fields=["rankfeatures"],
+        )
+        self.assertTrue(rank_features.shape[0] > 4)
+        # It should have at least one rank feature in addition to document_id, query_id and	label
+        self.assertTrue(rank_features.shape[1] > 3)
         training_data_batch = app.collect_training_data(
             labeled_data=labeled_data,
             id_field="id",


### PR DESCRIPTION
Fix #333 

Creates `collect_vespa_features` that uses `app.query_batch` to speed up Vespa feature collection. In addition, creates `store_vespa_features` to process labeled_data in batches and store the features in an output file.

Those methods will replace the inefficient `collect_training_data`, which will be deprecated in future versions.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
