### PR TITLE
Allow other partial updates than `assign`

### DIFF
--- a/vespa/application.py
+++ b/vespa/application.py
@@ -978,10 +978,9 @@ class VespaSync(object):
         data_id: str,
         fields: Dict,
         create: bool = False,
-        assign: bool = True,
+        auto_assign: bool = True,
         namespace: str = None,
         groupname: str = None,
-        update_operation: Optional[Dict] = None,
         **kwargs,
     ) -> VespaResponse:
         """
@@ -994,8 +993,7 @@ class VespaSync(object):
         :param data_id: Unique id associated with this data point.
         :param fields: Dict containing all the fields you want to update.
         :param create: If true, updates to non-existent documents will create an empty document to update
-        :param assign: If true, the assumes an assignment operation. If set to false, update_operation needs to be set.
-        :param update_operation: The operation to perform (in same format as the content of the 'fields'-property (see https://docs.vespa.ai/en/reference/document-json-format.html). If assign is set to false, this parameter is required.
+        :param auto_assign: Assumes an assignment operation. If set to false, the fields parameter should be a dictionary including the update operation.
         :param namespace: The namespace that we are updating data.
         :param groupname: The groupname used to update data
         :param kwargs: Additional HTTP request parameters (https://docs.vespa.ai/en/reference/document-v1-api-reference.html#request-parameters)
@@ -1009,14 +1007,10 @@ class VespaSync(object):
         end_point = "{}{}?create={}".format(
             self.app.end_point, path, str(create).lower()
         )
-        if assign:
+        if auto_assign:
             vespa_format = {"fields": {k: {"assign": v} for k, v in fields.items()}}
         else:
-            if update_operation is None:
-                raise ValueError(
-                    "update_operation is required when assign is set to False"
-                )
-            vespa_format = {"fields": update_operation}
+            vespa_format = {"fields": fields}
         response = self.http_session.put(end_point, json=vespa_format, params=kwargs)
         raise_for_status(response)
         return VespaResponse(

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -1010,7 +1010,8 @@ class VespaSync(object):
         if auto_assign:
             vespa_format = {"fields": {k: {"assign": v} for k, v in fields.items()}}
         else:
-            vespa_format = {"fields": fields}
+            # Can not send 'id' in fields for partial update
+            vespa_format = {"fields": {k: v for k, v in fields.items() if k != "id"}}
         response = self.http_session.put(end_point, json=vespa_format, params=kwargs)
         raise_for_status(response)
         return VespaResponse(
@@ -1162,6 +1163,7 @@ class VespaAsync(object):
         data_id: str,
         fields: Dict,
         create: bool = False,
+        auto_assign: bool = True,
         namespace: str = None,
         groupname: str = None,
         **kwargs,
@@ -1172,7 +1174,11 @@ class VespaAsync(object):
         end_point = "{}{}?create={}".format(
             self.app.end_point, path, str(create).lower()
         )
-        vespa_format = {"fields": {k: {"assign": v} for k, v in fields.items()}}
+        if auto_assign:
+            vespa_format = {"fields": {k: {"assign": v} for k, v in fields.items()}}
+        else:
+            # Can not send 'id' in fields for partial update
+            vespa_format = {"fields": {k: v for k, v in fields.items() if k != "id"}}
         response = await self.aiohttp_session.put(
             end_point, json=vespa_format, params=kwargs
         )


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Closing #718 

**What`s done?**

- Added `auto_assign`-parameter to `update_data()`-methods for both `VespaSync` and `VespaAsync`.
This is set to `True` by default, so the default behavior will remain the same. 
If `auto_assign` is set to `False`, however, the user can put any update request they want, including arithmetic, tensor operations etc. 
- Added some tests just for demonstration, but considered it infeasible to add tests for all update operations. Also, if request is invalid, the server will inform about this. 

Time spent on the feature: 10%
Time spent on making the tests pass: 90%. 
Hope (and think) I learned something from it. 
