### PR TITLE
Fix test (kernel died)

### DIFF
--- a/docs/sphinx/source/examples/Matryoshka_embeddings_in_Vespa-cloud.ipynb
+++ b/docs/sphinx/source/examples/Matryoshka_embeddings_in_Vespa-cloud.ipynb
@@ -897,6 +897,9 @@
    "source": [
     "import concurrent.futures\n",
     "\n",
+    "# only embed 100 docs while developing\n",
+    "sample_docs = list(dataset.docs_iter())[:100]\n",
+    "\n",
     "\n",
     "def embed_doc(doc):\n",
     "    embedding = embed(\n",
@@ -914,10 +917,8 @@
     "    }\n",
     "\n",
     "\n",
-    "with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:\n",
-    "    my_docs_to_feed = list(\n",
-    "        executor.map(embed_doc, dataset.docs_iter()[:100])\n",
-    "    )  # only embed 100 docs while developing"
+    "with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:\n",
+    "    my_docs_to_feed = list(executor.map(embed_doc, sample_docs))"
    ]
   },
   {

--- a/docs/sphinx/source/examples/Matryoshka_embeddings_in_Vespa-cloud.ipynb
+++ b/docs/sphinx/source/examples/Matryoshka_embeddings_in_Vespa-cloud.ipynb
@@ -1006,9 +1006,9 @@
     "    schema=\"my_schema\",\n",
     "    iter=vespa_feed(\"\"),\n",
     "    callback=callback,\n",
-    "    max_queue_size=8000,\n",
-    "    max_workers=64,\n",
-    "    max_connections=128,\n",
+    "    max_queue_size=2000,\n",
+    "    max_workers=32,\n",
+    "    max_connections=64,\n",
     ")"
    ]
   },

--- a/docs/sphinx/source/notebook_requirements.txt
+++ b/docs/sphinx/source/notebook_requirements.txt
@@ -10,3 +10,4 @@ ir_datasets
 pytrec_eval
 torch
 numpy
+vespacli


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

2 changes:
1. Add `vespacli` to `notebook_requirements.txt`, so it gets pre-installed on test-runners, reducing execution time of each notebook.
2. Try to fix strange test failure while running https://pyvespa.readthedocs.io/en/latest/examples/Matryoshka_embeddings_in_Vespa-cloud.html by reducing memory usage.

Test fails with
```python
08:04:58 nbclient.exceptions.DeadKernelError: Kernel died 
```
on some of the cells right after Cloud deployment.

This error usually occurs due to exceeding memory resources. 
It is still strange that this would only occur now, with unchanged resource specs. 🤔 