### PR TITLE
Kkraune/exceptions

### DIFF
--- a/vespa/application.py
+++ b/vespa/application.py
@@ -851,9 +851,10 @@ class VespaSync(object):
         :param body: Dict containing all the request parameters.
         :return: Either the request body if debug_request is True or the result from the Vespa application
         """
-        r = self.http_session.post(self.app.search_end_point, json=body, cert=self.cert)
+        response = self.http_session.post(self.app.search_end_point, json=body, cert=self.cert)
+        response.raise_for_status()
         return VespaQueryResponse(
-            json=r.json(), status_code=r.status_code, url=str(r.url)
+            json=response.json(), status_code=response.status_code, url=str(response.url)
         )
 
     def delete_data(
@@ -874,6 +875,7 @@ class VespaSync(object):
             self.app.end_point, namespace, schema, str(data_id)
         )
         response = self.http_session.delete(end_point, cert=self.cert)
+        response.raise_for_status()
         return VespaResponse(
             json=response.json(),
             status_code=response.status_code,
@@ -899,6 +901,7 @@ class VespaSync(object):
             self.app.end_point, namespace, schema, content_cluster_name
         )
         response = self.http_session.delete(end_point, cert=self.cert)
+        response.raise_for_status()
         return response
 
     def get_data(
@@ -919,6 +922,7 @@ class VespaSync(object):
             self.app.end_point, namespace, schema, str(data_id)
         )
         response = self.http_session.get(end_point, cert=self.cert)
+        response.raise_for_status()
         return VespaResponse(
             json=response.json(),
             status_code=response.status_code,
@@ -952,6 +956,7 @@ class VespaSync(object):
         )
         vespa_format = {"fields": {k: {"assign": v} for k, v in fields.items()}}
         response = self.http_session.put(end_point, json=vespa_format, cert=self.cert)
+        response.raise_for_status()
         return VespaResponse(
             json=response.json(),
             status_code=response.status_code,

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -831,6 +831,7 @@ class VespaSync(object):
         )
         vespa_format = {"fields": fields}
         response = self.http_session.post(end_point, json=vespa_format, cert=self.cert)
+        response.raise_for_status()
         return VespaResponse(
             json=response.json(),
             status_code=response.status_code,

--- a/vespa/io.py
+++ b/vespa/io.py
@@ -20,6 +20,12 @@ class VespaResponse(object):
             and self.operation_type == other.operation_type
         )
 
+    def get_status_code(self):
+        return self.status_code
+
+    def get_json(self):
+        return self.json
+
 
 def trec_format(
     vespa_result, id_field: Optional[str] = None, qid: int = 0

--- a/vespa/test_integration_docker.py
+++ b/vespa/test_integration_docker.py
@@ -467,22 +467,14 @@ class TestApplicationCommon(unittest.TestCase):
 
             self.assertEqual(
                 await async_app.feed_data_point(
-                    schema="msmarco",
+                    schema=schema_name,
                     data_id="1",
-                    fields={
-                        "id": "1",
-                        "title": "this is title 1",
-                        "body": "this is body 1",
-                    },
+                    fields=fields,
                 ),
                 app.feed_data_point(
-                    schema="msmarco",
+                    schema=schema_name,
                     data_id="1",
-                    fields={
-                        "id": "1",
-                        "title": "this is title 1",
-                        "body": "this is body 1",
-                    },
+                    fields=fields,
                 ),
             )
 

--- a/vespa/test_integration_docker.py
+++ b/vespa/test_integration_docker.py
@@ -6,6 +6,9 @@ import os
 import re
 import asyncio
 import json
+
+from requests import HTTPError
+
 from vespa.package import (
     HNSW,
     Document,
@@ -207,18 +210,13 @@ class TestDockerCommon(unittest.TestCase):
     def redeploy_with_application_package_changes(self, application_package):
         self.vespa_docker = VespaDocker(port=8089)
         app = self.vespa_docker.deploy(application_package=application_package)
-        res = app.query(
-            body={
-                "yql": "select * from sources * where default contains 'music'",
-                "ranking": "new-rank-profile",
-            }
-        ).json
-        self.assertIsNotNone(
-            re.search(
-                r"schema[\s\S]+ does not contain requested rank profile",
-                res["root"]["errors"][0]["message"],
-            )
-        )
+        with pytest.raises(HTTPError):
+            app.query(
+                body={
+                    "yql": "select * from sources * where default contains 'music'",
+                    "ranking": "new-rank-profile",
+                })
+
         application_package.schema.add_rank_profile(
             RankProfile(
                 name="new-rank-profile", inherits="default", first_phase="bm25(title)"
@@ -278,10 +276,9 @@ class TestApplicationCommon(unittest.TestCase):
         #
         # Get data that does not exist
         #
-        self.assertEqual(
-            app.get_data(schema=schema_name, data_id=fields_to_send["id"]).status_code,
-            404,
-        )
+        with pytest.raises(HTTPError):
+            app.get_data(schema=schema_name, data_id=fields_to_send["id"])
+
         #
         # Feed a data point
         #
@@ -354,10 +351,9 @@ class TestApplicationCommon(unittest.TestCase):
         #
         # Deleted data should be gone
         #
-        self.assertEqual(
-            app.get_data(schema=schema_name, data_id=fields_to_send["id"]).status_code,
-            404,
-        )
+        with pytest.raises(HTTPError):
+            app.get_data(schema=schema_name, data_id=fields_to_send["id"])
+
         #
         # Update a non-existent data point
         #
@@ -688,9 +684,8 @@ class TestApplicationCommon(unittest.TestCase):
         #
         # get batch deleted data
         #
-        result = app.get_batch(schema=schema, batch=docs, asynchronous=False)
-        for idx, response in enumerate(result):
-            self.assertEqual(response.status_code, 404)
+        with pytest.raises(HTTPError):
+            app.get_batch(schema=schema, batch=docs, asynchronous=False)
 
     def batch_operations_asynchronous_mode(
         self,


### PR DESCRIPTION
- It is a problem that errors are hidden, making it hard to understand why examples/notebooks don't work
- I think it is better to throw an exception on 4xx/5xx - this is a suggestion, if we decide to do it this way, must do in more places - for discussion

Example:
````
app.feed_data_point(schema="sentence", data_id=idx, fields=sentence)
````
will now fail on disk full:
````
---------------------------------------------------------------------------
HTTPError                                 Traceback (most recent call last)
Cell In [18], line 2
      1 for context in context_data:
----> 2     app.feed_data_point(schema="context", data_id=context["context_id"], fields=context)

File ~/github/vespa-engine/pyvespa/vespa/application.py:298, in Vespa.feed_data_point(self, schema, data_id, fields, namespace)
    295     namespace = schema
    297 with VespaSync(app=self) as sync_app:
--> 298     return sync_app.feed_data_point(
    299         schema=schema, data_id=data_id, fields=fields, namespace=namespace
    300     )

File ~/github/vespa-engine/pyvespa/vespa/application.py:834, in VespaSync.feed_data_point(self, schema, data_id, fields, namespace)
    832 vespa_format = {"fields": fields}
    833 response = self.http_session.post(end_point, json=vespa_format, cert=self.cert)
--> 834 response.raise_for_status()
    835 return VespaResponse(
    836     json=response.json(),
    837     status_code=response.status_code,
    838     url=str(response.url),
    839     operation_type="feed",
    840 )

File /usr/local/Cellar/jupyterlab/3.4.8/libexec/lib/python3.10/site-packages/requests/models.py:1021, in Response.raise_for_status(self)
   1016     http_error_msg = (
   1017         f"{self.status_code} Server Error: {reason} for url: {self.url}"
   1018     )
   1020 if http_error_msg:
-> 1021     raise HTTPError(http_error_msg, response=self)

HTTPError: 507 Server Error: Insufficient Storage for url: http://localhost:8080/document/v1/context/context/docid/0
````
