### PR TITLE
Update application package name checks

### DIFF
--- a/vespa/package.py
+++ b/vespa/package.py
@@ -2076,9 +2076,9 @@ class ApplicationPackage(object):
         It will create a default :class:`Schema`, :class:`QueryProfile` and :class:`QueryProfileType` that you can then
         populate with specifics of your application.
         """
-        if not name.isalnum():
+        if not name[0].isalpha() or not name.islower() or not name.isalnum() or not len(name) <= 20:
             raise ValueError(
-                "Application package name can only contain [a-zA-Z0-9], was '{}'".format(
+                "Application name must start with a letter, must be lowercase, can only contain [a-z0-9] and may contain no more than 20 characters, was '{}'".format(
                     name
                 )
             )


### PR DESCRIPTION
This PR adds more checks to make sure the application package name is valid in Vespa.

Previously, some invalid app package names could be used and it would not be noticed until deployment, where it would fail with a content hash mismatch (e.g. [https://github.com/vespa-engine/vespa/issues/30219](https://github.com/vespa-engine/vespa/issues/30219)), which was very confusing.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
