### PR TITLE
Add Summary from the Schema.

### DIFF
--- a/vespa/package.py
+++ b/vespa/package.py
@@ -129,6 +129,7 @@ class Field(object):
         match: Optional[List[Union[str, Tuple[str, str]]]] = None,
         weight: Optional[int] = None,
         bolding: Optional[Literal[True]] = None,
+        summary: Optional[Summary] = None,
     ) -> None:
         """
         Create a Vespa field.
@@ -150,9 +151,10 @@ class Field(object):
         :param match: Set properties that decide how the matching method for this field operate.
         :param weight: Sets the weight of the field, using when calculating Rank Scores.
         :param bolding: Whether to highlight matching query terms in the summary.
+        :param summary: Add configuration for summary of the field.
 
         >>> Field(name = "title", type = "string", indexing = ["index", "summary"], index = "enable-bm25")
-        Field('title', 'string', ['index', 'summary'], 'enable-bm25', None, None, None, None, None)
+        Field('title', 'string', ['index', 'summary'], 'enable-bm25', None, None, None, None, None, None)
 
         >>> Field(
         ...     name = "abstract",
@@ -160,7 +162,7 @@ class Field(object):
         ...     indexing = ["attribute"],
         ...     attribute=["fast-search", "fast-access"]
         ... )
-        Field('abstract', 'string', ['attribute'], None, ['fast-search', 'fast-access'], None, None, None, None)
+        Field('abstract', 'string', ['attribute'], None, ['fast-search', 'fast-access'], None, None, None, None, None)
 
         >>> Field(name="tensor_field",
         ...     type="tensor<float>(x[128])",
@@ -171,28 +173,35 @@ class Field(object):
         ...         neighbors_to_explore_at_insert=200,
         ...     ),
         ... )
-        Field('tensor_field', 'tensor<float>(x[128])', ['attribute'], None, None, HNSW('euclidean', 16, 200), None, None, None)
+        Field('tensor_field', 'tensor<float>(x[128])', ['attribute'], None, None, HNSW('euclidean', 16, 200), None, None, None, None)
 
         >>> Field(
         ...     name = "abstract",
         ...     type = "string",
         ...     match = ["exact", ("exact-terminator", '"@%"',)],
         ... )
-        Field('abstract', 'string', None, None, None, None, ['exact', ('exact-terminator', '"@%"')], None, None)
+        Field('abstract', 'string', None, None, None, None, ['exact', ('exact-terminator', '"@%"')], None, None, None)
 
         >>> Field(
         ...     name = "abstract",
         ...     type = "string",
         ...     weight = 200,
         ... )
-        Field('abstract', 'string', None, None, None, None, None, 200, None)
+        Field('abstract', 'string', None, None, None, None, None, 200, None, None)
 
         >>> Field(
         ...     name = "abstract",
         ...     type = "string",
         ...     bolding = True,
         ... )
-        Field('abstract', 'string', None, None, None, None, None, None, True)
+        Field('abstract', 'string', None, None, None, None, None, None, True, None)
+
+        >>> Field(
+        ...     name = "abstract",
+        ...     type = "string",
+        ...     summary = Summary(None, None, ["dynamic", ["bolding", "on"]]),
+        ... )
+        Field('abstract', 'string', None, None, None, None, None, None, None, Summary(None, None, ['dynamic', ['bolding', 'on']]))
         """
         self.name = name
         self.type = type
@@ -203,6 +212,7 @@ class Field(object):
         self.match = match
         self.weight = weight
         self.bolding = bolding
+        self.summary = summary
 
     @property
     def indexing_to_text(self) -> Optional[str]:
@@ -222,10 +232,11 @@ class Field(object):
             and self.match == other.match
             and self.weight == other.weight
             and self.bolding == other.bolding
+            and self.summary == other.summary
         )
 
     def __repr__(self):
