### PR TITLE
Improvements and Fixes to Validation-Overrides

### DIFF
--- a/vespa/package.py
+++ b/vespa/package.py
@@ -1495,7 +1495,7 @@ class Validation(object):
         """
         self.id = validation_id
         self.until = until
-        self.comment = comment if comment is not None else str()
+        self.comment = comment
 
 
 class ApplicationPackage(object):

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -1787,6 +1787,10 @@ class ApplicationPackage(object):
                     output_path=os.path.join(root, "models/{}.onnx".format(model_id))
                 )
 
+        if self.validations:
+            with open(os.path.join(root, "validation-overrides.xml"), "w") as f:
+                f.write(self.validations_to_text)
+
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return False

--- a/vespa/templates/validation-overrides.xml
+++ b/vespa/templates/validation-overrides.xml
@@ -1,7 +1,7 @@
 <validation-overrides>
     {% if validations %}
     {% for validation in validations %}
-    <allow until="{{ validation.until }}" comment="{{ validation.comment }}">{{ validation.id }}</allow>
+    <allow until="{{ validation.until }}"{% if validation.comment %} comment="{{ validation.comment }}"{% endif %}>{{ validation.id }}</allow>
     {% endfor %}
     {% endif %}
 </validation-overrides>


### PR DESCRIPTION
Commits contain full explanations:

1. Fix bug with missing validation-overrides.xml when using to_files()
2. Don't make :comment: an empty string and then render as comment="", just keep as None and don't try rendering it
3. Add an Enum that contains all known Validation IDs and check Validation against it, keep accepting a string for backwards compat and custom vespas

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
