### PR TITLE
Remove extras_require

### DIFF
--- a/docs/sphinx/source/exchange-data-with-app.ipynb
+++ b/docs/sphinx/source/exchange-data-with-app.ipynb
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "congressional-friendly",
    "metadata": {},
    "outputs": [],

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setuptools.setup(
         "cryptography",
         "aiohttp",
         "tenacity",
+        "typing_extensions",
     ],
     python_requires=">=3.6",
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -35,10 +35,6 @@ setuptools.setup(
         "aiohttp",
         "tenacity",
     ],
-    extras_require={
-        "ml": ["transformers", "torch<1.13", "tensorflow", "tensorflow_ranking", "keras_tuner"],
-        "full": ["onnxruntime", "transformers", "torch<1.13", "tensorflow", "tensorflow_ranking", "keras_tuner"],
-    },
     python_requires=">=3.6",
     zip_safe=False,
     package_data={"vespa": ["py.typed"]},


### PR DESCRIPTION
- `python3 -m pip install -e .[full]` pulls in this, and it is not needed now, as code is moved to learntorank