### PR TITLE
Thomasht86/sync retry strategy 429

### DIFF
--- a/docs/sphinx/source/examples/cross-encoders-for-global-reranking.ipynb
+++ b/docs/sphinx/source/examples/cross-encoders-for-global-reranking.ipynb
@@ -409,7 +409,7 @@
    "source": [
     "from vespa.deployment import VespaDocker\n",
     "\n",
-    "vespa_docker = VespaDocker(port=8080)\n",
+    "vespa_docker = VespaDocker(port=8089)\n",
     "\n",
     "vespa_docker.deploy(application_package=app_package)"
    ]

--- a/docs/sphinx/source/examples/cross-encoders-for-global-reranking.ipynb
+++ b/docs/sphinx/source/examples/cross-encoders-for-global-reranking.ipynb
@@ -411,7 +411,7 @@
     "\n",
     "vespa_docker = VespaDocker(port=8089)\n",
     "\n",
-    "vespa_docker.deploy(application_package=app_package)"
+    "app = vespa_docker.deploy(application_package=app_package)"
    ]
   },
   {
@@ -512,17 +512,6 @@
    "metadata": {},
    "source": [
     "With a time budget of 200ms for reranking, we can add a column indicating the number of documents we are able to rerank within the budget time.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from vespa.application import Vespa\n",
-    "\n",
-    "app = Vespa(url=\"http://localhost\", port=8089)"
    ]
   },
   {

--- a/docs/sphinx/source/examples/cross-encoders-for-global-reranking.ipynb
+++ b/docs/sphinx/source/examples/cross-encoders-for-global-reranking.ipynb
@@ -371,15 +371,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Waiting for configuration server, 0/300 seconds...\n",
-      "Waiting for configuration server, 5/300 seconds...\n",
+      "Waiting for configuration server, 0/60 seconds...\n",
+      "Waiting for configuration server, 5/60 seconds...\n",
       "Using plain http against endpoint http://localhost:8080/ApplicationStatus\n",
       "Waiting for application status, 0/300 seconds...\n",
       "Using plain http against endpoint http://localhost:8080/ApplicationStatus\n",
@@ -391,8 +391,6 @@
       "Using plain http against endpoint http://localhost:8080/ApplicationStatus\n",
       "Waiting for application status, 20/300 seconds...\n",
       "Using plain http against endpoint http://localhost:8080/ApplicationStatus\n",
-      "Waiting for application status, 25/300 seconds...\n",
-      "Using plain http against endpoint http://localhost:8080/ApplicationStatus\n",
       "Application is up!\n",
       "Finished deployment.\n"
      ]
@@ -403,7 +401,7 @@
        "Vespa(http://localhost, 8080)"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -418,7 +416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -518,18 +516,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
     "from vespa.application import Vespa\n",
     "\n",
-    "app = Vespa(url=\"http://localhost\", port=8080)"
+    "app = Vespa(url=\"http://localhost\", port=8089)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -551,7 +549,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -570,7 +568,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {

--- a/docs/sphinx/source/examples/cross-encoders-for-global-reranking.ipynb
+++ b/docs/sphinx/source/examples/cross-encoders-for-global-reranking.ipynb
@@ -478,7 +478,7 @@
     "\n",
     "url = \"https://huggingface.co/mixedbread-ai/mxbai-rerank-xsmall-v1/resolve/main/onnx/model.onnx\"\n",
     "# Example usage:\n",
