### PR TITLE
Tmaregge/cloud deploy from disk

### DIFF
--- a/vespa/application.py
+++ b/vespa/application.py
@@ -218,10 +218,6 @@ class Vespa(object):
         """
         endpoint = "{}/ApplicationStatus".format(self.end_point)
 
-        print(f"{endpoint = }")
-        print(f"{self.cert = }")
-        print(f"{self.key = }")
-
         try:
             if self.key:
                 response = requests.get(endpoint, cert=(self.cert, self.key))
@@ -231,7 +227,6 @@ class Vespa(object):
             print(f"ConnectionError: {e}")
             response = None
 
-        print(f"{response = }")
         return response
 
     def get_model_endpoint(self, model_id: Optional[str] = None) -> Optional[Response]:

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -223,8 +223,7 @@ class Vespa(object):
                 response = requests.get(endpoint, cert=(self.cert, self.key))
             else:
                 response = requests.get(endpoint, cert=self.cert)
-        except ConnectionError as e:
-            print(f"ConnectionError: {e}")
+        except ConnectionError:
             response = None
 
         return response

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -217,13 +217,21 @@ class Vespa(object):
         :return:
         """
         endpoint = "{}/ApplicationStatus".format(self.end_point)
+
+        print(f"{endpoint = }")
+        print(f"{self.cert = }")
+        print(f"{self.key = }")
+
         try:
             if self.key:
                 response = requests.get(endpoint, cert=(self.cert, self.key))
             else:
                 response = requests.get(endpoint, cert=self.cert)
-        except ConnectionError:
+        except ConnectionError as e:
+            print(f"ConnectionError: {e}")
             response = None
+
+        print(f"{response = }")
         return response
 
     def get_model_endpoint(self, model_id: Optional[str] = None) -> Optional[Response]:


### PR DESCRIPTION
Commit 1 implements a method to deploy to Vespa Cloud from an application package located on disk. This was already supported for Docker deployments, but not for cloud.

Commit 4 makes a base class for shared functionality between VespaDocker and VespaCloud to reduce duplication.

Commit 5 rearranges the order of the methods in deployment.py to improve readability without changing the functionality of the program. Previously, public and private methods were declared here and there, seemingly randomly. Now, the order is: magic methods, public methods, private methods.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
