### PR TITLE
[Don't Merge] Investigating the cause of CI failure

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -8,7 +8,7 @@ shared:
     PYVESPA_VERSION: 0.7
 jobs:
   unit-tests:
-    requires: [~commit,~pr]
+    requires: [~commit]
     annotations:
       screwdriver.cd/timeout: 120
       screwdriver.cd/cpu: HIGH
@@ -44,7 +44,7 @@ jobs:
           pytest tests/unit
 
   integration-except-cloud:
-    requires: [~commit,~pr]
+    requires: [~commit]
     annotations:
       screwdriver.cd/timeout: 120
       screwdriver.cd/cpu: HIGH
@@ -71,7 +71,7 @@ jobs:
           pytest tests/integration/test_integration_docker.py -s -v
 
   notebooks-except-cloud:
-    requires: [~commit,~pr]
+    requires: [~commit]
     annotations:
       screwdriver.cd/timeout: 120
       screwdriver.cd/cpu: HIGH

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -190,7 +190,7 @@ jobs:
           pytest tests/integration/test_integration_vespa_cloud_vector_search.py -s -v
 
   notebooks-cloud:
-    requires: [integration-cloud]
+    requires: [~pr]
     annotations:
       screwdriver.cd/timeout: 120
       screwdriver.cd/cpu: HIGH

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -122,7 +122,7 @@ jobs:
           done
 
   integration-cloud:
-    requires: [~commit]
+    requires: [~commit,~pr]
     annotations:
       screwdriver.cd/timeout: 120
       screwdriver.cd/cpu: HIGH
@@ -190,7 +190,7 @@ jobs:
           pytest tests/integration/test_integration_vespa_cloud_vector_search.py -s -v
 
   notebooks-cloud:
-    requires: [~pr]
+    requires: [integration-cloud]
     annotations:
       screwdriver.cd/timeout: 120
       screwdriver.cd/cpu: HIGH

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -122,7 +122,7 @@ jobs:
           done
 
   integration-cloud:
-    requires: [~commit,~pr]
+    requires: [~commit]
     annotations:
       screwdriver.cd/timeout: 120
       screwdriver.cd/cpu: HIGH

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -71,7 +71,7 @@ jobs:
           pytest tests/integration/test_integration_docker.py -s -v
 
   notebooks-except-cloud:
-    requires: [~commit]
+    requires: [~commit,~pr]
     annotations:
       screwdriver.cd/timeout: 120
       screwdriver.cd/cpu: HIGH


### PR DESCRIPTION
## Overview

I'm investigating the cause of the CI failure on the master branch.

## Notes

CI passes on PRs but fails on the master branch with the following error

```
ImportError                               Traceback (most recent call last)
09:36:26 Cell In[20], line 1
09:36:26 ----> 1 from llama_index.core import BaseRetriever
09:36:26       2 from llama_index.schema import NodeWithScore, QueryBundle, TextNode
09:36:26       3 from llama_index.callbacks.base import CallbackManager
09:36:26 
09:36:26 ImportError: cannot import name 'BaseRetriever' from 'llama_index.core' (/usr/local/lib/python3.8/site-packages/llama_index/core/__init__.py)
09:36:26 ```
```

_https://github.com/vespa-engine/pyvespa/pull/657#issuecomment-1893367857_

It appears that the problematic job `notebooks-cloud` is executed only on the master branch.

![Screenshot 2024-01-16 at 20 08 10](https://github.com/vespa-engine/pyvespa/assets/883148/bab4b11f-d817-4425-a963-d9a6e59e3df7)

`notebooks-cloud` executes the following commands:

```
      - run-notebooks-cloud-related: |
          echo "PATH:"
          echo $PATH
          find docs -name '*cloud*.ipynb' | while read f
          do
            echo "running: runnb --allow-not-trusted $f"
            runnb --allow-not-trusted $f
            if [ $? -ne 0 ]
            then
              exit 1
            fi
          done
```

I ran the `find` command on my machine:

```
$ (.venv) ~/p/pyvespa ❯❯❯ find docs -name '*cloud*.ipynb'
docs/sphinx/source/getting-started-pyvespa-cloud.ipynb
docs/sphinx/source/examples/turbocharge-rag-with-langchain-and-vespa-streaming-mode-cloud.ipynb
docs/sphinx/source/examples/scaling-personal-ai-assistants-with-streaming-mode-cloud.ipynb
docs/sphinx/source/examples/.ipynb_checkpoints/scaling-personal-ai-assistants-with-streaming-mode-cloud-checkpoint.ipynb
```

In the notebook, `!pip3 install -U pyvespa llama-index` runs.

<img width="347" alt="Screenshot 2024-01-16 at 20 11 20" src="https://github.com/vespa-engine/pyvespa/assets/883148/ef3f5d53-5a41-4705-9708-b857ff18876e">

Does `nbnotebook` ignore commands starting with `!`? I converted the notebook into a script to see how is generated.

```
(.venv) ~/p/pyvespa ❯❯❯ cd docs/sphinx/source/examples
(.venv) ~/p/p/d/s/s/examples ❯❯❯ jupyter nbconvert --to script scaling-personal-ai-assistants-with-streaming-mode-cloud.ipynb
[NbConvertApp] Converting notebook scaling-personal-ai-assistants-with-streaming-mode-cloud.ipynb to script
[NbConvertApp] Writing 32082 bytes to scaling-personal-ai-assistants-with-streaming-mode-cloud.py
```

The generated script is as follows:

![Screenshot 2024-01-16 at 20 14 04](https://github.com/vespa-engine/pyvespa/assets/883148/ffdeb296-8456-4307-ab50-524ac61b65d0)

~~It seems there is a discrepancy between the CI env and the notebook env~~

Ah, `requirements.txt` files also exist 💡 

```
$ find ./ -name '*requirements.txt'
.//docs/sphinx/source/requirements.txt
.//docs/sphinx/source/notebook_requirements.txt
```

## 👉 So, what's the root cause?

It turns out that `BaseRetriever` recently moved from `llama_index.core` to `llama_index.core.base_retriever` https://github.com/run-llama/llama_index/blob/main/llama_index/core/base_retriever.py#L20. Simply fixing the path would fix this issue. 

It has become apparent that there are two issues:

- The package versions are not fixed, causing unexpected errors
- It is difficult to replicate errors in `*cloud*.ipynb` as the job is unable to run on PRs

## 👉 Dependency Management

It turns out there are three ways to install dependencies:

- `setup.py`
- `requirements.txt`
- `pip3 install` in notebook

I feel like the dependencies in `requirements.txt` can be moved to `setup.py` and notebooks accordingly.

---

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