-    "download_and_analyze_model(url, vespa_docker.container)"
+    "# download_and_analyze_model(url, vespa_docker.container)"
    ]
   },
   {

--- a/docs/sphinx/source/examples/cross-encoders-for-global-reranking.ipynb
+++ b/docs/sphinx/source/examples/cross-encoders-for-global-reranking.ipynb
@@ -371,7 +371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -379,44 +379,29 @@
      "output_type": "stream",
      "text": [
       "Waiting for configuration server, 0/60 seconds...\n",
-      "Waiting for configuration server, 5/60 seconds...\n",
-      "Using plain http against endpoint http://localhost:8080/ApplicationStatus\n",
+      "Using plain http against endpoint http://localhost:8089/ApplicationStatus\n",
       "Waiting for application status, 0/300 seconds...\n",
-      "Using plain http against endpoint http://localhost:8080/ApplicationStatus\n",
+      "Using plain http against endpoint http://localhost:8089/ApplicationStatus\n",
       "Waiting for application status, 5/300 seconds...\n",
-      "Using plain http against endpoint http://localhost:8080/ApplicationStatus\n",
+      "Using plain http against endpoint http://localhost:8089/ApplicationStatus\n",
       "Waiting for application status, 10/300 seconds...\n",
-      "Using plain http against endpoint http://localhost:8080/ApplicationStatus\n",
-      "Waiting for application status, 15/300 seconds...\n",
-      "Using plain http against endpoint http://localhost:8080/ApplicationStatus\n",
-      "Waiting for application status, 20/300 seconds...\n",
-      "Using plain http against endpoint http://localhost:8080/ApplicationStatus\n",
+      "Using plain http against endpoint http://localhost:8089/ApplicationStatus\n",
       "Application is up!\n",
       "Finished deployment.\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Vespa(http://localhost, 8080)"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
     "from vespa.deployment import VespaDocker\n",
     "\n",
-    "vespa_docker = VespaDocker(port=8089)\n",
+    "vespa_docker = VespaDocker(port=8080)\n",
     "\n",
     "app = vespa_docker.deploy(application_package=app_package)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -425,27 +410,27 @@
      "text": [
       "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
       "                                 Dload  Upload   Total   Spent    Left  Speed\n",
-      "100  1120  100  1120    0     0   6054      0 --:--:-- --:--:-- --:--:--  6054\n",
-      "100  271M  100  271M    0     0  26.7M      0  0:00:10  0:00:10 --:--:-- 27.0M\n",
+      "100  1126  100  1126    0     0   5715      0 --:--:-- --:--:-- --:--:--  5686\n",
+      "100  271M  100  271M    0     0  15.8M      0  0:00:17  0:00:17 --:--:-- 16.3M\n",
       "unspecified option[0](optimize model), fallback: true\n",
-      "vm_size: 167420 kB, vm_rss: 47032 kB, malloc_peak: 0 kb, malloc_curr: 1060 (before loading model)\n",
-      "vm_size: 525104 kB, vm_rss: 413188 kB, malloc_peak: 0 kb, malloc_curr: 358744 (after loading model)\n",
+      "vm_size: 166648 kB, vm_rss: 46700 kB, malloc_peak: 0 kb, malloc_curr: 1100 (before loading model)\n",
+      "vm_size: 517176 kB, vm_rss: 405592 kB, malloc_peak: 0 kb, malloc_curr: 351628 (after loading model)\n",
       "model meta-data:\n",
       "  input[0]: 'input_ids' long[batch_size][sequence_length]\n",
       "  input[1]: 'attention_mask' long[batch_size][sequence_length]\n",
       "  output[0]: 'logits' float[batch_size][1]\n",
       "unspecified option[1](symbolic size 'batch_size'), fallback: 1\n",
       "unspecified option[2](symbolic size 'sequence_length'), fallback: 1\n",
-      "1713519978.318630\tlocalhost\t1145/43932\t-\t.eval.onnx_wrapper\twarning\tinput 'input_ids' with element type 'long' is bound to vespa value with cell type 'double'; adding explicit conversion step (this conversion might be lossy)\n",
-      "1713519978.318646\tlocalhost\t1145/43932\t-\t.eval.onnx_wrapper\twarning\tinput 'attention_mask' with element type 'long' is bound to vespa value with cell type 'double'; adding explicit conversion step (this conversion might be lossy)\n",
+      "1717140328.769314\tlocalhost\t1305/26134\t-\t.eval.onnx_wrapper\twarning\tinput 'input_ids' with element type 'long' is bound to vespa value with cell type 'double'; adding explicit conversion step (this conversion might be lossy)\n",
+      "1717140328.769336\tlocalhost\t1305/26134\t-\t.eval.onnx_wrapper\twarning\tinput 'attention_mask' with element type 'long' is bound to vespa value with cell type 'double'; adding explicit conversion step (this conversion might be lossy)\n",
       "test setup:\n",
       "  input[0]: tensor(d0[1],d1[1]) -> long[1][1]\n",
       "  input[1]: tensor(d0[1],d1[1]) -> long[1][1]\n",
       "  output[0]: float[1][1] -> tensor<float>(d0[1],d1[1])\n",
       "unspecified option[3](max concurrent evaluations), fallback: 1\n",
-      "vm_size: 525104 kB, vm_rss: 413316 kB, malloc_peak: 0 kb, malloc_curr: 358744 (no evaluations yet)\n",
-      "vm_size: 525104 kB, vm_rss: 413576 kB, malloc_peak: 0 kb, malloc_curr: 358744 (concurrent evaluations: 1)\n",
-      "estimated model evaluation time: 3.70174 ms\n"
+      "vm_size: 517176 kB, vm_rss: 405592 kB, malloc_peak: 0 kb, malloc_curr: 351628 (no evaluations yet)\n",
+      "vm_size: 517176 kB, vm_rss: 405856 kB, malloc_peak: 0 kb, malloc_curr: 351628 (concurrent evaluations: 1)\n",
+      "estimated model evaluation time: 3.77819 ms\n"
      ]
     }
    ],
