### PR TITLE
Major update

### DIFF
--- a/docs/sphinx/source/query.ipynb
+++ b/docs/sphinx/source/query.ipynb
@@ -55,6 +55,7 @@
    "source": [
     "from vespa.application import Vespa\n",
     "from vespa.io import VespaQueryResponse\n",
+    "from vespa.exceptions import VespaError\n",
     "\n",
     "app = Vespa(url=\"https://api.cord19.vespa.ai\")"
    ]
@@ -85,7 +86,8 @@
     "    hits=1, \n",
     "    query=\"Is remdesivir an effective treatment for COVID-19?\", \n",
     "    ranking=\"bm25\")\n",
-    "  print(response.is_successfull())\n"
+    "  print(response.is_successfull())\n",
+    "  print(response.url)\n"
    ]
   },
   {
@@ -208,7 +210,58 @@
     "## Error handling\n",
     "\n",
     "Vespa's default query timeout is 500ms, PyVespa will by default retry up to 3 times for queries\n",
-    "that return response codes like 429, 500,503 and 504. A `VespaError` is raised if retries did not end up with success. \n"
+    "that return response codes like 429, 500,503 and 504. A `VespaError` is raised if retries did not end up with success. In the following\n",
+    "example we set a very low [timeout](https://docs.vespa.ai/en/reference/query-api-reference.html#timeout) of `1ms` which will cause \n",
+    "Vespa to time out the request and it returns a 504 http error code. The underlaying error is wrapped in a `VespaError` with\n",
+    "the payload error message returned from Vespa:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with app.syncio(connections=12) as session:\n",
+    "    try:\n",
+    "        response:VespaQueryResponse = session.query(hits=1,\n",
+    "            body = {\n",
+    "                \"yql\": \"select * from sources * where userQuery()\", \n",
+    "                \"query\": \"Is remdesivir an effective treatment for COVID-19?\", \n",
+    "                \"timeout\": \"1ms\"\n",
+    "                }\n",
+    "            )\n",
+    "        print(response.is_successfull())\n",
+    "    except VespaError as e:\n",
+    "        print(str(e))\n",
+    "  \n",
+    "  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the following example we forgot to include the `query` parameter, but still reference it in the yql, this cause a bad client request response (400):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with app.syncio(connections=12) as session:\n",
+    "    try:\n",
+    "        response:VespaQueryResponse = session.query(hits=1,\n",
+    "            body = {\n",
+    "                \"yql\": \"select * from sources * where userQuery()\"\n",
+    "                }\n",
+    "            )\n",
+    "        print(response.is_successfull())\n",
+    "    except VespaError as e:\n",
+    "        print(str(e))\n",
+    "  "
    ]
   },
   {

--- a/docs/sphinx/source/query.ipynb
+++ b/docs/sphinx/source/query.ipynb
@@ -6,10 +6,10 @@
    "source": [
     "![Vespa logo](https://vespa.ai/assets/vespa-logo-color.png)\n",
     "\n",
-    "# Queries\n",
+    "# Querying Vespa\n",
     "\n",
     "This guide goes through how to query a Vespa instance using the Query API\n",
-    "and https://cord19.vespa.ai/ app as an example."
+    "and https://cord19.vespa.ai/ app as an example. "
    ]
   },
   {
@@ -44,7 +44,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Set the query endpoint:"
+    "Connect to a running Vespa instance. "
    ]
   },
   {
@@ -54,6 +54,7 @@
    "outputs": [],
    "source": [
     "from vespa.application import Vespa\n",
+    "from vespa.io import VespaQueryResponse\n",
     "\n",
     "app = Vespa(url=\"https://api.cord19.vespa.ai\")"
    ]
@@ -63,37 +64,38 @@
    "metadata": {},
    "source": [
     "See the [Vespa query language](https://docs.vespa.ai/en/reference/query-api-reference.html)\n",
-    "for the query parameters.\n",
+    "for Vespa query api request parameters.\n",
     "\n",
-    "The [userQuery()](https://docs.vespa.ai/en/reference/query-language-reference.html#userquery)\n",
-    "operator uses the query test from `query`.\n",
+    "The YQL [userQuery()](https://docs.vespa.ai/en/reference/query-language-reference.html#userquery)\n",
+    "operator uses the query read from `query`. The query also specificies to use the app specific [bm25 rank profile](https://docs.vespa.ai/en/reference/bm25.html). The code \n",
+    "uses [context manager](https://realpython.com/python-with-statement/) `with session` statement to make sure that connection pools are released. If\n",
+    "you attempt to make multiple queries, this is important as each query will not have to setup new connections.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "\n",
-    "The query uses the [weakAnd](https://docs.vespa.ai/en/using-wand-with-vespa.html#weakand) query operator\n",
-    "and [bm25 rank profile](https://docs.vespa.ai/en/reference/bm25.html):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "body = {\n",
-    "  'yql':     'select cord_uid, title, abstract from sources * where userQuery()',\n",
-    "  'hits':    5,\n",
-    "  'query':   'Is remdesivir an effective treatment for COVID-19?',\n",
-    "  'type':    'weakAnd',\n",
-    "  'ranking': 'bm25'\n",
-    "}\n",
-    "results = app.query(body=body)\n",
-    "results.number_documents_retrieved"
+    "with app.syncio() as session:\n",
+    "  response:VespaQueryResponse = session.query(\n",
+    "    yql=\"select documentid, cord_uid, title, abstract from sources * where userQuery()\", \n",
+    "    hits=1, \n",
+    "    query=\"Is remdesivir an effective treatment for COVID-19?\", \n",
+    "    ranking=\"bm25\")\n",
+    "  print(response.is_successfull())\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The query specified 5 hits:"
+    "Alternatively, if the native [Vespa query parameter](https://docs.vespa.ai/en/reference/query-api-reference.html) \n",
+    "contains \".\", which cannot be used as a `kwarg`, the parameters can be sent as HTTP POST with \n",
+    "the `body` argument. In this case `ranking` is an alias of `ranking.profile`, but using `ranking.profile` as a `**kwargs` argument is not allowed in python. This\n",
+    "will combine HTTP parameters with a HTTP POST body."
    ]
   },
   {
@@ -102,14 +104,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "len(results.hits)"
+    "with app.syncio() as session:\n",
+    "  response:VespaQueryResponse = session.query(hits=1,\n",
+    "    body = {\n",
+    "        \"yql\": \"select documentid, cord_uid, title, abstract from sources * where userQuery()\", \n",
+    "        \"query\": \"Is remdesivir an effective treatment for COVID-19?\", \n",
+    "        \"ranking.profile\": \"bm25\",\n",
+    "        \"presentation.timing\": True\n",
+    "        }\n",
+    "    )\n",
+    "  print(response.is_successfull())\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Iterate over `results.hits`:"
+    "The query specified that we wanted one hit:"
    ]
   },
   {
@@ -118,14 +129,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "[hit[\"fields\"][\"cord_uid\"] for hit in results.hits]"
+    "response.hits"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Get a specific hit:"
+    "Example of iterating over the returned hits obtained from `respone.hits`, extracting the `cord_uid` field:"
    ]
   },
   {
@@ -134,15 +145,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results.hits[0]"
+    "[hit[\"fields\"][\"cord_uid\"] for hit in response.hits]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Access the full response in the\n",
-    "[default result format](https://docs.vespa.ai/en/reference/default-result-format.html):"
+    "Access the full JSON response in the Vespa\n",
+    "[default JSON result format](https://docs.vespa.ai/en/reference/default-result-format.html):"
    ]
   },
   {
@@ -151,7 +162,53 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results.json"
+    "response.json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Query Performance\n",
+    "\n",
+    "There are several things that impact end-to-end query performance\n",
+    "\n",
+    "- HTTP layer performance, connecting handling, mututal TLS handshake and network round-trip latency \n",
+    "  - Make sure to re-use connections using context manager `with vespa.app.syncio():` to avoid setting up new connections\n",
+    "  for every unique query. See [http best practises](https://cloud.vespa.ai/en/http-best-practices)\n",
+    "  - The size of the fields and the number of hits requested also greatly impacts network performance, a larger payload means higher latency. \n",
+    "  - By adding `\"presentation.timing\": True` as a request parameter, the Vespa response includes the server side processing (also including reading the query \n",
+    "  from network, but not delivering the result over the network). This can be handy to debug latency. \n",
+    "- Vespa performance, the features used inside the Vespa instance. \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with app.syncio(connections=12) as session:\n",
+    "  response:VespaQueryResponse = session.query(hits=1,\n",
+    "    body = {\n",
+    "        \"yql\": \"select documentid, cord_uid, title, abstract from sources * where userQuery()\", \n",
+    "        \"query\": \"Is remdesivir an effective treatment for COVID-19?\", \n",
+    "        \"ranking.profile\": \"bm25\",\n",
+    "        \"presentation.timing\": True\n",
+    "        }\n",
+    "    )\n",
+    "  print(response.is_successfull())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Error handling\n",
+    "\n",
+    "Vespa's default query timeout is 500ms, PyVespa will by default retry up to 3 times for queries\n",
+    "that return response codes like 429, 500,503 and 504. A `VespaError` is raised if retries did not end up with success. \n"
    ]
   },
   {
@@ -168,7 +225,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.11.4 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -183,6 +240,11 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.4"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
+   }
   }
  },
  "nbformat": 4,

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -22,7 +22,7 @@ jobs:
           dnf install -y python38-pip
           dnf install -y --enablerepo=powertools pandoc
           python3 -m pip install --upgrade pip
