### PR TITLE
Downgrade torch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,8 @@ setuptools.setup(
         "tenacity",
     ],
     extras_require={
-        "ml": ["transformers", "torch", "tensorflow", "tensorflow_ranking", "keras_tuner"],
-        "full": ["onnxruntime", "transformers", "torch", "tensorflow", "tensorflow_ranking", "keras_tuner"],
+        "ml": ["transformers", "torch<1.13", "tensorflow", "tensorflow_ranking", "keras_tuner"],
+        "full": ["onnxruntime", "transformers", "torch<1.13", "tensorflow", "tensorflow_ranking", "keras_tuner"],
     },
     python_requires=">=3.6",
     zip_safe=False,


### PR DESCRIPTION
Master pipeline failure was due to an issue introduced by the latest pytorch release. Downgrading until the issue is fixed.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
