### PR TITLE
Expose visit api

### DIFF
--- a/docs/sphinx/source/examples/multi-vector-indexing.ipynb
+++ b/docs/sphinx/source/examples/multi-vector-indexing.ipynb
@@ -1074,6 +1074,7 @@
     "        \"ranking.profile\": \"hybrid\",\n",
     "        \"bolding\": False,\n",
     "        \"presentation.format.tensors\": \"short-value\",\n",
+    "        \"hits\": 1,\n",
     "    }\n",
     ")\n",
     "if len(result.hits) != 1:\n",

--- a/docs/sphinx/source/reads-writes.ipynb
+++ b/docs/sphinx/source/reads-writes.ipynb
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "congressional-friendly",
    "metadata": {},
    "outputs": [],
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "2eff8bc7",
    "metadata": {},
    "outputs": [
@@ -181,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "breeding-steal",
    "metadata": {},
    "outputs": [
@@ -222,7 +222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "b04503d7",
    "metadata": {},
    "outputs": [],
@@ -244,7 +244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "meaning-jamaica",
    "metadata": {},
    "outputs": [],
@@ -261,7 +261,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "98533b40",
    "metadata": {},
    "outputs": [],
@@ -289,7 +289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "03420d2a",
    "metadata": {},
    "outputs": [],
@@ -309,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "d6acf364",
    "metadata": {},
    "outputs": [],
@@ -323,6 +323,84 @@
     "    max_workers=12,\n",
     "    max_connections=12,\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3fc12a46",
+   "metadata": {},
+   "source": [
+    "### Visiting\n",
+    "\n",
+    "Visiting is a feature to efficiently get or process a set of documents, identified by a document selection expression. Visit yields multiple slices (run concurrently) each yielding responses (depending on chunk size). This allows for custom handling of each response. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "7a604ba2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1047\n",
+      "1021\n",
+      "675\n",
+      "1032\n",
+      "1023\n",
+      "667\n",
+      "1020\n",
+      "1014\n",
+      "782\n",
+      "1006\n",
+      "1001\n",
+      "712\n"
+     ]
+    }
+   ],
+   "source": [
+    "for slice in app.visit(\n",
+    "    content_cluster_name=\"vector_content\",\n",
+    "    schema=\"doc\",\n",
+    "    namespace=\"benchmark\",\n",
+    "    selection=\"true\",\n",
+    "    slices=4,\n",
+    "    chunk_size=1000,\n",
+    "):\n",
+    "    for response in slice:\n",
+    "        print(response.number_documents_retrieved)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "2a38a926",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1001\n",
+      "1009\n",
+      "1034\n",
+      "1015\n",
+      "1004\n",
+      "1027\n",
+      "1000\n",
+      "1006\n",
+      "1024\n",
+      "1040\n",
+      "840\n"
+     ]
+    }
+   ],
+   "source": [
+    "for slice in app.visit(content_cluster_name=\"vector_content\", chunk_size=1000):\n",
+    "    for response in slice:\n",
+    "        print(response.number_documents_retrieved)"
    ]
   },
   {
@@ -677,7 +755,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.8.17"
   },
   "vscode": {
    "interpreter": {

--- a/tests/integration/test_integration_docker.py
+++ b/tests/integration/test_integration_docker.py
@@ -266,6 +266,7 @@ class TestApplicationCommon(unittest.TestCase):
         self,
         app,
         schema_name,
+        cluster_name,
         fields_to_send,
         field_to_update,
         expected_fields_from_get_operation,
@@ -326,6 +327,33 @@ class TestApplicationCommon(unittest.TestCase):
                 "pathId": "/document/v1/{}/{}/docid/{}".format(
                     schema_name, schema_name, fields_to_send["id"]
                 ),
+            },
+        )
+
+        #
+        # Visit data
+        visit_results = []
+        for slice in app.visit(
+            schema=schema_name,
+            content_cluster_name=cluster_name,
+            timeout="200s",
+        ):
+            for response in slice:
+                visit_results.append(response)
+
+        self.assertDictEqual(
+            visit_results[0].json,
+            {
+                "pathId": "/document/v1/{}/{}/docid/".format(schema_name, schema_name),
+                "documents": [
+                    {
+                        "id": "id:{}:{}::{}".format(
+                            schema_name, schema_name, fields_to_send["id"]
+                        ),
+                        "fields": expected_fields_from_get_operation,
+                    }
+                ],
+                "documentCount": 1,
             },
         )
 