@@ -474,12 +459,17 @@
     "    # Construct the command to download and analyze the model inside the container.\n",
     "    command = f\"bash -c 'curl -Lo {model_path} {url} && vespa-analyze-onnx-model {model_path}'\"\n",
     "\n",
+    "    # Command to delete the model after analysis.\n",
+    "    delete_command = f\"rm {model_path}\"\n",
+    "\n",
     "    # Execute the command in the container and handle potential errors.\n",
     "    try:\n",
     "        exit_code, output = container.exec_run(command, stream=True)\n",
     "        # Print the output from the command.\n",
     "        for line in output:\n",
     "            print(line.decode(), end=\"\")\n",
+    "        # Remove the model after analysis.\n",
+    "        container.exec_run(delete_command)\n",
     "\n",
     "    except Exception as e:\n",
     "        print(f\"An error occurred: {e}\")\n",
@@ -516,7 +506,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,7 +528,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -557,7 +547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -628,7 +618,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/tests/integration/test_integration_docker.py
+++ b/tests/integration/test_integration_docker.py
@@ -26,7 +26,7 @@ from vespa.package import (
 from vespa.deployment import VespaDocker
 from vespa.application import VespaSync
 from vespa.exceptions import VespaError
-
+import random
 
 CONTAINER_STOP_TIMEOUT = 10
 RESOURCES_DIR = get_resource_path()
@@ -1348,6 +1348,83 @@ class TestUpdateApplication(TestApplicationCommon):
                 app=self.app, schema_name=self.schema_name
             )
         )