-        return "{0}({1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9})".format(
+        return "{0}({1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}, {10})".format(
             self.__class__.__name__,
             repr(self.name),
             repr(self.type),
@@ -236,6 +247,7 @@ class Field(object):
             repr(self.match),
             repr(self.weight),
             repr(self.bolding),
+            repr(self.summary)
         )
 
 
@@ -304,10 +316,10 @@ class Document(object):
         Document(None, None)
 
         >>> Document(fields=[Field(name="title", type="string")])
-        Document([Field('title', 'string', None, None, None, None, None, None, None)], None)
+        Document([Field('title', 'string', None, None, None, None, None, None, None, None)], None)
 
         >>> Document(fields=[Field(name="title", type="string")], inherits="context")
-        Document([Field('title', 'string', None, None, None, None, None, None, None)], context)
+        Document([Field('title', 'string', None, None, None, None, None, None, None, None)], context)
         """
         self.inherits = inherits
         self._fields = (

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -9,6 +9,75 @@ from jinja2 import Environment, PackageLoader, select_autoescape
 from io import BytesIO
 
 
+class Summary(object):
+    def __init__(
+        self,
+        name: Optional[str],
+        type: Optional[str],
+        fields: List[Union[str, Tuple[str, Union[List[str], str]]]],
+    ) -> None:
+        """
+        Configures a summary Field.
+
+        :param name: Name of the summary field, can be None if used inside a Field, which then uses the name of the Field.
+        :param type: Type of the summary field, can be None if used inside a Field, which then uses the type of the Field.
+        :param fields: List of properties used to configure the summary, can be single properties (like "summary: dynamic", common in Field), or composite values (like "source: another_field")
+
+        >>> Summary(None, None, ["dynamic"])
+        Summary(None, None, ['dynamic'])
+
+        >>> Summary(
+        ...     "title",
+        ...     "string",
+        ...     [("source", "title")]
+        ... )
+        Summary('title', 'string', [('source', 'title')])
+
+        >>> Summary(
+        ...     "title",
+        ...     "string",
+        ...     [("source", ["title", "abstract"])]
+        ... )
+        Summary('title', 'string', [('source', ['title', 'abstract'])])
+        """
+        self.name = name
+        self.type = type
+        self.fields = fields
+
+    @property
+    def attributes_as_string_list(self) -> List[str]:
+        final_list = []
+        for field in self.fields:
+            if isinstance(field, str):
+                final_list.append(field)
+            else:
+                final_string = f"{field[0]}: "
+                if isinstance(field[1], str):
+                    final_string += f'{field[1]}'
+                else:
+                    final_string += f'{", ".join(field[1])}'
+                final_list.append(final_string)
+
+        return final_list
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Summary):
+            return NotImplemented
+        return (
+            self.name == other.name
+            and self.type == other.type
+            and self.fields == other.fields
+        )
+
+    def __repr__(self) -> str:
+        return "{0}({1}, {2}, {3})".format(
+            self.__class__.__name__,
+            repr(self.name),
+            repr(self.type),
+            repr(self.fields)
+        )
+
+
 class HNSW(object):
     def __init__(
         self,

--- a/vespa/templates/schema.txt
+++ b/vespa/templates/schema.txt
@@ -45,6 +45,13 @@ schema {{ schema_name }} {
             {% if field.bolding %}
             bolding: on
             {% endif %}
+            {% if field.summary %}
+            summary {% if field.summary.name %}{{field.summary.name}}{% endif %}{% if field.summary.type %} type {{ field.summary.type }} {% endif %}{
+                {% for field in field.summary.attributes_as_string_list %}
+                {{ field }}
+                {% endfor %}
+            }
+            {% endif %}
         }
         {% endfor %}
     }


### PR DESCRIPTION
Created using the [Schema reference](https://docs.vespa.ai/en/reference/schema-reference.html#summary).

I am not fully happy with this, specially that it cannot output simple `summary: [property]`, instead doing `summary {\n	[property]\n}`, but otherwise it should be able to output anything you throw at it.

The expectation is being able to add `document-summary` at a later date, which this is a requirement.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
