### PR TITLE
Debug CI: Add mem tracking and run in subshell

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -217,7 +217,6 @@ jobs:
           curl -fsSL https://github.com/vespa-engine/vespa/releases/download/v${VESPA_CLI_VERSION}/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64.tar.gz | tar -zxf - -C /opt && \
           ln -sf /opt/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64/bin/vespa /usr/local/bin/
       - run-notebooks-cloud-related: |
-          # Display the PATH environment variable
           echo "PATH:"
           echo $PATH
 

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -219,7 +219,7 @@ jobs:
       - run-notebooks-cloud-related: |
           echo "PATH:"
           echo $PATH
-          find docs -name '*cloud*.ipynb' -not -name 'mother-of-all-embedding-models-cloud.ipynb' | while read f
+          find docs -name '*cloud*.ipynb' -not -name mother-of-all-embedding-models-cloud.ipynb | while read f
           do
             # Display total and free memory in human-readable format before running each notebook
             total_mem=$(free -h | grep Mem | awk '{print $2}')

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -217,14 +217,25 @@ jobs:
           curl -fsSL https://github.com/vespa-engine/vespa/releases/download/v${VESPA_CLI_VERSION}/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64.tar.gz | tar -zxf - -C /opt && \
           ln -sf /opt/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64/bin/vespa /usr/local/bin/
       - run-notebooks-cloud-related: |
+          # Display the PATH environment variable
           echo "PATH:"
           echo $PATH
-          find docs -name '*cloud*.ipynb' -not -name mother-of-all-embedding-models-cloud.ipynb | while read f
+
+          # Find and process specified Jupyter notebooks
+          find docs -name '*cloud*.ipynb' -not -name 'mother-of-all-embedding-models-cloud.ipynb' | while read f
           do
+            # Display total and free memory in human-readable format before running each notebook
+            total_mem=$(free -h | grep Mem | awk '{print $2}')
+            free_mem=$(free -h | grep Mem | awk '{print $4}')
+            echo "Before running $f - Total Memory: $total_mem, Free Memory: $free_mem"
+
+            # Run the notebook in a subshell
             echo "running: runnb --allow-not-trusted $f"
-            runnb --allow-not-trusted $f
+            (runnb --allow-not-trusted $f)
+            # Check the exit status of the last command in the subshell
             if [ $? -ne 0 ]
             then
+              echo "Error running $f"
               exit 1
             fi
           done

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -220,7 +220,6 @@ jobs:
           echo "PATH:"
           echo $PATH
 
-          # Find and process specified Jupyter notebooks
           find docs -name '*cloud*.ipynb' -not -name 'mother-of-all-embedding-models-cloud.ipynb' | while read f
           do
             # Display total and free memory in human-readable format before running each notebook

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -219,7 +219,6 @@ jobs:
       - run-notebooks-cloud-related: |
           echo "PATH:"
           echo $PATH
-
           find docs -name '*cloud*.ipynb' -not -name 'mother-of-all-embedding-models-cloud.ipynb' | while read f
           do
             # Display total and free memory in human-readable format before running each notebook


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Notebooks fail with kernel died. 
Adding print of mem usage, and changed `runnb` to run in subshell. 