### PR TITLE
Thomasht86/bump twine and requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 keywords = ["vespa", "search engine", "data science"]
 classifiers = ["License :: OSI Approved :: Apache Software License"]
 dependencies = [
-    "requests",
+    "requests>=2.32.0",
     "requests_toolbelt",
     "docker",
     "jinja2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ build = [
     "build==1.0.3",
     "twine==5.1.1",
     "toml==0.10.2",
-    "requests~=2.26.0",
+    "requests~=2.32.0",
     "ruff",
 ]
 vespacli = ["vespacli"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dev = [
 build = [
     "setuptools==69.0.3",
     "build==1.0.3",
-    "twine==4.0.1",
+    "twine==5.1.1",
     "toml==0.10.2",
     "requests~=2.26.0",
     "ruff",

--- a/vespacli/pyproject.toml
+++ b/vespacli/pyproject.toml
@@ -25,7 +25,7 @@ repository = "https://github.com/pyvespa/vespacli"
 vespa = "vespacli:run_vespa_cli"
 
 [project.optional-dependencies]
-build = [ "setuptools==69.0.3", "build==1.0.3", "twine==4.0.1", "toml==0.10.2", "requests==2.32.0",]
+build = [ "setuptools==69.0.3", "build==1.0.3", "twine==5.1.1", "toml==0.10.2", "requests==2.32.0",]
 
 [tool.setuptools.packages.find]
 where = [ ".",]


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

1. Bump version of twine (which caused release pipeline to fail due to https://stackoverflow.com/questions/78694572/unable-to-upload-pip-package-to-google-artifact-registry-using-twine-err-keyer) 
2. Pin version of `requests` for pyvespa to `>=2.32.0` to fix #820

We are using the `[dev]` version in CI. Should make sure at least unit testing is run with as little diff as possible from main dependencies (only pytest?) to avoid this from happening again. 