-          python3 -m pip install pytest notebook nbconvert
+          python3 -m pip install pytest notebook nbconvert requests_mock
           python3 -m pip install -e .[full]
           python3 -m pip install -r docs/sphinx/source/requirements.txt
           python3 -m pip install -r docs/sphinx/source/notebook_requirements.txt

--- a/vespa/io.py
+++ b/vespa/io.py
@@ -1,10 +1,13 @@
 from typing import Optional, Dict, List
-
+import warnings
 from pandas import DataFrame
 
 
 class VespaResponse(object):
-    def __init__(self, json, status_code, url, operation_type) -> None:
+    """
+    Class to represent a Vespa HTTP API response.
+    """
+    def __init__(self, json:Dict, status_code:int, url:str, operation_type:str) -> None:
         self.json = json
         self.status_code = status_code
         self.url = url
@@ -20,10 +23,16 @@ class VespaResponse(object):
             and self.operation_type == other.operation_type
         )
 
-    def get_status_code(self):
+    def get_status_code(self) -> int:
+        """Return status code of the response."""
         return self.status_code
 
-    def get_json(self):
+    def is_successfull(self) -> bool:
+        """True if status code is 200."""
+        return self.status_code == 200
+
+    def get_json(self) -> Dict:
+        """Return json of the response."""
         return self.json
 
 
