### PR TITLE
Thomasht86/pin requests version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 keywords = ["vespa", "search engine", "data science"]
 classifiers = ["License :: OSI Approved :: Apache Software License"]
 dependencies = [
-    "requests>=2.32.0",
+    "requests==2.31",
     "requests_toolbelt",
     "docker",
     "jinja2",

--- a/vespacli/pyproject.toml
+++ b/vespacli/pyproject.toml
@@ -25,7 +25,7 @@ repository = "https://github.com/pyvespa/vespacli"
 vespa = "vespacli:run_vespa_cli"
 
 [project.optional-dependencies]
-build = [ "setuptools==69.0.3", "build==1.0.3", "twine==5.1.1", "toml==0.10.2", "requests==2.32.0",]
+build = [ "setuptools==69.0.3", "build==1.0.3", "twine==5.1.1", "toml==0.10.2", "requests>=2.32.3",]
 
 [tool.setuptools.packages.find]
 where = [ ".",]


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Ref #850. Edit version to avoid regression introduced in `requests==2.32.0`. 
This made our `feed_iterable()` fail when using cert, causing integration tests to fail with segfault.
Pinning to `2.31` fixes the issue. 
 
Waiting for fix in coming `requests`-releases. 