### PR TITLE
use input name input

### DIFF
--- a/docs/sphinx/source/use_cases/tensorflow-via-onnx.ipynb
+++ b/docs/sphinx/source/use_cases/tensorflow-via-onnx.ipynb
@@ -858,7 +858,7 @@
     "    OnnxModel(\n",
     "        model_name=\"ltr_tensorflow\",\n",
     "        model_file_path=\"simpler_keras_model.onnx\",\n",
-    "        inputs={\"input:0\": \"vespa_input\"},\n",
+    "        inputs={\"input\": \"vespa_input\"},\n",
     "        outputs={\"dense\": \"dense\"},\n",
     "    )\n",
     ")"


### PR DESCRIPTION
- preliminary fix: it seems like it expects "input" - persisting this in a PR until I understand more

FYI @lesters 