### PR TITLE
Fix commit path workflow

### DIFF
--- a/.github/workflows/vespacli_check_version.yml
+++ b/.github/workflows/vespacli_check_version.yml
@@ -46,9 +46,9 @@ jobs:
         if: ${{ (steps.check_latest_version.outputs.version != 'NA') && (github.ref == 'refs/heads/master') }}
         uses: EndBug/add-and-commit@v9
         with:
-          add: |
-            'pyproject.toml'
-            'vespacli/_version_generated.py'
+          add: | # Action does not use working-directory 
+            'vespacli/pyproject.toml'
+            'vespacli/vespacli/_version_generated.py'
           # Add `cli-vX.Y.Z` tag to the commit
           tag: ${{ format('cli-v{0}', steps.check_latest_version.outputs.version) }}
           default_author: github_actions

--- a/.github/workflows/vespacli_check_version.yml
+++ b/.github/workflows/vespacli_check_version.yml
@@ -38,7 +38,7 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Update the version (if not NA)
-        if: ${{ (steps.check_latest_version.outputs.version != 'NA') && (github.ref == 'refs/heads/master') }}
+        if: ${{ (steps.check_latest_version.outputs.version != 'NA') }} 
         run: |
           # Print evaluation of the condition
           echo "Version is not NA, updating version to ${{ steps.check_latest_version.outputs.version }}"
@@ -46,7 +46,7 @@ jobs:
           python utils/update_version.py --version ${{ steps.check_latest_version.outputs.version }}
 
       - name: Commit the changes (if not NA)
-        if: ${{ (steps.check_latest_version.outputs.version != 'NA') && (github.ref == 'refs/heads/master') }}
+        if: ${{ (steps.check_latest_version.outputs.version != 'NA') }}
         uses: EndBug/add-and-commit@v9
         with:
           add: | # Action does not use working-directory 

--- a/.github/workflows/vespacli_check_version.yml
+++ b/.github/workflows/vespacli_check_version.yml
@@ -6,6 +6,9 @@ defaults:
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - thomasht86/fix-commit-path-workflow # Temporary branch for testing
   schedule:
     - cron: "0 0 * * *" # Runs at 00:00 UTC daily
 

--- a/.github/workflows/vespacli_check_version.yml
+++ b/.github/workflows/vespacli_check_version.yml
@@ -6,9 +6,6 @@ defaults:
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - thomasht86/fix-commit-path-workflow # Temporary branch for testing
   schedule:
     - cron: "0 0 * * *" # Runs at 00:00 UTC daily
 
@@ -38,7 +35,7 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Update the version (if not NA)
-        if: ${{ (steps.check_latest_version.outputs.version != 'NA') }} 
+        if: ${{ (steps.check_latest_version.outputs.version != 'NA') && (github.ref == 'refs/heads/master') }}
         run: |
           # Print evaluation of the condition
           echo "Version is not NA, updating version to ${{ steps.check_latest_version.outputs.version }}"
@@ -46,7 +43,7 @@ jobs:
           python utils/update_version.py --version ${{ steps.check_latest_version.outputs.version }}
 
       - name: Commit the changes (if not NA)
-        if: ${{ (steps.check_latest_version.outputs.version != 'NA') }}
+        if: ${{ (steps.check_latest_version.outputs.version != 'NA') && (github.ref == 'refs/heads/master') }}
         uses: EndBug/add-and-commit@v9
         with:
           add: | # Action does not use working-directory 

--- a/vespacli/pyproject.toml
+++ b/vespacli/pyproject.toml
@@ -8,7 +8,7 @@ description = "A Python wrapper for Vespa CLI tools, supporting multiple platfor
 keywords = [ "vespa", "cli", "wrapper",]
 name = "vespacli"
 readme = "README.md"
-version = "8.328.24"
+version = "8.340.17"
 [[project.authors]]
 name = "Thomas Thoresen"
 email = "thomas@vespa.ai"

--- a/vespacli/vespacli/_version_generated.py
+++ b/vespacli/vespacli/_version_generated.py
@@ -1,1 +1,1 @@
-vespa_version = "8.328.24"  # Automatically updated by github actions bot vespacli/_version_generated.py
+vespa_version = "8.340.17"  # Automatically updated by github actions bot vespacli/_version_generated.py


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Vespacli action did commit files with new version correctly, as the action workflow needed full path to files to update. 
Should work now - tested in [this workflow](https://github.com/vespa-engine/pyvespa/actions/runs/9051111145/job/24867245344). 