+
+    def tearDown(self) -> None:
+        self.vespa_docker.container.stop(timeout=CONTAINER_STOP_TIMEOUT)
+        self.vespa_docker.container.remove()
+
+
+class TestRetryApplication(unittest.TestCase):
+    """
+    Test class that simulates slow docprocessing which causes 429 errors while feeding documents to Vespa.
+
+    Through the CustomHTTPAdapter in `application.py`, these 429 errors will be retried with an exponential backoff strategy,
+    and hence not be returned to the user.
+
+    The slow docprocessing is simulated by setting the `sleep` indexing option on the `latency` field, which then will sleep
+    according to the value of the field when processing the document.
+    """
+
+    def setUp(self) -> None:
+        document = Document(
+            fields=[
+                Field(name="id", type="string", indexing=["attribute", "summary"]),
+                Field(
+                    name="latency",
+                    type="double",
+                    indexing=["attribute", "summary", "sleep"],
+                ),
+            ]
+        )
+        schema = Schema(
+            name="retryapplication",
+            document=document,
+        )
+        self.app_package = ApplicationPackage(name="retryapplication", schema=[schema])
+
+        self.vespa_docker = VespaDocker(port=8089)
+        self.app = self.vespa_docker.deploy(application_package=self.app_package)
+
+    def doc_generator(self, num_docs: int):
+        for i in range(num_docs):
+            yield {
+                "id": str(i),
+                "fields": {
+                    "id": str(i),
+                    "latency": random.uniform(3, 4),
+                },
+            }
+
+    def test_retry(self):
+        num_docs = 100
+        num_429 = 0
+
+        def callback(response: VespaResponse, id: str):
+            nonlocal num_429
+            if response.status_code == 429:
+                print(f"429 response for id {id}")
+                num_429 += 1
+
+        self.app.feed_iterable(
+            self.doc_generator(num_docs),
+            schema="retryapplication",
+            callback=callback,
+        )
+        print(f"Number of 429 responses: {num_429}")
+        total_docs = []
+        for doc_slice in self.app.visit(
+            content_cluster_name="retryapplication_content",
+            schema="retryapplication",
+            namespace="retryapplication",
+            selection="true",
+            slices=4,
+            max_workers=32,
+            max_connections=32,
+            wanted_document_count=num_docs // 4,
+        ):
+            for response in doc_slice:
+                total_docs.extend(response.documents)
+        self.assertEqual(len(total_docs), num_docs)
 
     def tearDown(self) -> None:
         self.vespa_docker.container.stop(timeout=CONTAINER_STOP_TIMEOUT)

--- a/tests/integration/test_integration_docker.py
+++ b/tests/integration/test_integration_docker.py
@@ -1396,7 +1396,7 @@ class TestRetryApplication(unittest.TestCase):
             }
 
     def test_retry(self):
-        num_docs = 100
+        num_docs = 10
         num_429 = 0
 
         def callback(response: VespaResponse, id: str):
@@ -1410,17 +1410,13 @@ class TestRetryApplication(unittest.TestCase):
             schema="retryapplication",
             callback=callback,
         )
-        print(f"Number of 429 responses: {num_429}")
+        self.assertEqual(num_429, 0)
         total_docs = []
         for doc_slice in self.app.visit(
             content_cluster_name="retryapplication_content",
             schema="retryapplication",
             namespace="retryapplication",
             selection="true",
-            slices=4,
-            max_workers=32,
-            max_connections=32,
-            wanted_document_count=num_docs // 4,
         ):
             for response in doc_slice:
                 total_docs.extend(response.documents)

--- a/tests/integration/test_integration_vespa_cloud.py
+++ b/tests/integration/test_integration_vespa_cloud.py
@@ -202,9 +202,9 @@ class TestRetryApplication(unittest.TestCase):
         def callback(response: VespaResponse, id: str):
             nonlocal num_429
             if response.status_code == 429:
-                print(f"429 response for id {id}")
                 num_429 += 1
 
+        self.assertEqual(num_429, 0)
         self.app.feed_iterable(
             self.doc_generator(num_docs),
             schema="retryapplication",
@@ -217,10 +217,6 @@ class TestRetryApplication(unittest.TestCase):
             schema="retryapplication",
             namespace="retryapplication",
             selection="true",
-            slices=4,
-            max_workers=32,
-            max_connections=32,
-            wanted_document_count=num_docs // 4,
         ):
             for response in doc_slice:
                 total_docs.extend(response.documents)

--- a/tests/integration/test_integration_vespa_cloud.py
+++ b/tests/integration/test_integration_vespa_cloud.py
@@ -9,6 +9,9 @@ import unittest
 from cryptography.hazmat.primitives import serialization
 from vespa.application import Vespa
 from vespa.deployment import VespaCloud
+from vespa.package import ApplicationPackage, Schema, Document, Field
+import random
+from vespa.io import VespaResponse
 from test_integration_docker import (
     TestApplicationCommon,
     create_msmarco_application_package,
@@ -26,7 +29,7 @@ class TestVespaKeyAndCertificate(unittest.TestCase):
             key_content=os.getenv("VESPA_TEAM_API_KEY").replace(r"\n", "\n"),
             application_package=self.app_package,
         )
