### PR TITLE
Shorten ID to avoid test crashing

### DIFF
--- a/tests/integration/test_integration_vespa_cloud_vector_search.py
+++ b/tests/integration/test_integration_vespa_cloud_vector_search.py
@@ -243,7 +243,7 @@ class TestProdDeployment(TestVectorSearch):
 
         self.vespa_cloud = VespaCloud(
             tenant="vespa-team",
-            application="pyvespa-int-vsearch-prod",
+            application="pyvespa-int-prod",
             key_content=os.getenv("VESPA_TEAM_API_KEY").replace(r"\n", "\n"),
             application_package=self.app_package,
         )


### PR DESCRIPTION
The old ID was too long.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
