### PR TITLE
Remove pandas dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setuptools.setup(
     include_package_data=True,
     install_requires=[
         "requests",
-        "pandas",
         "docker",
         "jinja2",
         "cryptography",


### PR DESCRIPTION
Remove unused dependency on pandas ref https://github.com/vespa-engine/pyvespa/issues/647

grep and git-grep found no uses of pandas in library code.
The tests are unaffected.


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
