### PR TITLE
update test to pass auth_client to cluster instead

### DIFF
--- a/tests/integration/test_integration_vespa_cloud_token.py
+++ b/tests/integration/test_integration_vespa_cloud_token.py
@@ -182,9 +182,7 @@ class TestMsmarcoProdApplicationWithTokenAuth(TestApplicationCommon):
                 parameters=[Parameter("token", {"id": CLIENT_TOKEN_ID})],
             ),
         ]
-        self.app_package = create_msmarco_application_package(
-            auth_clients=self.auth_clients
-        )
+        self.app_package = create_msmarco_application_package()
         # Add prod deployment config
         prod_region = "aws-us-east-1c"
         self.app_package.clusters = [
@@ -197,6 +195,7 @@ class TestMsmarcoProdApplicationWithTokenAuth(TestApplicationCommon):
             ContainerCluster(
                 id=f"{schema_name}_container",
                 nodes=Nodes(count="2"),
+                auth_clients=self.auth_clients,
             ),
         ]
         self.app_package.deployment_config = DeploymentConfiguration(


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Update integration test to pass AuthClient to ContainerCluster. 