### PR TITLE
Simplify `getting-started-pyvespa-cloud.ipynb`

### DIFF
--- a/docs/sphinx/source/getting-started-pyvespa-cloud.ipynb
+++ b/docs/sphinx/source/getting-started-pyvespa-cloud.ipynb
@@ -68,12 +68,7 @@
    "id": "02f706ff",
    "metadata": {},
    "source": [
-    "## Configure data-plane security\n",
-    "\n",
-    "Create Vespa Cloud data-plane mTLS cert/key-pair. This mutual certificate pair is used to talk to your Vespa cloud endpoints.\n",
-    "See [Vespa Cloud Security Guide](https://cloud.vespa.ai/en/security/guide).\n",
-    "\n",
-    "We save the paths to the credentials, for later dataplane access without using pyvespa APIs - see example at the end of this notebook.\n"
+    "## Configure application\n"
    ]
   },
   {
@@ -83,8 +78,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tenant_name = \"vespa-team\"  # Replace with your tenant name\n",
-    "application = \"hybridsearch\"  # Replace with your application name"
+    "# Replace with your tenant name from the Vespa Cloud Console\n",
+    "tenant_name = \"vespa-team\"\n",
+    "# Replace with your application name (does not need to exist yet)\n",
+    "application = \"hybridsearch\""
    ]
   },
   {
@@ -237,12 +234,15 @@
     "from vespa.deployment import VespaCloud\n",
     "import os\n",
     "\n",
+    "# Key is only used for CI/CD. Can be removed if logging in interactively\n",
+    "key = os.getenv(\"VESPA_TEAM_API_KEY\", None)\n",
+    "if key is not None:\n",
+    "    key = key.replace(r\"\\n\", \"\\n\")  # To parse key correctly\n",
+    "\n",
     "vespa_cloud = VespaCloud(\n",
     "    tenant=tenant_name,\n",
     "    application=application,\n",
-    "    key_content=os.getenv(\n",
-    "        \"VESPA_TEAM_API_KEY\", None\n",
-    "    ),  # This is only used for CI/CD. Can be removed if logging in interactively\n",
+    "    key_content=key,  # Key is only used for CI/CD. Can be removed if logging in interactively\n",
     "    application_package=package,\n",
     ")"
    ]

--- a/docs/sphinx/source/getting-started-pyvespa-cloud.ipynb
+++ b/docs/sphinx/source/getting-started-pyvespa-cloud.ipynb
@@ -36,7 +36,7 @@
    "id": "148d275b",
    "metadata": {},
    "source": [
-    "Pre-requisite: Create a tenant at [cloud.vespa.ai](https://cloud.vespa.ai/), save the tenant name.\n",
+    "**Pre-requisite**: Create a tenant at [cloud.vespa.ai](https://cloud.vespa.ai/), save the tenant name.\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vespa-engine/pyvespa/blob/master/docs/sphinx/source/getting-started-pyvespa-cloud.ipynb)\n"
    ]
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "136750de",
    "metadata": {},
    "outputs": [],
