### PR TITLE
Upgrade requests from v2.26.0 to v2.32.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ build = [
     "build==1.0.3",
     "twine==4.0.1",
     "toml==0.10.2",
-    "requests~=2.26.0",
+    "requests~=2.32.0",
     "ruff",
 ]
 vespacli = ["vespacli"]


### PR DESCRIPTION
Following the [issue](https://github.com/vespa-engine/pyvespa/issues/820) I opened and with encouragement to contribute from @baldersheim, I have updated the `requests` dependency from v2.26.0 to v2.32.0. If there are any aspects of this PR that do not meet your requirements, please let me know.