### PR TITLE
Implement DocumentSummary

### DIFF
--- a/vespa/package.py
+++ b/vespa/package.py
@@ -387,6 +387,77 @@ class Struct(object):
         )
 
 
+class DocumentSummary(object):
+    def __init__(
+        self,
+        name: str,
+        inherits: Optional[str] = None,
+        summary_fields: Optional[List[Summary]] = None,
+        from_disk: Optional[Literal[True]] = None,
+        omit_summary_features: Optional[Literal[True]] = None,
+    ) -> None:
+        """
+        Create a Document Summary.
+        Check the `Vespa documentation <https://docs.vespa.ai/en/reference/schema-reference.html#document-summary>`__
+        for more detailed information about documment-summary.
+        :param name: Name of the document-summary.
+        :param inherits: Name of another document-summary from which this inherits from.
+        :param summary_fields: List of summaries used in this document-summary.
+        :param from_disk: Marks this document-summary as accessing fields on disk.
+        :param omit_summary_features: Specifies that summary-features should be omitted from this document summary.
+
+        >>> DocumentSummary(
+        ...     name="document-summary",
+        ... )
+        DocumentSummary('document-summary', None, None, None, None)
+
+        >>> DocumentSummary(
+        ...     name="which-inherits",
+        ...     inherits="base-document-summary",
+        ... )
+        DocumentSummary('which-inherits', 'base-document-summary', None, None, None)
+
+        >>> DocumentSummary(
+        ...     name="with-field",
+        ...     summary_fields=[Summary("title", "string", [("source", "title")])]
+        ... )
+        DocumentSummary('with-field', None, [Summary('title', 'string', [('source', 'title')])], None, None)
+
+        >>> DocumentSummary(
+        ...     name="with-bools",
+        ...     from_disk=True,
+        ...     omit_summary_features=True,
+        ... )
+        DocumentSummary('with-bools', None, None, True, True)
+        """
+        self.name = name
+        self.inherits = inherits
+        self.summary_fields = summary_fields
+        self.from_disk = from_disk
+        self.omit_summary_features = omit_summary_features
+
+    def __eq__(self, other: object):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return (
+            self.name == other.name
+            and self.inherits == other.inherits
+            and self.summary_fields == other.summary_fields
+            and self.from_disk == other.from_disk
+            and self.omit_summary_features == other.omit_summary_features
+        )
+
+    def __repr__(self) -> str:
+        return "{0}({1}, {2}, {3}, {4}, {5})".format(
+            self.__class__.__name__,
+            repr(self.name),
+            repr(self.inherits),
+            repr(self.summary_fields),
+            repr(self.from_disk),
+            repr(self.omit_summary_features),
+        )
+
+
 class Document(object):
     def __init__(
         self,

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -918,6 +918,7 @@ class Schema(object):
         models: Optional[List[OnnxModel]] = None,
         global_document: bool = False,
         imported_fields: Optional[List[ImportedField]] = None,
+        document_summaries: Optional[List[DocumentSummary]] = None,
     ) -> None:
         """
         Create a Vespa Schema.
@@ -932,11 +933,12 @@ class Schema(object):
         :param models: A list of :class:`OnnxModel` associated with the Schema.
         :param global_document: Set to True to copy the documents to all content nodes. Default to False.
         :param imported_fields: A list of :class:`ImportedField` defining fields from global documents to be imported.
+        :param document_summaries: A list of :class:`DocumentSummary` associated with the schema.
 
         To create a Schema:
 
         >>> Schema(name="schema_name", document=Document())
-        Schema('schema_name', Document(None, None, None), None, None, [], False, None)
+        Schema('schema_name', Document(None, None, None), None, None, [], False, None, [])
         """
         self.name = name
         self.document = document
@@ -960,6 +962,10 @@ class Schema(object):
             }
 
         self.models = [] if models is None else list(models)
+
+        self.document_summaries = (
+            [] if document_summaries is None else list(document_summaries)
+        )
 
     def add_fields(self, *fields: Field) -> None:
         """
@@ -1002,6 +1008,14 @@ class Schema(object):
         """
         self.imported_fields[imported_field.name] = imported_field
 
+    def add_document_summary(self, document_summary: DocumentSummary) -> None:
+        """
+        Add a :class:`DocumentSummary` to the Schema.
+
+        :param document_summary: document summary to be added.
+        """
+        self.document_summaries.append(document_summary)
+
     @property
     def schema_to_text(self):
         env = Environment(
@@ -1023,6 +1037,7 @@ class Schema(object):
             rank_profiles=self.rank_profiles,
             models=self.models,
             imported_fields=self.imported_fields,
+            document_summaries=self.document_summaries,
         )
 
     def __eq__(self, other):
