### PR TITLE
add support for match in Field

### DIFF
--- a/vespa/templates/schema.txt
+++ b/vespa/templates/schema.txt
@@ -28,6 +28,17 @@ schema {{ schema_name }} {
                 }
             }
             {% endif %}
+            {% if field.match %}
+            match {
+                {% for match in field.match %}
+                {% if match is string %}
+                {{ match }}
+                {% else %}
+                {{ match.0 }}: {{ match.1 }}
+                {% endif %}
+                {% endfor %}
+            }
+            {% endif %}
         }
         {% endfor %}
     }


### PR DESCRIPTION
This adds supports for match blocks as described here: https://docs.vespa.ai/en/reference/schema-reference.html#match.

The new `match` optional attribute can use a simple `str` for any property that does not require a value (like `exact` and `gram`), and uses a `Tuple[str, str]` for properties that require a value (like `exact-terminator` and `gram-size`).=

Example Field:

```python3
Field(
	name="abstract",
	type="string",
	match=["exact", ("exact-terminator", '"@%"'), "gram", ("gram-size", 3)],
),
```

leads to this generated schema:

```
field abstract type string {
    match {
        exact
        exact-terminator: "@%"
        gram
        gram-size: 3
    }
}
```

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
