### PR TITLE
Add data plane auth token to integration test

### DIFF
--- a/tests/integration/test_integration_vespa_cloud_vector_search.py
+++ b/tests/integration/test_integration_vespa_cloud_vector_search.py
@@ -246,6 +246,7 @@ class TestProdDeployment(TestVectorSearch):
             application="pyvespa-int-prod",
             key_content=os.getenv("VESPA_TEAM_API_KEY").replace(r"\n", "\n"),
             application_package=self.app_package,
+            auth_client_token_id="pyvespa_integration_msmarco",
         )
         self.disk_folder = os.path.join(os.getenv("WORK_DIR"), "sample_application")
         self.instance_name = "default"


### PR DESCRIPTION
One of the vector search integration tests fails on the CI server. Adding the same auth_client_token_id as for the other test should hopefully fix this.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