-        self.disk_folder = os.path.join(os.getenv("WORK_DIR"), "sample_application")
+        self.disk_folder = os.path.join(os.getcwd(), "sample_application")
         self.instance_name = "msmarco"
         self.app = self.vespa_cloud.deploy(
             instance=self.instance_name, disk_folder=self.disk_folder
@@ -88,7 +91,7 @@ class TestMsmarcoApplication(TestApplicationCommon):
             key_content=os.getenv("VESPA_TEAM_API_KEY").replace(r"\n", "\n"),
             application_package=self.app_package,
         )
-        self.disk_folder = os.path.join(os.getenv("WORK_DIR"), "sample_application")
+        self.disk_folder = os.path.join(os.getcwd(), "sample_application")
         self.instance_name = "msmarco"
         self.app = self.vespa_cloud.deploy(
             instance=self.instance_name, disk_folder=self.disk_folder
@@ -138,6 +141,94 @@ class TestMsmarcoApplication(TestApplicationCommon):
     def tearDown(self) -> None:
         self.app.delete_all_docs(
             content_cluster_name="msmarco_content", schema="msmarco"
+        )
+        shutil.rmtree(self.disk_folder, ignore_errors=True)
+        self.vespa_cloud.delete(instance=self.instance_name)
+
+
+class TestRetryApplication(unittest.TestCase):
+    """
+    Test class that simulates slow docprocessing which causes 429 errors while feeding documents to Vespa.
+
+    Through the CustomHTTPAdapter in `application.py`, these 429 errors will be retried with an exponential backoff strategy,
+    and hence not be returned to the user.
+
+    The slow docprocessing is simulated by setting the `sleep` indexing option on the `latency` field, which then will sleep
+    according to the value of the field when processing the document.
+    """
+
+    def setUp(self) -> None:
+        document = Document(
+            fields=[
+                Field(name="id", type="string", indexing=["attribute", "summary"]),
+                Field(
+                    name="latency",
+                    type="double",
+                    indexing=["attribute", "summary", "sleep"],
+                ),
+            ]
+        )
+        schema = Schema(
+            name="retryapplication",
+            document=document,
+        )
+        self.app_package = ApplicationPackage(name="retryapplication", schema=[schema])
+        self.vespa_cloud = VespaCloud(
+            tenant="vespa-team",
+            application="pyvespa-integration",
+            key_content=os.getenv("VESPA_TEAM_API_KEY").replace(r"\n", "\n"),
+            application_package=self.app_package,
+        )
+        self.disk_folder = os.path.join(os.getcwd(), "sample_application")
+        self.instance_name = "retryapplication"
+        self.app = self.vespa_cloud.deploy(
+            instance=self.instance_name, disk_folder=self.disk_folder
+        )
+
+    def doc_generator(self, num_docs: int):
+        for i in range(num_docs):
+            yield {
+                "id": str(i),
+                "fields": {
+                    "id": str(i),
+                    "latency": random.uniform(3, 4),
+                },
+            }
+
+    def test_retry(self):
+        num_docs = 10
+        num_429 = 0
+
+        def callback(response: VespaResponse, id: str):
+            nonlocal num_429
+            if response.status_code == 429:
+                print(f"429 response for id {id}")
+                num_429 += 1
+
+        self.app.feed_iterable(
+            self.doc_generator(num_docs),
+            schema="retryapplication",
+            callback=callback,
+        )
+        print(f"Number of 429 responses: {num_429}")
+        total_docs = []
+        for doc_slice in self.app.visit(
+            content_cluster_name="retryapplication_content",
+            schema="retryapplication",
+            namespace="retryapplication",
+            selection="true",
+            slices=4,
+            max_workers=32,
+            max_connections=32,
+            wanted_document_count=num_docs // 4,
+        ):
+            for response in doc_slice:
+                total_docs.extend(response.documents)
+        self.assertEqual(len(total_docs), num_docs)
+
+    def tearDown(self) -> None:
+        self.app.delete_all_docs(
+            content_cluster_name="retryapplication_content", schema="retryapplication"
         )
         shutil.rmtree(self.disk_folder, ignore_errors=True)
         self.vespa_cloud.delete(instance=self.instance_name)

--- a/tests/integration/test_integration_vespa_cloud_token.py
+++ b/tests/integration/test_integration_vespa_cloud_token.py
@@ -39,7 +39,7 @@ class TestTokenBasedAuth(unittest.TestCase):
             key_content=os.getenv("VESPA_TEAM_API_KEY").replace(r"\n", "\n"),
             application_package=self.app_package,
         )
