### PR TITLE
Support setting default stemming of Schema

### DIFF
--- a/vespa/package.py
+++ b/vespa/package.py
@@ -1098,6 +1098,7 @@ class Schema(object):
         global_document: bool = False,
         imported_fields: Optional[List[ImportedField]] = None,
         document_summaries: Optional[List[DocumentSummary]] = None,
+        stemming: Optional[str] = None,
     ) -> None:
         """
         Create a Vespa Schema.
@@ -1113,11 +1114,12 @@ class Schema(object):
         :param global_document: Set to True to copy the documents to all content nodes. Default to False.
         :param imported_fields: A list of :class:`ImportedField` defining fields from global documents to be imported.
         :param document_summaries: A list of :class:`DocumentSummary` associated with the schema.
+        :param stemming: The default stemming setting. Defaults to 'best'.
 
         To create a Schema:
 
         >>> Schema(name="schema_name", document=Document())
-        Schema('schema_name', Document(None, None, None), None, None, [], False, None, [])
+        Schema('schema_name', Document(None, None, None), None, None, [], False, None, [], None)
         """
         self.name = name
         self.document = document
@@ -1145,6 +1147,8 @@ class Schema(object):
         self.document_summaries = (
             [] if document_summaries is None else list(document_summaries)
         )
+
+        self.stemming = stemming
 
     def add_fields(self, *fields: Field) -> None:
         """
@@ -1217,6 +1221,7 @@ class Schema(object):
             models=self.models,
             imported_fields=self.imported_fields,
             document_summaries=self.document_summaries,
+            stemming=self.stemming,
         )
 
     def __eq__(self, other):
@@ -1231,10 +1236,11 @@ class Schema(object):
             and self.global_document == other.global_document
             and self.imported_fields == other.imported_fields
             and self.document_summaries == other.document_summaries
+            and self.stemming == other.stemming
         )
 
     def __repr__(self):
-        return "{0}({1}, {2}, {3}, {4}, {5}, {6}, {7}, {8})".format(
+        return "{0}({1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9})".format(
             self.__class__.__name__,
             repr(self.name),
             repr(self.document),
@@ -1254,6 +1260,7 @@ class Schema(object):
                 else None
             ),
             repr(self.document_summaries),
+            repr(self.stemming),
         )
 
 
@@ -1526,7 +1533,7 @@ class ApplicationPackage(object):
         The easiest way to get started is to create a default application package:
 
         >>> ApplicationPackage(name="testapp")
-        ApplicationPackage('testapp', [Schema('testapp', Document(None, None, None), None, None, [], False, None, [])], QueryProfile(None), QueryProfileType(None))
+        ApplicationPackage('testapp', [Schema('testapp', Document(None, None, None), None, None, [], False, None, [], None)], QueryProfile(None), QueryProfileType(None))
 
         It will create a default :class:`Schema`, :class:`QueryProfile` and :class:`QueryProfileType` that you can then
         populate with specifics of your application.

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -1200,7 +1200,7 @@ class Schema(object):
         self.document_summaries.append(document_summary)
 
     @property
-    def schema_to_text(self):
+    def schema_to_text(self) -> str:
         env = Environment(
             loader=PackageLoader("vespa", "templates"),
             autoescape=select_autoescape(
@@ -1224,9 +1224,9 @@ class Schema(object):
             stemming=self.stemming,
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         return (
             self.name == other.name
             and self.document == other.document
@@ -1239,7 +1239,7 @@ class Schema(object):
             and self.stemming == other.stemming
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "{0}({1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9})".format(
             self.__class__.__name__,
             repr(self.name),

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -1086,6 +1086,8 @@ class OnnxModel(object):
             repr(self.outputs),
         )
 
+class SchemaConfiguration(TypedDict, total=False):
+    stemming: Optional[str]
 
 class Schema(object):
     def __init__(
@@ -1098,7 +1100,7 @@ class Schema(object):
         global_document: bool = False,
         imported_fields: Optional[List[ImportedField]] = None,
         document_summaries: Optional[List[DocumentSummary]] = None,
-        stemming: Optional[str] = None,
+        **kwargs: Unpack[SchemaConfiguration],
     ) -> None:
         """
         Create a Vespa Schema.
@@ -1114,7 +1116,7 @@ class Schema(object):
         :param global_document: Set to True to copy the documents to all content nodes. Default to False.
         :param imported_fields: A list of :class:`ImportedField` defining fields from global documents to be imported.
         :param document_summaries: A list of :class:`DocumentSummary` associated with the schema.
-        :param stemming: The default stemming setting. Defaults to 'best'.
+        :key stemming: The default stemming setting. Defaults to 'best'.
 
         To create a Schema:
 
@@ -1148,7 +1150,7 @@ class Schema(object):
             [] if document_summaries is None else list(document_summaries)
         )
 
-        self.stemming = stemming
+        self.stemming = kwargs.get("stemming", None)
 
     def add_fields(self, *fields: Field) -> None:
         """

--- a/vespa/templates/schema.txt
+++ b/vespa/templates/schema.txt
@@ -1,4 +1,7 @@
 schema {{ schema_name }} {
+{% if stemming %}
+    stemming: {{ stemming }}
+{% endif %}
     document {{ document_name }}{% if document.inherits %} inherits {{ document.inherits }}{% endif %} {
     {% for field in document.fields %}
         field {{ field.name }} type {{ field.type }} {


### PR DESCRIPTION
This adds support for setting the default stemming of a schema by adding
a 'stemming: <stemming-type>' to the root of the schema, as described in https://docs.vespa.ai/en/reference/schema-reference.html#schema

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
