### PR TITLE
Typo and timeout

### DIFF
--- a/docs/sphinx/source/examples/colpali-document-retrieval-vision-language-models.ipynb
+++ b/docs/sphinx/source/examples/colpali-document-retrieval-vision-language-models.ipynb
@@ -63,7 +63,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip3 install git+https://github.com/ManuelFay/colpali pdf2image pydf pyvespa vespacli"
+        "!pip3 install git+https://github.com/ManuelFay/colpali pdf2image pypdf pyvespa vespacli"
       ]
     },
     {
@@ -1121,6 +1121,7 @@
         "        yql=\"select title,url,images from doc where userInput(@userQuery)\",\n",
         "        ranking=\"default\",\n",
         "        userQuery=query,\n",
+        "        timeout=1,\n",
         "        body={\n",
         "            \"presentation.format.tensors\": \"short-value\",\n",
         "            \"input.query(qt)\": float_query_token_vectors(qs[idx])\n",


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

2 little changes:
1. Typo in the pypdf package name.
2. With the default timeout value on my M1 Max for pretty much any query I'm getting error:
```
VespaError: [{'code': 12, 'summary': 'Timed out', 'message': 'Summary data is incomplete: Timed out waiting for summary data. 1 responses outstanding.'}]
```