@@ -1036,10 +1051,11 @@ class Schema(object):
             and self.models == other.models
             and self.global_document == other.global_document
             and self.imported_fields == other.imported_fields
+            and self.document_summaries == other.document_summaries
         )
 
     def __repr__(self):
-        return "{0}({1}, {2}, {3}, {4}, {5}, {6}, {7})".format(
+        return "{0}({1}, {2}, {3}, {4}, {5}, {6}, {7}, {8})".format(
             self.__class__.__name__,
             repr(self.name),
             repr(self.document),
@@ -1058,6 +1074,7 @@ class Schema(object):
                 if self.imported_fields
                 else None
             ),
+            repr(self.document_summaries),
         )
 
 
@@ -1261,7 +1278,7 @@ class ApplicationPackage(object):
         The easiest way to get started is to create a default application package:
 
         >>> ApplicationPackage(name="testapp")
-        ApplicationPackage('testapp', [Schema('testapp', Document(None, None, None), None, None, [], False, None)], QueryProfile(None), QueryProfileType(None))
+        ApplicationPackage('testapp', [Schema('testapp', Document(None, None, None), None, None, [], False, None, [])], QueryProfile(None), QueryProfileType(None))
 
         It will create a default :class:`Schema`, :class:`QueryProfile` and :class:`QueryProfileType` that you can then
         populate with specifics of your application.

--- a/vespa/templates/schema.txt
+++ b/vespa/templates/schema.txt
@@ -46,11 +46,9 @@ schema {{ schema_name }} {
             bolding: on
             {% endif %}
             {% if field.summary %}
-            summary {% if field.summary.name %}{{field.summary.name}}{% endif %}{% if field.summary.type %} type {{ field.summary.type }} {% endif %}{
-                {% for field in field.summary.attributes_as_string_list %}
-                {{ field }}
-                {% endfor %}
-            }
+            {% for line in field.summary.as_lines %}
+            {{ line }}
+            {% endfor %}
             {% endif %}
             {% if field.stemming %}
             stemming: {{ field.stemming }}
@@ -111,11 +109,9 @@ schema {{ schema_name }} {
                 bolding: on
                 {% endif %}
                 {% if field.summary %}
-                summary {% if field.summary.name %}{{field.summary.name}}{% endif %}{% if field.summary.type %} type {{ field.summary.type }} {% endif %}{
-                    {% for field in field.summary.attributes_as_string_list %}
-                    {{ field }}
-                    {% endfor %}
-                }
+                {% for line in field.summary.as_lines %}
+                {{ line }}
+                {% endfor %}
                 {% endif %}
                 {% if field.stemming %}
                 stemming: {{ field.stemming }}

--- a/vespa/templates/schema.txt
+++ b/vespa/templates/schema.txt
@@ -186,4 +186,19 @@ schema {{ schema_name }} {
         {% endif %}
     }
 {% endfor %}
+{% for document_summary in document_summaries %}
+    document-summary {{ document_summary.name }}{% if document_summary.inherits %} inherits {{ document_summary.inherits }}{% endif %} {
+        {% for summary in document_summary.summary_fields %}
+        {% for field in summary.as_lines %}
+        {{ field }}
+        {% endfor %}
+        {% endfor %}
+        {% if document_summary.from_disk %}
+        {{ document_summary.from_disk }}
+        {% endif %}
+        {% if document_summary.omit_summary_features %}
+        {{ document_summary.omit_summary_features }}
+        {% endif %}
+    }
+{% endfor %}
 }


### PR DESCRIPTION
This implements DocummentSummary, as described in
https://docs.vespa.ai/en/reference/schema-reference.html#document-summary,
making use of the previous Summary work from #405

It also changes how `Summary` is generated in the final schema by adding a new property `as_lines`, which represents each line of summary class as it would be written out in the final file on disk.

This has the advantage of moving all the logic to python which is much easier to handle than Jinja, this has the effect of allowing us to do single-attribute summaries like `summary: dynamic`, and also we can handle Summaries with no body (like `summary simple type string {}`).

The one drawback I see from this `as_lines` approach is that the indent is tied to the python code, in Jinja we could write it out the fields and the structure would lead to the indentation, but with `as_lines` we add 4 whitespaces to lines that are in the body of the summary.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