@@ -909,6 +937,7 @@ class TestMsmarcoApplication(TestApplicationCommon):
         self.execute_data_operations(
             app=self.app,
             schema_name=self.app_package.name,
+            cluster_name=f"{self.app_package.name}_content",
             fields_to_send=self.fields_to_send[0],
             field_to_update=self.fields_to_update[0],
             expected_fields_from_get_operation=self.fields_to_send[0],
@@ -991,6 +1020,7 @@ class TestQaApplication(TestApplicationCommon):
         self.execute_data_operations(
             app=self.app,
             schema_name="sentence",
+            cluster_name="qa_content",
             fields_to_send=self.fields_to_send_sentence[0],
             field_to_update=self.fields_to_update[0],
             expected_fields_from_get_operation=self.expected_fields_from_sentence_get_operation[
@@ -1002,6 +1032,7 @@ class TestQaApplication(TestApplicationCommon):
         self.execute_data_operations(
             app=self.app,
             schema_name="context",
+            cluster_name="qa_content",
             fields_to_send=self.fields_to_send_context[0],
             field_to_update=self.fields_to_update[0],
             expected_fields_from_get_operation=self.fields_to_send_context[0],

--- a/tests/integration/test_integration_vespa_cloud.py
+++ b/tests/integration/test_integration_vespa_cloud.py
@@ -13,7 +13,6 @@ from test_integration_docker import (
     TestApplicationCommon,
     create_msmarco_application_package,
 )
-from pathlib import Path
 
 APP_INIT_TIMEOUT = 900
 
@@ -119,6 +118,7 @@ class TestMsmarcoApplication(TestApplicationCommon):
         self.execute_data_operations(
             app=self.app,
             schema_name=self.app_package.name,
+            cluster_name=f"{self.app_package.name}_content",
             fields_to_send=self.fields_to_send[0],
             field_to_update=self.fields_to_update[0],
             expected_fields_from_get_operation=self.fields_to_send[0],

--- a/tests/integration/test_integration_vespa_cloud_token.py
+++ b/tests/integration/test_integration_vespa_cloud_token.py
@@ -120,6 +120,7 @@ class TestMsmarcoApplicationWithTokenAuth(TestApplicationCommon):
         self.execute_data_operations(
             app=self.app,
             schema_name=self.app_package.name,
+            cluster_name=f"{self.app_package.name}_content",
             fields_to_send=self.fields_to_send[0],
             field_to_update=self.fields_to_update[0],
             expected_fields_from_get_operation=self.fields_to_send[0],
@@ -130,6 +131,7 @@ class TestMsmarcoApplicationWithTokenAuth(TestApplicationCommon):
             self.execute_async_data_operations(
                 app=self.app,
                 schema_name=self.app_package.name,
+                cluster_name=f"{self.app_package.name}_content",
                 fields_to_send=self.fields_to_send,
                 field_to_update=self.fields_to_update[0],
                 expected_fields_from_get_operation=self.fields_to_send,

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -94,6 +94,50 @@ class TestVespaRequestsUsage(unittest.TestCase):
                 timeout="200s",
             )
 
+    def test_visit(self):
+        app = Vespa(url="http://localhost", port=8080)
+        with requests_mock.Mocker() as m:
+            m.get(
+                "http://localhost:8080/document/v1/foo/foo/docid/",
+                [
+                    {"json": {"continuation": "AAA"}, "status_code": 200},
+                    {"json": {}, "status_code": 200},
+                ],
+            )
+
+            results = []
+            for slice in app.visit(
+                schema="foo",
+                namespace="foo",
+                content_cluster_name="content",
+                timeout="200s",
+            ):
+                for response in slice:
+                    results.append(response)
+            assert len(results) == 2
+
+            urls = [response.url for response in results]
+            assert (
+                "http://localhost:8080/document/v1/foo/foo/docid/"
+                "?cluster=content"
+                "&selection=true"
+                "&wantedDocumentCount=500"
+                "&slices=1"
+                "&sliceId=0"
+                "&timeout=200s"
+                "&continuation=AAA"
+            ) in urls
+
+            assert (
+                "http://localhost:8080/document/v1/foo/foo/docid/"
+                "?cluster=content"
+                "&selection=true"
+                "&wantedDocumentCount=500"
+                "&slices=1"
+                "&sliceId=0"
+                "&timeout=200s"
+            ) in urls
+
 
 class TestVespa(unittest.TestCase):
     def test_end_point(self):

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -1,10 +1,41 @@
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 import unittest
-from vespa.io import VespaQueryResponse
+from vespa.io import VespaVisitResponse, VespaQueryResponse
 
 
-class TestVespaResult(unittest.TestCase):
+class TestVespaVisitResult(unittest.TestCase):
+    def setUp(self) -> None:
+        self.raw_vespa_result = {
+            "pathId": "/document/v1/foo/foo/docid/",
+            "documents": [
+                {
+                    "id": "id:foo:foo::01",
+                    "fields": {"id": "01", "desc": "some data for 01"},
+                },
+                {
+                    "id": "id:foo:foo::02",
+                    "fields": {"id": "02", "desc": "some data for 02"},
+                },
+            ],
+            "documentCount": 2,
+            "continuation": "AAA",
+        }
+
+    def test_json(self):
+        vespa_result = VespaVisitResponse(
+            json=self.raw_vespa_result, status_code=None, url=None
+        )
+        self.assertDictEqual(vespa_result.json, self.raw_vespa_result)
+
+    def test_continuation(self):
+        vespa_result = VespaVisitResponse(
+            json=self.raw_vespa_result, status_code=None, url=None
+        )
+        assert vespa_result.continuation == "AAA"
+
+
+class TestVespaQueryResult(unittest.TestCase):
     def setUp(self) -> None:
         self.raw_vespa_result_empty_hits = {
             "root": {

--- a/vespa/io.py
+++ b/vespa/io.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Optional, Dict, List
+from typing import Any, Optional, Dict, List
 
 
 class VespaResponse(object):
@@ -76,3 +76,26 @@ class VespaQueryResponse(VespaResponse):
         :return: JSON object with full response
         """
         return self.json
+
+
+class VespaVisitResponse(VespaResponse):
+    def __init__(self, json, status_code, url) -> None:
+        super().__init__(
+            json=json, status_code=status_code, url=url, operation_type="visit"
+        )
+
+    @property
+    def continuation(self) -> Optional[str]:
+        return self.json.get("continuation")
+
+    @property
+    def path_id(self) -> str:
+        return self.json.get("pathId", "")
+
+    @property
+    def documents(self) -> List[Dict[str, Any]]:
+        return self.json.get("documents", [])
+
+    @property
+    def number_documents_retrieved(self) -> int:
+        return self.json.get("documentCount", 0)


### PR DESCRIPTION
Adds a method that returns a generator which fetches all data across the documents in a vespa instance. Optionally run concurrently by increasing the number of slices, and optionally supply a yql query to filter.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

https://github.com/vespa-engine/pyvespa/issues/711

@thomasht86