@@ -31,7 +40,7 @@ def trec_format(
     vespa_result, id_field: Optional[str] = None, qid: int = 0
 ) -> DataFrame:
     """
-    Function to format Vespa output according to TREC format.
+    [Deprecated] Function to format Vespa output according to TREC format.
 
     TREC format include qid, doc_id, score and rank.
 
@@ -40,6 +49,10 @@ def trec_format(
     :param qid: custom query id.
     :return: pandas DataFrame with columns qid, doc_id, score and rank.
     """
+    warnings.warn(
+        "trec_format is deprecated and will be removed in a future version. No replacement is planned.",
+        DeprecationWarning
+    )
     hits = vespa_result.get("root", {}).get("children", [])
     records = []
     for rank, hit in enumerate(hits):
@@ -71,12 +84,16 @@ class VespaQueryResponse(VespaResponse):
 
     def get_hits(self, format_function=trec_format, **kwargs) -> DataFrame:
         """
-        Get Vespa hits according to `format_function` format.
+        [Deprecated] Get Vespa hits according to `format_function` format.
 
         :param format_function: function to format the raw Vespa result. Should take raw vespa result as first argument.
         :param kwargs: Extra arguments to be passed to `format_function`.
         :return: Output of the `format_function`.
         """
+        warnings.warn(
+            "get_hits is deprecated and will be removed in a future version. No replacement is planned.",
+            DeprecationWarning
+        )
         if not format_function:
             return self.hits
         return format_function(self.json, **kwargs)
@@ -91,18 +108,10 @@ class VespaQueryResponse(VespaResponse):
             self.json.get("root", {}).get("coverage", {}).get("documents", 0)
         )
 
-    def get_json(self):
+    def get_json(self) -> Dict:
         """
         For debugging when the response does not have hits.
 
         :return: JSON object with full response
         """
         return self.json
-
-    def get_status_code(self):
-        """
-        For debugging when the response does not have hits.
-
-        :return: HTTP status code
-        """
-        return self.status_code


### PR DESCRIPTION
- Deprecate batch APIs
- Do not throw on retry errors without capturing actual error. Previously any retry error would just throw and making it difficult to assess the actual reason such as out of storage, issues in the feed or a query timeout. 
- More unit tests 
- Saner default connections for Vespa:query operations where you only have a single request and no reason for setting up a large connection pool
- `*kwargs` for query and document v1 API to send valid parameters directly 
- fix bug limiting the throughput of feed_iterable. 


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