-        self.disk_folder = os.path.join(os.getenv("WORK_DIR"), "sample_application")
+        self.disk_folder = os.path.join(os.getcwd(), "sample_application")
         self.instance_name = "token"
         self.app: Vespa = self.vespa_cloud.deploy(
             instance=self.instance_name, disk_folder=self.disk_folder
@@ -94,7 +94,7 @@ class TestMsmarcoApplicationWithTokenAuth(TestApplicationCommon):
             key_content=os.getenv("VESPA_TEAM_API_KEY").replace(r"\n", "\n"),
             application_package=self.app_package,
         )
-        self.disk_folder = os.path.join(os.getenv("WORK_DIR"), "sample_application")
+        self.disk_folder = os.path.join(os.getcwd(), "sample_application")
         self.instance_name = "token"
         self.app = self.vespa_cloud.deploy(
             instance=self.instance_name, disk_folder=self.disk_folder

--- a/tests/integration/test_integration_vespa_cloud_vector_search.py
+++ b/tests/integration/test_integration_vespa_cloud_vector_search.py
@@ -72,7 +72,7 @@ class TestVectorSearch(unittest.TestCase):
             application_package=self.app_package,
             auth_client_token_id="pyvespa_integration_msmarco",
         )
-        self.disk_folder = os.path.join(os.getenv("WORK_DIR"), "sample_application")
+        self.disk_folder = os.path.join(os.getcwd(), "sample_application")
         self.instance_name = "default"
         self.app: Vespa = self.vespa_cloud.deploy(
             instance=self.instance_name, disk_folder=self.disk_folder
@@ -265,7 +265,7 @@ class TestProdDeployment(TestVectorSearch):
             application_package=self.app_package,
             auth_client_token_id="pyvespa_integration_msmarco",
         )
-        self.disk_folder = os.path.join(os.getenv("WORK_DIR"), "sample_application")
+        self.disk_folder = os.path.join(os.getcwd(), "sample_application")
         self.instance_name = "default"
         self.app = self.vespa_cloud.deploy_to_prod(
             instance=self.instance_name, disk_folder=self.disk_folder

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -532,7 +532,9 @@ class Vespa(object):
                     )
 
         with VespaSync(
-            app=self, pool_maxsize=max_connections, pool_connections=max_connections
+            app=self,
+            pool_maxsize=max_connections,
+            pool_connections=max_connections,
         ) as session:
             queue = Queue(maxsize=max_queue_size)
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
@@ -826,7 +828,9 @@ class CustomHTTPAdapter(HTTPAdapter):
 
 
 class VespaSync(object):
-    def __init__(self, app: Vespa, pool_maxsize: int = 10, pool_connections=10) -> None:
+    def __init__(
+        self, app: Vespa, pool_maxsize: int = 10, pool_connections: int = 10
+    ) -> None:
         self.app = app
         if self.app.key:
             self.cert = (self.app.cert, self.app.key)
