### PR TITLE
Call the callback function without using keyword argument

### DIFF
--- a/vespa/application.py
+++ b/vespa/application.py
@@ -306,15 +306,15 @@ class Vespa(object):
                 schema=schema, data_id=data_id, fields=fields, namespace=namespace, groupname=groupname, **kwargs
             )
    
-    def feed_iterable(self, 
-        iter:Iterable[Dict], 
-        schema:Optional[str] = None, 
-        namespace:Optional[str] = None, 
-        callback:Optional[Callable] = None, 
-        operation_type:Optional[str] = "feed",
-        max_queue_size:int = 1000,
-        max_workers:int = 8, 
-        max_connections:int = 16,
+    def feed_iterable(self,
+        iter: Iterable[Dict],
+        schema: Optional[str] = None,
+        namespace: Optional[str] = None,
+        callback: Optional[Callable[[VespaResponse, str], None]] = None,
+        operation_type: Optional[str] = "feed",
+        max_queue_size: int = 1000,
+        max_workers: int = 8,
+        max_connections: int = 16,
         **kwargs
     ):
         """
@@ -414,7 +414,7 @@ class Vespa(object):
             except Exception as e:
                 return (id, e)
 
-        def _handle_result_callback(future:Future, callback:Callable):
+        def _handle_result_callback(future: Future, callback: Optional[Callable[[VespaResponse, str], None]]):
             id, response = future.result()
             if isinstance(response, Exception): 
                 response = VespaResponse(

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -423,7 +423,7 @@ class Vespa(object):
                     url="n/a", operation_type=operation_type)
             if callback is not None:    
                 try:
-                    callback(response,id=id)
+                    callback(response, id)
                 except Exception as e:
                     print(f"Exception in user callback for id {id}", file=sys.stderr)
                     traceback.print_exception(type(e), e, e.__traceback__, file=sys.stderr)


### PR DESCRIPTION
## Overview

This PR allows defining the callback function of `feed_iterable` with arbitrary arg names.

## Background

I recently updated pyvespa to 0.39.0 and replaced `feed_batch` with the newly introduced function `feed_iterable`. I called `feed_iterable` for testing and got the error `TypeError: callback() got an unexpected keyword argument 'id'`.

Looking into the implementation, I found that `_handle_result_callback` invokes the callback with `id=id`, which was the cause of my issue.

<img width="560" alt="Screenshot 2023-12-29 at 22 38 35" src="https://github.com/vespa-engine/pyvespa/assets/883148/f0a94178-58a0-416a-bb67-6eeba1e83839">

_☝️ How it occurs_

In Python, `id` is a built-in function ([Built-in Functions — Python 3.12.1 documentation](https://docs.python.org/3/library/functions.html#id)), so I usually refrain from using it as a variable name. I guess others might encounter this error as well

## Solution

I stopped calling the argument of that callback function as a keyword argument. It doesn't change the behavior but would give more flexibility.

<img width="500" alt="Screenshot 2023-12-29 at 22 40 12" src="https://github.com/vespa-engine/pyvespa/assets/883148/c1528312-fdf7-4441-ad76-ef93d25147aa">

---

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.