### PR TITLE
Use cert/key generated by 'vespa auth cert' instead of regenerating each deployment

### DIFF
--- a/vespa/deployment.py
+++ b/vespa/deployment.py
@@ -378,8 +378,8 @@ class VespaCloud(object):
                 serialization.PublicFormat.SubjectPublicKeyInfo,
             )
         )
-        self.cert_path = None
-        self.key_path = None
+        self.data_cert_path = None
+        self.data_key_path = None
         self.data_key, self.data_certificate = self._load_certificate_pair()
         self.connection = http.client.HTTPSConnection(
             "api.vespa-external.aws.oath.cloud", 4443
@@ -404,76 +404,46 @@ class VespaCloud(object):
             raise TypeError("Key must be an elliptic curve private key")
         return key
 
-    def _write_private_key_and_cert(
-        self, key: ec.EllipticCurvePrivateKey, cert: x509.Certificate, disk_folder: str
-    ) -> None:
-        cert_file = os.path.join(disk_folder, self.private_cert_file_name)
-        with open(cert_file, "w+") as file:
-            file.write(
-                key.private_bytes(
-                    serialization.Encoding.PEM,
-                    serialization.PrivateFormat.TraditionalOpenSSL,
-                    serialization.NoEncryption(),
-                ).decode("UTF-8")
-            )
-            file.write(cert.public_bytes(serialization.Encoding.PEM).decode("UTF-8"))
-
-    @staticmethod
-    def _create_certificate_pair() -> Tuple[ec.EllipticCurvePrivateKey, x509.Certificate]:
-        key = ec.generate_private_key(ec.SECP384R1, default_backend())
-        name = x509.Name([x509.NameAttribute(x509.NameOID.COMMON_NAME, u"localhost")])
-        certificate = (
-            x509.CertificateBuilder()
-            .subject_name(name)
-            .issuer_name(name)
-            .serial_number(x509.random_serial_number())
-            .not_valid_before(datetime.utcnow() - timedelta(minutes=1))
-            .not_valid_after(datetime.utcnow() + timedelta(days=7))
-            .public_key(key.public_key())
-            .sign(key, hashes.SHA256(), default_backend())
-        )
-        return key, certificate
-    
     def _load_certificate_pair(self) -> Tuple[ec.EllipticCurvePrivateKey, x509.Certificate]:
         cert_file_name = 'data-plane-public-cert.pem'
         key_file_name = 'data-plane-private-key.pem'
-        
-        # Try to look in application root first, assuming working directory is root
+
+        # Try to look in application root first, assuming working directory is the same as application root
         vespa_dir = Path.cwd() / '.vespa'
         cert_path = vespa_dir / cert_file_name
         key_path = vespa_dir / key_file_name
-        if (cert_path.exists() and key_path.exists()):
+        if cert_path.exists() and key_path.exists():
             cert = str(cert_path)
             key = str(key_path)
         else:
-            # If cert/key not found in application root: look in ~/.vespa/project_name/        
+            # If cert/key not found in application root: look in ~/.vespa/tenant.app.default/
             home_dir = Path.home()
             vespa_dir = home_dir / '.vespa' / f"{self.tenant}.{self.application_package.name}.default" # TODO Support other instance names
             cert_path = vespa_dir / cert_file_name
             key_path = vespa_dir / key_file_name
 
             if not (cert_path.exists() and key_path.exists()):
-                raise FileNotFoundError(f"Certificate and key not found. Please generate with 'vespa auth cert'")        
-                  
-        self.cert_path = str(cert_path)
-        self.key_path= str(key_path)
+                raise FileNotFoundError(f"Certificate and key not found. Please generate with 'vespa auth cert'")
 
-        # Read private key from file
-        with open(key_path, "rb") as key_file: 
-         private_key = serialization.load_pem_private_key( 
-             key_file.read(), 
-             password=None, 
-             backend=default_backend() 
-         ) 
+        self.data_cert_path = str(cert_path)
+        self.data_key_path= str(key_path)
 
-        # Read public certificate from file
-        with open(cert_path, "rb") as cert_file: 
-         cert = x509.load_pem_x509_certificate( 
-             cert_file.read(), 
-             default_backend() 
-         ) 
+        # Read contents of private key from file
+        with open(self.data_key_path, "rb") as key_file:
+            private_key = serialization.load_pem_private_key(
+                key_file.read(),
+                password=None,
+                backend=default_backend()
+            )
 
-        return private_key, cert 
+        # Read contents of public certificate from file
+        with open(self.data_cert_path, "rb") as cert_file:
+            cert = x509.load_pem_x509_certificate(
+                cert_file.read(),
+                default_backend()
+            )
+
+        return private_key, cert
 
     def _request(
         self, method: str, path: str, body: BytesIO = BytesIO(), headers={}
@@ -592,13 +562,7 @@ class VespaCloud(object):
             )
         )
 
-        #Path(disk_folder).mkdir(parents=True, exist_ok=True)
-
         application_zip_bytes = self._to_application_zip(disk_folder=disk_folder)
-
-        #self._write_private_key_and_cert(
-        #    self.data_key, self.data_certificate, disk_folder
-        #)
 
         response = self._request(
             "POST",
@@ -692,8 +656,8 @@ class VespaCloud(object):
         endpoint_url = self._get_endpoint(instance=instance, region=region)
         app = Vespa(
             url=endpoint_url,
-            cert=self.cert_path,
-            key=self.key_path,
+            cert=self.data_cert_path,
+            key=self.data_key_path,
             application_package=self.application_package,
         )
         app.wait_for_application_up(max_wait=APP_INIT_TIMEOUT)

--- a/vespa/deployment.py
+++ b/vespa/deployment.py
@@ -417,8 +417,7 @@ class VespaCloud(object):
             key = str(key_path)
         else:
             # If cert/key not found in application root: look in ~/.vespa/tenant.app.default/
-            home_dir = Path.home()
-            vespa_dir = home_dir / '.vespa' / f"{self.tenant}.{self.application_package.name}.default" # TODO Support other instance names
+            vespa_dir = Path.home() / '.vespa' / f"{self.tenant}.{self.application_package.name}.default" # TODO Support other instance names
             cert_path = vespa_dir / cert_file_name
             key_path = vespa_dir / key_file_name
 


### PR DESCRIPTION
Pyvespa used to make a new cert/key pair each time an app was deployed.
This pair was different than the one made by 'vespa auth cert', which meant that you could not use CLI commands to interact with an app deployed with pyvespa.
The PR makes pyvespa look for an existing pair in either the local .vespa directory (in application root), or in ~/.vespa.
If it can't find any, the deployment fails.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
