### PR TITLE
Minor fix for dependency management

### DIFF
--- a/docs/sphinx/source/requirements.txt
+++ b/docs/sphinx/source/requirements.txt
@@ -1,4 +1,4 @@
-.[full]
+.[dev]
 sphinx
 ipykernel
 nbsphinx


### PR DESCRIPTION
## Overview

This PR fixes a minor issue in dependency management. More specifically, it replaces `.[full]` with `.[dev]`.

I found this when I was looking into https://github.com/vespa-engine/pyvespa/pull/659

## Context

`pip install -e '.[dev]'` was introduced in https://github.com/vespa-engine/pyvespa/pull/657 but I overlooked the use of `.[full]` in `requirements.txt`.

However, it wouldn't cause an immediate problem for the following reasons:

- Executing `pip install -e '.[full]'` does not raise an error even if `.[full]` is not defined
- In the current settings, dependencies are always installed in the following order

```
# from screwdriver.yaml
python3 -m pip install --upgrade pip
python3 -m pip install -e .[dev]
python3 -m pip install -r docs/sphinx/source/requirements.txt
python3 -m pip install -r docs/sphinx/source/notebook_requirements.txt
```

But I would like to fix it to prevent future confusion.

---

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
