### PR TITLE
increate test run timeout

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -34,7 +34,7 @@ jobs:
   integration-except-cloud:
     requires: [~commit]
     annotations:
-      screwdriver.cd/timeout: 120
+      screwdriver.cd/timeout: 180
       screwdriver.cd/cpu: HIGH
       screwdriver.cd/ram: HIGH
       screwdriver.cd/dockerEnabled: true


### PR DESCRIPTION
- A better fix will be to remove some steps, we probably do not need all of this, lets revisit when green
