### PR TITLE
Include Vespa error message in custom error raised

### DIFF
--- a/vespa/exceptions.py
+++ b/vespa/exceptions.py
@@ -1,2 +1,2 @@
 class VespaError(Exception):
-    pass
+    """Vespa returned an error response"""

--- a/vespa/exceptions.py
+++ b/vespa/exceptions.py
@@ -1,0 +1,2 @@
+class VespaError(Exception):
+    pass

--- a/vespa/test_integration_docker.py
+++ b/vespa/test_integration_docker.py
@@ -24,6 +24,7 @@ from vespa.package import (
 )
 from vespa.deployment import VespaDocker
 from vespa.application import VespaSync
+from vespa.exceptions import VespaError
 
 
 CONTAINER_STOP_TIMEOUT = 10
@@ -210,7 +211,7 @@ class TestDockerCommon(unittest.TestCase):
     def redeploy_with_application_package_changes(self, application_package):
         self.vespa_docker = VespaDocker(port=8089)
         app = self.vespa_docker.deploy(application_package=application_package)
-        with pytest.raises(HTTPError):
+        with pytest.raises(VespaError):
             app.query(
                 body={
                     "yql": "select * from sources * where default contains 'music'",


### PR DESCRIPTION
## Summary

This PR allows including error messages when `HTTPError` occurs.

## Context

When we receive an unsuccessful HTTP status code, we currently raise HTTPError. However, the error object only contains a general message such as `Client Error: Bad Request` for a status code 400, and doesn't include the error messages from Vespa. This can make it difficult for callers to identify the cause of the error.

In this PR, I have included additional error information in the error message to help callers diagnose the issue more easily.

The previous discussion is here: https://github.com/vespa-engine/pyvespa/pull/494

## Issue

Calling `response.raise_for_status()` raises `HTTPError` as shown below.

```python
if 400 <= self.status_code < 500:
    http_error_msg = (
        f"{self.status_code} Client Error: {reason} for url: {self.url}"
    )

elif 500 <= self.status_code < 600:
    http_error_msg = (
        f"{self.status_code} Server Error: {reason} for url: {self.url}"
    )

if http_error_msg:
    raise HTTPError(http_error_msg, response=self)
```

_https://github.com/psf/requests/blob/main/requests/models.py#L994-L1021_

Although it includes `status_code`, `reason`, and `url`, it doesn't include the response body. The following is an example response body for a 400 error.

```python
{
  'root': {
    'id': 'toplevel',
    'relevance': 1.0,
    'fields': {
      'totalCount': 0
    },
    'errors': [
      {
        'code': 4,
        'summary': 'Invalid query parameter',
        'message': "Could not resolve source ref 'typo'. Valid source refs are amazon_content."
      }
    ]
  }
}
```

I had to consider how to pass on this message to the callers.

## Proposal: Raising a custom error

I added a custom error called `vespa.expections.VespaError`. This error is raised from `HTTPError` _when the response has `response_json["root"]["errors"]`_ so we can preserve both pieces of information. I suppose that the response body can be non-JSON in some cases. So I checked the following cases:

| status code | response body |  HTTPError | VespaError |
|:---|:---|:---|:---|
| successful | - | not raised | not raised |
| successful | `root.errors` is present | not raised | not raised |
| unsuccessful | - | raised | not raised |
| unsuccessful | `root.errors` is empty | raised | not raised |
| unsuccessful | `root.errors` is present | raised | raised |

`VespaError` itself may be a general error, and we may want to define more specific error types later like [`requests.exceptions`](https://github.com/psf/requests/blob/main/requests/exceptions.py).

## Sanity Check

I installed `pyvespa` with `--editable` into [my project](https://github.com/rejasupotaro/amazon-product-search).

```shell
$ poetry add --editable ../pyvespa

Updating dependencies
Resolving dependencies... (2.2s)

Writing lock file

Package operations: 0 installs, 1 update, 0 removals
```

Then, I intentionally ran defective code.

<details>

<summary>Result</summary>

```shell
$ poetry run inv vespa.search
query: query
Traceback (most recent call last):
  File "/Users/kentaro-takiguchi/projects/pyvespa/vespa/application.py", line 70, in raise_for_status
    response.raise_for_status()
  File "/Users/kentaro-takiguchi/projects/amazon-product-search/.venv/lib/python3.10/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: http://localhost:8080/search/

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/kentaro-takiguchi/projects/amazon-product-search/.venv/bin/inv", line 8, in <module>
    sys.exit(program.run())
  File "/Users/kentaro-takiguchi/projects/amazon-product-search/.venv/lib/python3.10/site-packages/invoke/program.py", line 384, in run
    self.execute()
  File "/Users/kentaro-takiguchi/projects/amazon-product-search/.venv/lib/python3.10/site-packages/invoke/program.py", line 569, in execute
    executor.execute(*self.tasks)
  File "/Users/kentaro-takiguchi/projects/amazon-product-search/.venv/lib/python3.10/site-packages/invoke/executor.py", line 129, in execute
    result = call.task(*args, **call.kwargs)
  File "/Users/kentaro-takiguchi/projects/amazon-product-search/.venv/lib/python3.10/site-packages/invoke/tasks.py", line 127, in __call__
    result = self.body(*args, **kwargs)
  File "/Users/kentaro-takiguchi/projects/amazon-product-search/tasks/vespa_tasks.py", line 45, in search
    res = client.search(query)
  File "/Users/kentaro-takiguchi/projects/amazon-product-search/src/amazon_product_search/vespa/vespa_client.py", line 44, in search
    return self.vespa_app.query(query)
  File "/Users/kentaro-takiguchi/projects/pyvespa/vespa/application.py", line 248, in query
    return sync_app.query(
  File "/Users/kentaro-takiguchi/projects/pyvespa/vespa/application.py", line 885, in query
    raise_for_status(response)
  File "/Users/kentaro-takiguchi/projects/pyvespa/vespa/application.py", line 79, in raise_for_status
    raise VespaError(errors) from http_error
vespa.exceptions.VespaError: [{'code': 4, 'summary': 'Invalid query parameter', 'message': "Could not resolve source ref 'typo'. Valid source refs are amazon_content."}]
```

</details>

I confirmed that `VespaError` was raised along with `HTTPError`.