@@ -78,97 +78,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "9ca4da83",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "\n",
-    "os.environ[\"TENANT_NAME\"] = \"vespa-team\"  # Replace with your tenant name\n",
-    "application = \"hybridsearch\"\n",
-    "vespa_cli_command = (\n",
-    "    f'vespa config set application {os.environ[\"TENANT_NAME\"]}.{application}'\n",
-    ")\n",
-    "\n",
-    "!vespa config set target cloud\n",
-    "!{vespa_cli_command}\n",
-    "!vespa auth cert -N"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "64da11f2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from os.path import exists\n",
-    "from pathlib import Path\n",
-    "\n",
-    "cert_path = (\n",
-    "    Path.home()\n",
-    "    / \".vespa\"\n",
-    "    / f\"{os.environ['TENANT_NAME']}.{application}.default/data-plane-public-cert.pem\"\n",
-    ")\n",
-    "key_path = (\n",
-    "    Path.home()\n",
-    "    / \".vespa\"\n",
-    "    / f\"{os.environ['TENANT_NAME']}.{application}.default/data-plane-private-key.pem\"\n",
-    ")\n",
-    "\n",
-    "if not exists(cert_path) or not exists(key_path):\n",
-    "    print(\n",
-    "        \"ERROR: set the correct paths to security credentials. Correct paths above and rerun until you do not see this error\"\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d4f064e2",
-   "metadata": {},
-   "source": [
-    "Note that the subsequent deploy-call below will add `data-plane-public-cert.pem` to the application before deploying it to Vespa Cloud, so that\n",
-    "you have access to both the private key and the public certificate, while Vespa Cloud only knows the public certificate.\n",
-    "\n",
-    "## Configure control-plane security\n",
-    "\n",
-    "Authenticate to generate a tenant level control-plane API key for deploying the applications to Vespa Cloud, and save the path to it.\n",
-    "\n",
-    "<div style=\"background-color: #ffcc00; padding: 10px; border: 1px solid #ff9900; font-weight: bold;\">\n",
-    "    <strong>Warning:</strong>The generated tenant api key must be added in the Vespa Console before attempting to deploy the application.\n",
-    "</div>\n",
-    "\n",
-    "The following step will print the following message:\n",
-    "\n",
-    "```\n",
-    "To use this key in Vespa Cloud click 'Add custom key' at\n",
-    "https://console.vespa-cloud.com/tenant/TENANT_NAME/account/keys\n",
-    "and paste the entire public key including the BEGIN and END lines.\n",
-    "```\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "1346ad93",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!vespa auth api-key\n",
-    "\n",
-    "from pathlib import Path\n",
-    "\n",
-    "api_key_path = Path.home() / \".vespa\" / f\"{os.environ['TENANT_NAME']}.api-key.pem\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "99e82a48",
-   "metadata": {},
-   "source": [
-    "Follow the instrauctions from the output above and add the control-plane key in the console at `https://console.vespa-cloud.com/tenant/TENANT_NAME/account/keys`\n",
-    "(replace TENANT_NAME with your tenant name).\n"
+    "tenant_name = \"vespa-team\"  # Replace with your tenant name\n",
+    "application = \"hybridsearch\"  # Replace with your application name"
    ]
   },
   {
@@ -185,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "bd5c2629",
    "metadata": {},
    "outputs": [],
@@ -313,29 +229,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "canadian-blood",
    "metadata": {},
    "outputs": [],
    "source": [
     "from vespa.deployment import VespaCloud\n",
-    "\n",
-    "\n",
-    "def read_secret():\n",
-    "    \"\"\"Read the API key from the environment variable. This is\n",
-    "    only used for CI/CD purposes.\"\"\"\n",
-    "    t = os.getenv(\"VESPA_TEAM_API_KEY\")\n",
-    "    if t:\n",
-    "        return t.replace(r\"\\n\", \"\\n\")\n",
-    "    else:\n",
-    "        return t\n",
-    "\n",
+    "import os\n",
     "\n",
     "vespa_cloud = VespaCloud(\n",
-    "    tenant=os.environ[\"TENANT_NAME\"],\n",
+    "    tenant=tenant_name,\n",
     "    application=application,\n",
-    "    key_content=read_secret() if read_secret() else None,\n",
-    "    key_location=api_key_path,\n",
+    "    key_content=os.getenv(\n",
+    "        \"VESPA_TEAM_API_KEY\", None\n",
+    "    ),  # This is only used for CI/CD. Can be removed if logging in interactively\n",
     "    application_package=package,\n",
     ")"
    ]
@@ -354,7 +261,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "337d9b05",
    "metadata": {},
    "outputs": [],
@@ -384,7 +291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "afa0d69d",
    "metadata": {},
    "outputs": [],
@@ -415,7 +322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "executed-reservoir",
    "metadata": {},
    "outputs": [],
@@ -448,7 +355,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "bottom-memorabilia",
    "metadata": {},
    "outputs": [],
@@ -488,7 +395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "82b5f6fe",
    "metadata": {},
    "outputs": [],
@@ -519,7 +426,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "bc32d29b",
    "metadata": {},
    "outputs": [],
@@ -549,7 +456,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "b32d70ae",
    "metadata": {},
    "outputs": [],
@@ -585,7 +492,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "11faeacf",
    "metadata": {},
    "outputs": [],
@@ -616,7 +523,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "13fe1ef0",
    "metadata": {},
    "outputs": [],
@@ -645,7 +552,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "36c96921",
    "metadata": {},
    "outputs": [],
@@ -698,13 +605,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "ff72148c",
    "metadata": {},
    "outputs": [],
    "source": [
     "import requests\n",
     "\n",
+    "cert_path = app.cert\n",
+    "key_path = app.key\n",
     "session = requests.Session()\n",
     "session.cert = (cert_path, key_path)"
    ]
@@ -720,7 +629,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "79f7d12c",
    "metadata": {},
    "outputs": [],
@@ -740,7 +649,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "21c7c399",
    "metadata": {},
    "outputs": [],
@@ -760,7 +669,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "2e3d560b",
    "metadata": {},
    "outputs": [],
@@ -783,7 +692,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "c87da6cf",
    "metadata": {},
    "outputs": [],
@@ -822,7 +731,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "66354a53",
    "metadata": {},
    "outputs": [],

--- a/docs/sphinx/source/getting-started-pyvespa-cloud.ipynb
+++ b/docs/sphinx/source/getting-started-pyvespa-cloud.ipynb
@@ -48,7 +48,7 @@
    "source": [
     "## Install\n",
     "\n",
-    "Install [pyvespa](https://pyvespa.readthedocs.io/) >= 0.38\n",
+    "Install [pyvespa](https://pyvespa.readthedocs.io/) >= 0.45\n",
     "and the [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html).\n",
     "The Vespa CLI is used for data and control plane key management ([Vespa Cloud Security Guide](https://cloud.vespa.ai/en/security/guide)).\n"
    ]


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Creating a PR with suggested simplification of `getting-started-pyvespa-cloud.ipynb` with support for interactive login.

Will prompt users running in notebook/Colab to login interactively. (Still works in CI/CD as api-key will be checked first if provided).  Please try running it, maybe output during/after auth is a bit too verbose? 

Removed quite a bit of the authentication explanation, maybe too much, but it looks more like a quickstart now. 
Once we agree on approach, I can batch-update rest of the cloud notebooks.