### PR TITLE
Bugfix: Remove param from async function

### DIFF
--- a/tests/integration/test_integration_vespa_cloud_token.py
+++ b/tests/integration/test_integration_vespa_cloud_token.py
@@ -131,7 +131,6 @@ class TestMsmarcoApplicationWithTokenAuth(TestApplicationCommon):
             self.execute_async_data_operations(
                 app=self.app,
                 schema_name=self.app_package.name,
-                cluster_name=f"{self.app_package.name}_content",
                 fields_to_send=self.fields_to_send,
                 field_to_update=self.fields_to_update[0],
                 expected_fields_from_get_operation=self.fields_to_send,


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

New parameter introduced for visit in #776 , that should not be added to async operations, making some tests fail.