@@ -840,7 +844,8 @@ class VespaSync(object):
         self.adapter = CustomHTTPAdapter(
             pool_maxsize=pool_maxsize,
             pool_connections=pool_connections,
-            num_retries_429=100,
+            num_retries_429=10,
+            pool_block=True,
         )
 
     def __enter__(self):

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -808,7 +808,7 @@ class CustomHTTPAdapter(HTTPAdapter):
         retry_strategy = Retry(
             total=3,
             backoff_factor=1,
-            raise_on_status=True,  # raise exception on status
+            raise_on_status=False,
             status_forcelist=[503],
             allowed_methods=["POST", "GET", "DELETE", "PUT"],
         )

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -819,7 +819,7 @@ class CustomHTTPAdapter(HTTPAdapter):
             response = super().send(request, **kwargs)
             if response.status_code == 429:
                 wait_time = (
-                    2** attempt + random.uniform(0, 1)
+                    0.1 * 1.618** attempt + random.uniform(0, 1)
                 )  # Exponential backoff with jitter. The 10th retry will sleep for 1024 seconds.
                 time.sleep(wait_time)
             else:

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -30,18 +30,12 @@ from tenacity import (
 from time import sleep
 from os import environ
 from urllib.parse import quote
+import random
+import time
 
 from vespa.exceptions import VespaError
 from vespa.io import VespaQueryResponse, VespaResponse, VespaVisitResponse
 from vespa.package import ApplicationPackage
-
-retry_strategy = Retry(
-    total=3,  # should be an unbounded amount of retrires for 429
-    backoff_factor=1,
-    raise_on_status=False,  # we want to raise and wrap with VespaError instead to get the payload (if any)
-    status_forcelist=[429, 503],
-    allowed_methods=["POST", "GET", "DELETE", "PUT"],
-)
 
 VESPA_CLOUD_SECRET_TOKEN: str = "VESPA_CLOUD_SECRET_TOKEN"
 
@@ -802,6 +796,35 @@ class Vespa(object):
         return f"/document/v1/{namespace}/{schema}/docid/{id}"
 
 
+class CustomHTTPAdapter(HTTPAdapter):
+    def __init__(self, *args, **kwargs):
+        self.pool_maxsize = kwargs.pop("pool_maxsize")
+        self.pool_connections = kwargs.pop("pool_connections")
+        self.num_retries_429 = kwargs.pop("num_retries_429", 10)
+        super().__init__(*args, **kwargs)
+
+        retry_strategy = Retry(
+            total=3,
+            backoff_factor=1,
+            raise_on_status=True,  # raise exception on status
+            status_forcelist=[503],
+            allowed_methods=["POST", "GET", "DELETE", "PUT"],
+        )
+        self.retry_strategy = retry_strategy
+
+    def send(self, request, **kwargs) -> Response:
+        for attempt in range(self.num_retries_429):
+            response = super().send(request, **kwargs)
+            if response.status_code == 429:
+                wait_time = (
+                    2** attempt + random.uniform(0, 1)
+                )  # Exponential backoff with jitter. The 10th retry will sleep for 1024 seconds.
+                time.sleep(wait_time)
+            else:
+                break
+        return response
+
+
 class VespaSync(object):
     def __init__(self, app: Vespa, pool_maxsize: int = 10, pool_connections=10) -> None:
         self.app = app
@@ -814,10 +837,10 @@ class VespaSync(object):
                 "Authorization": f"Bearer {self.app.vespa_cloud_secret_token}"
             }
         self.http_session = None
-        self.adapter = HTTPAdapter(
-            max_retries=retry_strategy,
+        self.adapter = CustomHTTPAdapter(
             pool_maxsize=pool_maxsize,
             pool_connections=pool_connections,
+            num_retries_429=100,
         )
 
     def __enter__(self):


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Closing #791 

After @jonmv fixed the async retry-strategy, we decided fixing the sync retry strategy for 429 was highest priority to gain confidence that the upcoming change in feed queue handling will not affect users negatively. 

After a nice tip from @jonmv on how to easily simulate slow feeding, it was also easy to add integration test for this. 
These tests would have failed with the old strategy, where 429s were only retried 3 times, and are very relevant as people add slow embedders etc. 

- Also a small refactor to get rid of `WORK_DIR` env variable.

Will create a new issue to add async feeding to the same integration-tests. 

Really don't like to break the DRY-principle by duplicating a lot of code for both docker and cloud tests. 
It would be very nice to refactor the Test classes properly, to make it easier to add both Cloud and Docker applications without duplicating code. 
