### PR TITLE
add weight and bolding support for Field

### DIFF
--- a/vespa/package.py
+++ b/vespa/package.py
@@ -58,6 +58,7 @@ class Field(object):
         attribute: Optional[List[str]] = None,
         ann: Optional[HNSW] = None,
         match: Optional[List[Union[str, Tuple[str, str]]]] = None,
+        weight: Optional[int] = None,
     ) -> None:
         """
         Create a Vespa field.
@@ -77,9 +78,10 @@ class Field(object):
         :param attribute:  Specifies a property of an index structure attribute.
         :param ann: Add configuration for approximate nearest neighbor.
         :param match: Set properties that decide how the matching method for this field operate.
+        :param weight: Sets the weight of the field, using when calculating Rank Scores.
 
         >>> Field(name = "title", type = "string", indexing = ["index", "summary"], index = "enable-bm25")
-        Field('title', 'string', ['index', 'summary'], 'enable-bm25', None, None, None)
+        Field('title', 'string', ['index', 'summary'], 'enable-bm25', None, None, None, None)
 
         >>> Field(
         ...     name = "abstract",
@@ -87,7 +89,7 @@ class Field(object):
         ...     indexing = ["attribute"],
         ...     attribute=["fast-search", "fast-access"]
         ... )
-        Field('abstract', 'string', ['attribute'], None, ['fast-search', 'fast-access'], None, None)
+        Field('abstract', 'string', ['attribute'], None, ['fast-search', 'fast-access'], None, None, None)
 
         >>> Field(name="tensor_field",
         ...     type="tensor<float>(x[128])",
@@ -98,15 +100,21 @@ class Field(object):
         ...         neighbors_to_explore_at_insert=200,
         ...     ),
         ... )
-        Field('tensor_field', 'tensor<float>(x[128])', ['attribute'], None, None, HNSW('euclidean', 16, 200), None)
+        Field('tensor_field', 'tensor<float>(x[128])', ['attribute'], None, None, HNSW('euclidean', 16, 200), None, None)
 
         >>> Field(
         ...     name = "abstract",
         ...     type = "string",
         ...     match = ["exact", ("exact-terminator", '"@%"',)],
         ... )
-        Field('abstract', 'string', None, None, None, None, ['exact', ('exact-terminator', '"@%"')])
+        Field('abstract', 'string', None, None, None, None, ['exact', ('exact-terminator', '"@%"')], None)
 
+        >>> Field(
+        ...     name = "abstract",
+        ...     type = "string",
+        ...     weight = 200,
+        ... )
+        Field('abstract', 'string', None, None, None, None, None, 200)
         """
         self.name = name
         self.type = type
@@ -115,6 +123,7 @@ class Field(object):
         self.index = index
         self.ann = ann
         self.match = match
+        self.weight = weight
 
     @property
     def indexing_to_text(self) -> Optional[str]:
@@ -132,10 +141,11 @@ class Field(object):
             and self.attribute == other.attribute
             and self.ann == other.ann
             and self.match == other.match
+            and self.weight == other.weight
         )
 
     def __repr__(self):
-        return "{0}({1}, {2}, {3}, {4}, {5}, {6}, {7})".format(
+        return "{0}({1}, {2}, {3}, {4}, {5}, {6}, {7}, {8})".format(
             self.__class__.__name__,
             repr(self.name),
             repr(self.type),
@@ -143,7 +153,8 @@ class Field(object):
             repr(self.index),
             repr(self.attribute),
             repr(self.ann),
-            repr(self.match)
+            repr(self.match),
+            repr(self.weight),
         )
 
 
@@ -212,10 +223,10 @@ class Document(object):
         Document(None, None)
 
         >>> Document(fields=[Field(name="title", type="string")])
-        Document([Field('title', 'string', None, None, None, None, None)], None)
+        Document([Field('title', 'string', None, None, None, None, None, None)], None)
 
         >>> Document(fields=[Field(name="title", type="string")], inherits="context")
-        Document([Field('title', 'string', None, None, None, None, None)], context)
+        Document([Field('title', 'string', None, None, None, None, None, None)], context)
         """
         self.inherits = inherits
         self._fields = (

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -3,7 +3,7 @@ import zipfile
 
 from pathlib import Path
 from shutil import copyfile
-from typing import List, Optional, Tuple, Union, Dict
+from typing import List, Literal, Optional, Tuple, Union, Dict
 from collections import OrderedDict
 from jinja2 import Environment, PackageLoader, select_autoescape
 from io import BytesIO
@@ -59,6 +59,7 @@ class Field(object):
         ann: Optional[HNSW] = None,
         match: Optional[List[Union[str, Tuple[str, str]]]] = None,
         weight: Optional[int] = None,
+        bolding: Optional[Literal[True]] = None,
     ) -> None:
         """
         Create a Vespa field.
@@ -79,9 +80,10 @@ class Field(object):
         :param ann: Add configuration for approximate nearest neighbor.
         :param match: Set properties that decide how the matching method for this field operate.
         :param weight: Sets the weight of the field, using when calculating Rank Scores.
+        :param bolding: Whether to highlight matching query terms in the summary.
 
         >>> Field(name = "title", type = "string", indexing = ["index", "summary"], index = "enable-bm25")
-        Field('title', 'string', ['index', 'summary'], 'enable-bm25', None, None, None, None)
+        Field('title', 'string', ['index', 'summary'], 'enable-bm25', None, None, None, None, None)
 
         >>> Field(
         ...     name = "abstract",
@@ -89,7 +91,7 @@ class Field(object):
         ...     indexing = ["attribute"],
         ...     attribute=["fast-search", "fast-access"]
         ... )
-        Field('abstract', 'string', ['attribute'], None, ['fast-search', 'fast-access'], None, None, None)
+        Field('abstract', 'string', ['attribute'], None, ['fast-search', 'fast-access'], None, None, None, None)
 
         >>> Field(name="tensor_field",
         ...     type="tensor<float>(x[128])",
@@ -100,21 +102,28 @@ class Field(object):
         ...         neighbors_to_explore_at_insert=200,
         ...     ),
         ... )
