### PR TITLE
734 document v1 paths should be urlencoded

### DIFF
--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -142,9 +142,9 @@ class TestVespa(unittest.TestCase):
 
         self.assertEqual(
             vespa.get_document_v1_path(
-                id="#1", schema="foo", namespace="bar", group="ab"
+                id="mydoc#1", schema="foo", namespace="bar", group="ab"
             ),
-            "/document/v1/bar/foo/group/ab/#1",
+            "/document/v1/bar/foo/group/ab/mydoc%231",
         )
 
     def test_query_token(self):

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -19,6 +19,7 @@ from urllib3.util import Retry
 from tenacity import retry, wait_exponential, stop_after_attempt
 from time import sleep
 from os import environ
+from urllib.parse import quote
 
 from vespa.exceptions import VespaError
 from vespa.io import VespaQueryResponse, VespaResponse
@@ -691,6 +692,8 @@ class Vespa(object):
         :param number: The number of the document
         :return: The path to the document v1 endpoint
         """
+        # Make sure `id` is properly quoted, e.g. myid#123 -> myid%23123
+        id = quote(str(id))
         if not schema:
             print("schema is not provided. Attempting to infer schema name.")
             schema = self._infer_schema_name()


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Closing #734.

Made the function that creates the path do quoting and changed unit test accordingly. 