### PR TITLE
Prevent errors from being raised when calling APIs

### DIFF
--- a/vespa/application.py
+++ b/vespa/application.py
@@ -825,7 +825,6 @@ class VespaSync(object):
         :param fields: Dict containing all the fields required by the `schema`.
         :param namespace: The namespace that we are sending data to. If no namespace is provided the schema is used.
         :return: Response of the HTTP POST request.
-        :raises HTTPError: if one occurred
         """
 
         if not namespace:
@@ -836,7 +835,6 @@ class VespaSync(object):
         )
         vespa_format = {"fields": fields}
         response = self.http_session.post(end_point, json=vespa_format, cert=self.cert)
-        response.raise_for_status()
         return VespaResponse(
             json=response.json(),
             status_code=response.status_code,
@@ -855,10 +853,8 @@ class VespaSync(object):
 
         :param body: Dict containing all the request parameters.
         :return: Either the request body if debug_request is True or the result from the Vespa application
-        :raises HTTPError: if one occurred
         """
         response = self.http_session.post(self.app.search_end_point, json=body, cert=self.cert)
-        response.raise_for_status()
         return VespaQueryResponse(
             json=response.json(), status_code=response.status_code, url=str(response.url)
         )
@@ -873,7 +869,6 @@ class VespaSync(object):
         :param data_id: Unique id associated with this data point.
         :param namespace: The namespace that we are deleting data from.
         :return: Response of the HTTP DELETE request.
-        :raises HTTPError: if one occurred
         """
         if not namespace:
             namespace = schema
@@ -882,7 +877,6 @@ class VespaSync(object):
             self.app.end_point, namespace, schema, str(data_id)
         )
         response = self.http_session.delete(end_point, cert=self.cert)
-        response.raise_for_status()
         return VespaResponse(
             json=response.json(),
             status_code=response.status_code,
@@ -900,7 +894,6 @@ class VespaSync(object):
         :param schema: The schema that we are deleting data from.
         :param namespace: The namespace that we are deleting data from.
         :return: Response of the HTTP DELETE request.
-        :raises HTTPError: if one occurred
         """
         if not namespace:
             namespace = schema
@@ -909,7 +902,6 @@ class VespaSync(object):
             self.app.end_point, namespace, schema, content_cluster_name
         )
         response = self.http_session.delete(end_point, cert=self.cert)
-        response.raise_for_status()
         return response
 
     def get_data(
@@ -922,7 +914,6 @@ class VespaSync(object):
         :param data_id: Unique id associated with this data point.
         :param namespace: The namespace that we are getting data from.
         :return: Response of the HTTP GET request.
-        :raises HTTPError: if one occurred
         """
         if not namespace:
             namespace = schema
@@ -931,7 +922,6 @@ class VespaSync(object):
             self.app.end_point, namespace, schema, str(data_id)
         )
         response = self.http_session.get(end_point, cert=self.cert)
-        response.raise_for_status()
         return VespaResponse(
             json=response.json(),
             status_code=response.status_code,
@@ -956,7 +946,6 @@ class VespaSync(object):
         :param create: If true, updates to non-existent documents will create an empty document to update
         :param namespace: The namespace that we are updating data.
         :return: Response of the HTTP PUT request.
-        :raises HTTPError: if one occurred
         """
         if not namespace:
             namespace = schema
@@ -966,7 +955,6 @@ class VespaSync(object):
         )
         vespa_format = {"fields": {k: {"assign": v} for k, v in fields.items()}}
         response = self.http_session.put(end_point, json=vespa_format, cert=self.cert)
-        response.raise_for_status()
         return VespaResponse(
             json=response.json(),
             status_code=response.status_code,


### PR DESCRIPTION
## Summary

This PR prevents errors from being raised when calling Vespa APIs.

It is just one of the possible options for the problems I have encountered.

## Context

I'm new to Vespa. I attempted to call the search API, but the following code resulted in the error below.

```python
body = {
    "yql": "select * from sources typo where userQuery()",
    "query": "hello",
    "type": "any",
    "ranking": "random",
    "hits": 10,
}
vespa_app.query(body)
```

```python
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: http://localhost:8080/search/
```

I was struggling with debugging because the error message didn't provide enough details, but I managed to find out that there was a typo in `sources typo`.

## Issue

Reading the code, `raise_for_status` is called to raise an error when the HTTP status code is not successful.

```python
# vespa/application.py
    def query(
        self,
        body: Optional[Dict] = None,
    ) -> VespaQueryResponse:
        ...
        response = self.http_session.post(self.app.search_end_point, json=body, cert=self.cert)
        response.raise_for_status()
        return VespaQueryResponse(
            json=response.json(), status_code=response.status_code, url=str(response.url)
        )
```

It seems that this was added in https://github.com/vespa-engine/pyvespa/pull/466 This PR enabled us to receive a forced notification when an error occurred. 

<details>

```python
# requests/models.py
    def raise_for_status(self):
        """Raises :class:`HTTPError`, if one occurred."""

        http_error_msg = ""
        if isinstance(self.reason, bytes):
            # We attempt to decode utf-8 first because some servers
            # choose to localize their reason strings. If the string
            # isn't utf-8, we fall back to iso-8859-1 for all other
            # encodings. (See PR #3538)
            try:
                reason = self.reason.decode("utf-8")
            except UnicodeDecodeError:
                reason = self.reason.decode("iso-8859-1")
        else:
            reason = self.reason

        if 400 <= self.status_code < 500:
            http_error_msg = (
                f"{self.status_code} Client Error: {reason} for url: {self.url}"
            )

        elif 500 <= self.status_code < 600:
            http_error_msg = (
                f"{self.status_code} Server Error: {reason} for url: {self.url}"
            )

        if http_error_msg:
            raise HTTPError(http_error_msg, response=self)
```

</details>

However, the error doesn't include a message from Vespa. The message that should have been returned was as follows:

```python
{
  'root': {
    'id': 'toplevel',
    'relevance': 1.0,
    'fields': {
      'totalCount': 0
    },
    'errors': [
      {
        'code': 4,
        'summary': 'Invalid query parameter',
        'message': "Could not resolve source ref 'typo'. Valid source refs are amazon_content."
      }
    ]
  }
}
```

I would be able to identify the cause instantly if I could see the message.

## Options

There are several approaches that I think we can resolve this issue.

### 1. Stop calling `raise_for_status`

This is the approach I took in this PR. Errors are no longer raised, and it is now the responsibility of the caller to decide how to handle errors by checking the status code.

### 2. Raise a custom error

If we want to raise an error and include a message from Vespa, it would be better to create a custom error rather than raising `HTTPError`.

## Example of [elasticsearch-py](https://github.com/elastic/elasticsearch-py)

The Bulk API has the [`raise_on_error`](https://github.com/elastic/elasticsearch-py/blob/main/elasticsearch/helpers/actions.py#L363) param. If True, [an error is raised](https://github.com/elastic/elasticsearch-py/blob/f9df3af3db99e6ac4db5cfed22f819469c4b41fb/elasticsearch/helpers/actions.py#L307-L310).