-        Field('tensor_field', 'tensor<float>(x[128])', ['attribute'], None, None, HNSW('euclidean', 16, 200), None, None)
+        Field('tensor_field', 'tensor<float>(x[128])', ['attribute'], None, None, HNSW('euclidean', 16, 200), None, None, None)
 
         >>> Field(
         ...     name = "abstract",
         ...     type = "string",
         ...     match = ["exact", ("exact-terminator", '"@%"',)],
         ... )
-        Field('abstract', 'string', None, None, None, None, ['exact', ('exact-terminator', '"@%"')], None)
+        Field('abstract', 'string', None, None, None, None, ['exact', ('exact-terminator', '"@%"')], None, None)
 
         >>> Field(
         ...     name = "abstract",
         ...     type = "string",
         ...     weight = 200,
         ... )
-        Field('abstract', 'string', None, None, None, None, None, 200)
+        Field('abstract', 'string', None, None, None, None, None, 200, None)
+
+        >>> Field(
+        ...     name = "abstract",
+        ...     type = "string",
+        ...     bolding = True,
+        ... )
+        Field('abstract', 'string', None, None, None, None, None, None, True)
         """
         self.name = name
         self.type = type
@@ -124,6 +133,7 @@ class Field(object):
         self.ann = ann
         self.match = match
         self.weight = weight
+        self.bolding = bolding
 
     @property
     def indexing_to_text(self) -> Optional[str]:
@@ -142,10 +152,11 @@ class Field(object):
             and self.ann == other.ann
             and self.match == other.match
             and self.weight == other.weight
+            and self.bolding == other.bolding
         )
 
     def __repr__(self):
-        return "{0}({1}, {2}, {3}, {4}, {5}, {6}, {7}, {8})".format(
+        return "{0}({1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9})".format(
             self.__class__.__name__,
             repr(self.name),
             repr(self.type),
@@ -155,6 +166,7 @@ class Field(object):
             repr(self.ann),
             repr(self.match),
             repr(self.weight),
+            repr(self.bolding),
         )
 
 
@@ -223,10 +235,10 @@ class Document(object):
         Document(None, None)
 
         >>> Document(fields=[Field(name="title", type="string")])
-        Document([Field('title', 'string', None, None, None, None, None, None)], None)
+        Document([Field('title', 'string', None, None, None, None, None, None, None)], None)
 
         >>> Document(fields=[Field(name="title", type="string")], inherits="context")
-        Document([Field('title', 'string', None, None, None, None, None, None)], context)
+        Document([Field('title', 'string', None, None, None, None, None, None, None)], context)
         """
         self.inherits = inherits
         self._fields = (

--- a/vespa/templates/schema.txt
+++ b/vespa/templates/schema.txt
@@ -39,6 +39,9 @@ schema {{ schema_name }} {
                 {% endfor %}
             }
             {% endif %}
+            {% if field.weight %}
+            weight: {{ field.weight }}
+            {% endif %}
         }
         {% endfor %}
     }

--- a/vespa/templates/schema.txt
+++ b/vespa/templates/schema.txt
@@ -42,6 +42,9 @@ schema {{ schema_name }} {
             {% if field.weight %}
             weight: {{ field.weight }}
             {% endif %}
+            {% if field.bolding %}
+            bolding: on
+            {% endif %}
         }
         {% endfor %}
     }


### PR DESCRIPTION
This adds supports for the weight and bolding fields, as described [here](https://docs.vespa.ai/en/reference/schema-reference.html#bolding) and [here](https://docs.vespa.ai/en/reference/schema-reference.html#bolding).

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
