### PR TITLE
More elaborate app package name validation

### DIFF
--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -1306,6 +1306,12 @@ class TestValidAppName(unittest.TestCase):
             ApplicationPackage(name="test_app")
         with pytest.raises(ValueError):
             ApplicationPackage(name="test-app")
+        with pytest.raises(ValueError):
+            ApplicationPackage(name="42testapp")
+        with pytest.raises(ValueError):
+            ApplicationPackage(name="testApp")
+        with pytest.raises(ValueError):
+            ApplicationPackage(name="testapp" + "x" * 20)
 
 
 class TestFieldAlias(unittest.TestCase):

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -2076,9 +2076,9 @@ class ApplicationPackage(object):
         It will create a default :class:`Schema`, :class:`QueryProfile` and :class:`QueryProfileType` that you can then
         populate with specifics of your application.
         """
-        if not name.isalnum():
+        if not (name[0].isalpha() and name.islower() and len(name) <= 20 and name.isalnum()):
             raise ValueError(
-                "Application package name can only contain [a-zA-Z0-9], was '{}'".format(
+                "Application package name must start with a letter, must be lowercase, can only contain [a-z0-9], and may contain no more than 20 characters, was '{}'".format(
                     name
                 )
             )


### PR DESCRIPTION
Implements most changes from [https://github.com/vespa-engine/pyvespa/pull/685](https://github.com/vespa-engine/pyvespa/pull/685) to improve validation of application package names. Support for dashes is not added, as this would affect automatic schema name generation down the line.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
