### PR TITLE
Update vespacli workflows

### DIFF
--- a/.github/workflows/vespacli_check_version.yml
+++ b/.github/workflows/vespacli_check_version.yml
@@ -35,7 +35,7 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Update the version (if not NA)
-        if: ${{ (steps.check_latest_version.outputs.version != 'NA') && (github.ref == 'refs/heads/main') }}
+        if: ${{ (steps.check_latest_version.outputs.version != 'NA') && (github.ref == 'refs/heads/master') }}
         run: |
           # Print evaluation of the condition
           echo "Version is not NA, updating version to ${{ steps.check_latest_version.outputs.version }}"
@@ -43,7 +43,7 @@ jobs:
           python utils/update_version.py --version ${{ steps.check_latest_version.outputs.version }}
 
       - name: Commit the changes (if not NA)
-        if: ${{ (steps.check_latest_version.outputs.version != 'NA') && (github.ref == 'refs/heads/main') }}
+        if: ${{ (steps.check_latest_version.outputs.version != 'NA') && (github.ref == 'refs/heads/master') }}
         uses: EndBug/add-and-commit@v9
         with:
           add: |

--- a/.github/workflows/vespacli_release_publish.yml
+++ b/.github/workflows/vespacli_release_publish.yml
@@ -4,12 +4,16 @@ defaults:
   run:
     working-directory: ./vespacli
 
-
 on:
+  workflow_run:
+    workflows: ["vespacli - tests"]
+    branches: [master]
+    types:
+      - completed
   workflow_dispatch:
   # push:
   #   tags:
-  #     - cli-v*.*.* # Push events to matching cv*.*.* tags
+  #     - cli-v*.*.* # Push events to matching cli-v*.*.* tags
 
 jobs:
   prepare-binaries:
@@ -35,7 +39,7 @@ jobs:
           echo "Current version is $version"
           echo "version=$version" >> $GITHUB_ENV
           python utils/download_binaries.py --version $version
-      
+
       - name: Upload binaries as artifact
         uses: actions/upload-artifact@v4
         with:
@@ -69,9 +73,9 @@ jobs:
       - name: Build
         run: |
           python -m build
-      
+
       - name: Upload to PyPI
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN_VESPACLI }}
-        run: twine upload --repository testpypi dist/* --non-interactive
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_VESPACLI }}
+        run: twine upload dist/* --non-interactive

--- a/.github/workflows/vespacli_test.yml
+++ b/.github/workflows/vespacli_test.yml
@@ -1,4 +1,4 @@
-name: vespacli - Cross-Platform build and test
+name: vespacli - tests
 
 defaults:
   run:
@@ -26,7 +26,7 @@ jobs:
           pip install -r requirements_build.txt
           pip install -e .
           python utils/download_binaries.py --version current
-      
+
       - name: Upload binaries as artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Noticed that the workflow didn't complete due to this condition:
`if: ${{ (steps.check_latest_version.outputs.version != 'NA') && (github.ref == 'refs/heads/main') }}`
Considering our main branch is called `master`, that's not so strange. 

Modified  the release workflow to run on test workflow completion (test  is run once a week.)
Could modify to run daily on each new VespaCLI release later if we want to. 