### PR TITLE
Support different deploy environments

### DIFF
--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -25,9 +25,9 @@ from vespa.package import (
     ContainerCluster,
     Parameter,
     ApplicationPackage,
-    AuthClient
+    AuthClient,
+    DeploymentConfiguration
 )
-
 
 class TestField(unittest.TestCase):
     def test_field_name_type(self):
@@ -1413,3 +1413,22 @@ class TestCluster(unittest.TestCase):
             '</services>'
         )
         self.assertEqual(self.app_package.services_to_text, expected_result)
+
+
+class TestDeploymentConfiguration(unittest.TestCase):
+    def test_deployment_to_text(self):
+        deploy_config = DeploymentConfiguration(
+            environment="prod",
+            regions=["aws-us-east-1c", "aws-us-west-2a"]
+        )
+
+        expected_result = (
+            '<deployment version="1.0">\n'
+            '    <prod>\n'
+            '        <region>aws-us-east-1c</region>\n'
+            '        <region>aws-us-west-2a</region>\n'
+            '    </prod>\n'
+            '</deployment>'
+        )
+
+        self.assertEqual(expected_result, deploy_config.deployment_to_text())

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -1422,6 +1422,8 @@ class TestDeploymentConfiguration(unittest.TestCase):
             regions=["aws-us-east-1c", "aws-us-west-2a"]
         )
 
+        app_package = ApplicationPackage(name="test", deployment_config=deploy_config)
+
         expected_result = (
             '<deployment version="1.0">\n'
             '    <prod>\n'
@@ -1431,4 +1433,4 @@ class TestDeploymentConfiguration(unittest.TestCase):
             '</deployment>'
         )
 
-        self.assertEqual(expected_result, deploy_config.deployment_to_text())
+        self.assertEqual(expected_result, app_package.deployment_to_text)

--- a/vespa/deployment.py
+++ b/vespa/deployment.py
@@ -450,7 +450,7 @@ class VespaCloud(VespaDeployment):
         if not disk_folder:
             disk_folder = os.path.join(os.getcwd(), self.application_package.name)
         self.application_package.to_files(disk_folder)
-        
+
         region = self.get_dev_region()
         job = "dev-" + region
         run = self._start_deployment(instance, job, disk_folder, None)
@@ -805,6 +805,10 @@ class VespaCloud(VespaDeployment):
                 "security/clients.pem",
                 self.data_certificate.public_bytes(serialization.Encoding.PEM),
             )
+            if self.application_package.deployment_config:
+                zip_archive.writestr(
+                    "deployment.xml", self.application_package.deployment_to_text
+                )
 
         return buffer
 

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -2032,22 +2032,6 @@ class DeploymentConfiguration(object):
         self.environment = environment
         self.regions = regions
 
-    def deployment_to_text(self):
-        env = Environment(
-            loader=PackageLoader("vespa", "templates"),
-            autoescape=select_autoescape(
-                disabled_extensions=("txt",),
-                default_for_string=True,
-                default=True,
-            ),
-        )
-        env.trim_blocks = True
-        env.lstrip_blocks = True
-        deployment_template = env.get_template("deployment.xml")
-        return deployment_template.render(
-            deployment_config=self  # In order to be able to call to_xml_string from the template
-        )
-
     def to_xml_string(self, indent=1) -> str:
         root = ET.Element(self.environment)
         for region in self.regions:
@@ -2247,6 +2231,21 @@ class ApplicationPackage(object):
         env.lstrip_blocks = True
         validations_template = env.get_template("validation-overrides.xml")
         return validations_template.render(validations=self.validations)
+
+    @property
+    def deployment_to_text(self):
+        env = Environment(
+            loader=PackageLoader("vespa", "templates"),
+            autoescape=select_autoescape(
+                disabled_extensions=("txt",),
+                default_for_string=True,
+                default=True,
+            ),
+        )
+        env.trim_blocks = True
+        env.lstrip_blocks = True
+        deployment_template = env.get_template("deployment.xml")
+        return deployment_template.render(deployment_config=self.deployment_config)
 
     @staticmethod
     def _application_package_file_name(disk_folder):

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -2293,6 +2293,9 @@ class ApplicationPackage(object):
                     self.query_profile_type_to_text,
                 )
 
+            if self.deployment_config:
+                zip_archive.writestr("deployment.xml", self.deployment_to_text)
+
         buffer.seek(0)
         return buffer
 
@@ -2364,6 +2367,10 @@ class ApplicationPackage(object):
         if self.validations:
             with open(os.path.join(root, "validation-overrides.xml"), "w") as f:
                 f.write(self.validations_to_text)
+
+        if self.deployment_config:
+            with open(os.path.join(root, "deployment.xml"), "w") as f:
+                f.write(self.deployment_to_text)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, self.__class__):

--- a/vespa/templates/deployment.xml
+++ b/vespa/templates/deployment.xml
@@ -1,0 +1,5 @@
+<deployment version="1.0">
+    {% autoescape off %}
+    {{ deployment_config.to_xml_string(1) }}
+    {% endautoescape %}
+</deployment>


### PR DESCRIPTION
This PR adds support for specifying deploy environments other than dev.
Currently, a very limited subset of the functionality of deployment.xml is supported (namely regions).

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
