### PR TITLE
Fix Vespa Cloud integration tests failure due to Vespa 8 tensor default formatting

### DIFF
--- a/vespa/test_integration_vespa_cloud.py
+++ b/vespa/test_integration_vespa_cloud.py
@@ -209,13 +209,8 @@ class TestCord19Application(TestApplicationCommon):
             expected_fields.update(
                 {
                     "pretrained_bert_tiny_doc_token_ids": {
-                        "cells": [
-                            {
-                                "address": {"d0": str(x)},
-                                "value": float(tensor_field_values[x]),
-                            }
-                            for x in range(len(tensor_field_values))
-                        ]
+                        "type": f"tensor<float>(d0[{len(tensor_field_values)}])",
+                        "values": tensor_field_values,
                     }
                 }
             )
@@ -331,10 +326,8 @@ class TestQaApplication(TestApplicationCommon):
                 "dataset": d["dataset"],
                 "context_id": d["context_id"],
                 "sentence_embedding": {
-                    "cells": [
-                        {"address": {"x": str(idx)}, "value": value}
-                        for idx, value in enumerate(d["sentence_embedding"]["values"])
-                    ]
+                    "type": f"tensor<float>(x[{len(d['sentence_embedding']['values'])}])",
+                    "values": d["sentence_embedding"]["values"],
                 },
             }
             if len(d["questions"]) > 0:


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
