### PR TITLE
Improve pyvespa chunks to docsearch

### DIFF
--- a/.github/workflows/feed.yml
+++ b/.github/workflows/feed.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           sudo apt-get install -y pandoc
           python3 -m pip install --upgrade pip
-          python3 -m pip install -e .[docs, feed]
+          python3 -m pip install -e .[docs,feed]
 
       - name: Build site
         run: |

--- a/.github/workflows/feed.yml
+++ b/.github/workflows/feed.yml
@@ -1,86 +1,72 @@
 name: pyvespa documentation search feed
 on:
   push:
-    branches: [ master ]
+    branches: [master, thomasht86/fix-docsearch-feed]
 
 env:
-  DATA_PLANE_PUBLIC_KEY     : ${{ secrets.VESPA_TEAM_DATA_PLANE_PUBLIC_CERT }}
-  DATA_PLANE_PRIVATE_KEY    : ${{ secrets.VESPA_TEAM_DATA_PLANE_PRIVATE_KEY }}
-  VESPA_CLI_DATA_PLANE_CERT : ${{ secrets.VESPA_TEAM_VESPA_CLI_DATA_PLANE_CERT }}
-  VESPA_CLI_DATA_PLANE_KEY  : ${{ secrets.VESPA_TEAM_VESPA_CLI_DATA_PLANE_KEY }}
+  DATA_PLANE_PUBLIC_KEY: ${{ secrets.VESPA_TEAM_DATA_PLANE_PUBLIC_CERT }}
+  DATA_PLANE_PRIVATE_KEY: ${{ secrets.VESPA_TEAM_DATA_PLANE_PRIVATE_KEY }}
+  VESPA_CLI_DATA_PLANE_CERT: ${{ secrets.VESPA_TEAM_VESPA_CLI_DATA_PLANE_CERT }}
+  VESPA_CLI_DATA_PLANE_KEY: ${{ secrets.VESPA_TEAM_VESPA_CLI_DATA_PLANE_KEY }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
 
-    - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          bundler-cache: true
 
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.1
-        bundler-cache: true
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
 
-    - name: Install Sphinx
-      run: |
-        sudo apt-get install -y pandoc
-        python3 -m pip install --upgrade pip
-        python3 -m pip install -r docs/sphinx/source/requirements-feed.txt
+      - name: Install Sphinx
+        run: |
+          sudo apt-get install -y pandoc
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -e .[docs, feed]
 
-    - name: Build site
-      run: |
-        sphinx-build -E -D nbsphinx_allow_errors=True -b html docs/sphinx/source docs/sphinx/build
-        #
-        # strip liquid macros from html files
-        #
-        find docs/sphinx/build -name \*.html | \
-          while read f; do \
-            ( echo -e "---\n---\n"; sed 's/{%/{ %/g; s/%}/% }/g; s/{{/{ {/g; s/}}/} }/g' < ${f} ) >${f}.new; \
-            mv ${f}.new ${f}; \
-          done
-        bundle exec jekyll build -s docs/sphinx/build/ -p _plugins-vespafeed --config _config.yml
+      - name: Build site
+        run: |
+          sphinx-build -E -D nbsphinx_allow_errors=True -b html docs/sphinx/source docs/sphinx/build
 
-    - name: Setup Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
+          # Add front matter and strip liquid macros from html files
+          find docs/sphinx/build -name \*.html | \
+            while read f; do \
+              { echo "---"; echo "---"; sed 's/{%/{ %/g; s/%}/% }/g; s/{{/{ {/g; s/}}/} }/g' < ${f}; } >${f}.new; \
+              mv ${f}.new ${f}; \
+            done
 
-    - name: Install dependencies
-      run: |
-        pip3 install PyYAML spacy mmh3 requests html5lib beautifulsoup4 markdownify tiktoken
+          bundle exec jekyll build -s docs/sphinx/build/ -p _plugins-vespafeed --config _config.yml
 
-    - name: Get Vespa CLI - update to later versions as needed
-      run: |
-        # Workaround: Rename the "vespa" directory in pyvespa, conflicts with the cli install below
-        # This directory is not needed for the feeding anyway
-        mv vespa vespa.org
-        apt update && apt -y install curl
-        curl -SsLo vespa-cli.tar.gz https://github.com/vespa-engine/vespa/releases/download/v8.209.11/vespa-cli_8.209.11_linux_amd64.tar.gz
-        tar -xvf vespa-cli.tar.gz && ln -fs vespa-cli_8.209.11_linux_amd64/bin/vespa
+      - name: Feed site
+        run: |
+          # The python scripts below uses the Vespa CLI for feeding / data access.
+          # See https://docs.vespa.ai/en/vespa-cli.html.
+          # The environment variables below have credentials for endpoint access -
+          # use the key/cert files in .vespa and paste their content into GitHub Secrets.
+          # VESPA_CLI_API_KEY must be set and empty as below.
+          export VESPA_CLI_DATA_PLANE_CERT
+          export VESPA_CLI_DATA_PLANE_KEY
+          export VESPA_CLI_API_KEY=
+          ./feed_to_vespa.py _config.yml
 
-    - name: Feed site
-      run: |
-        # The python scripts below uses the Vespa CLI for feeding / data access.
-        # See https://docs.vespa.ai/en/vespa-cli.html.
-        # The environment variables below have credentials for endpoint access -
-        # use the key/cert files in .vespa and paste their content into GitHub Secrets.
-        # VESPA_CLI_API_KEY must be set and empty as below.
-        export VESPA_CLI_DATA_PLANE_CERT
-        export VESPA_CLI_DATA_PLANE_KEY
-        export VESPA_CLI_API_KEY=
-        ./feed_to_vespa.py _config.yml
+      - name: Feed paragraphs site
+        run: |
+          export VESPA_CLI_DATA_PLANE_CERT
+          export VESPA_CLI_DATA_PLANE_KEY
+          export VESPA_CLI_API_KEY=
+          ./feed-split.py pyvespa_index.json https://pyvespa.readthedocs.io/en/latest questions.jsonl
+          ./feed_to_vespa.py _paragraphs_config.yml
 
-    - name: Feed paragraphs site
-      run: |
-        export VESPA_CLI_DATA_PLANE_CERT
-        export VESPA_CLI_DATA_PLANE_KEY
-        export VESPA_CLI_API_KEY=
-        ./feed-split.py pyvespa_index.json https://pyvespa.readthedocs.io/en/latest questions.jsonl
-        ./feed_to_vespa.py _paragraphs_config.yml
-
-    - name: Feed suggestions 
-      run: |
-        export VESPA_CLI_DATA_PLANE_CERT
-        export VESPA_CLI_DATA_PLANE_KEY
-        export VESPA_CLI_API_KEY=
-        ./feed_to_vespa.py _suggestions_config.yml
+      - name: Feed suggestions
+        run: |
+          export VESPA_CLI_DATA_PLANE_CERT
+          export VESPA_CLI_DATA_PLANE_KEY
+          export VESPA_CLI_API_KEY=
+          ./feed_to_vespa.py _suggestions_config.yml

--- a/.github/workflows/feed.yml
+++ b/.github/workflows/feed.yml
@@ -1,7 +1,7 @@
 name: pyvespa documentation search feed
 on:
   push:
-    branches: [master, thomasht86/fix-docsearch-feed]
+    branches: [master]
 
 env:
   DATA_PLANE_PUBLIC_KEY: ${{ secrets.VESPA_TEAM_DATA_PLANE_PUBLIC_CERT }}

--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,8 @@ Pipfile
 _site/
 pyvespa_index.json
 paragraph_index.json
+markdown_after/
+markdown_before/
 
 # All .pem and .crt files
 *.pem

--- a/_plugins-vespafeed/vespa_index_generator.rb
+++ b/_plugins-vespafeed/vespa_index_generator.rb
@@ -7,16 +7,25 @@ require 'kramdown/parser/kramdown'
 module Jekyll
 
     class VespaIndexGenerator < Jekyll::Generator
+        puts "VespaIndexGenerator is being loaded"
         priority :lowest
 
         def generate(site)
             namespace = site.config["search"]["namespace"]
             operations = []
-            site.pages.each do |page|
+            puts "VespaIndexGenerator is processing pages"
+
+            if site.pages.empty?
+                puts "No pages found!"
+            else
+                puts "Pages found: #{site.pages.size}"
+                site.pages.each do |page|
+                puts "Processing page: #{page.url}" # Debugging output
                 next if (page.path.start_with?("search.html") ||
-                         page.path.start_with?("genindex.html") ||
-                         page.url.start_with?("/redirects.json"))
+                        page.path.start_with?("genindex.html") ||
+                        page.url.start_with?("/redirects.json"))
                 if page.data["index"] == true
+                    puts "Indexing page: #{page.url}" # Debugging output
                     title = clean_chars(extract_title(page))
                     text  = clean_chars(extract_text(page))
                     operations.push({
@@ -32,12 +41,15 @@ module Jekyll
                             :outlinks => extract_links(page)
                         }
                     })
+                else
+                    puts "Page not indexed: #{page.url}, index flag: #{page.data['index']}" # Debugging output
                 end
+                end
+            
+                json = JSON.pretty_generate(operations)
+                File.open(namespace + "_index.json", "w") { |f| f.write(json) }
             end
-
-            json = JSON.pretty_generate(operations)
-            File.open(namespace + "_index.json", "w") { |f| f.write(json) }
-        end
+        end # Added missing 'end' keyword to close the 'generate' method
 
         def strip_a_from_headers(htmldoc)
             doc = Nokogiri::HTML(htmldoc)

--- a/feed_to_vespa.py
+++ b/feed_to_vespa.py
@@ -90,7 +90,7 @@ def vespa_feed(endpoint, feed, namespace, doc_type):
         app_string = splits[3] + "." + splits[2]
         print(
             subprocess.run(
-                ["./vespa", "feed", "-a", app_string, "-t", endpoint, feed],
+                ["vespa", "feed", "-a", app_string, "-t", endpoint, feed],
                 capture_output=True,
             )
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,17 @@ docs = [
     "nbsphinx",
     "sphinx-rtd-theme>=0.5.0",
 ]
+feed = [
+    "PyYAML", 
+    "spacy", 
+    "mmh3", 
+    "requests<=2.31.0", 
+    "html5lib", 
+    "beautifulsoup4", 
+    "markdownify", 
+    "tiktoken",
+    "vespacli",
+]
 notebooks = [
     "notebook",
     "nbconvert<=7.12.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ docs = [
     "sphinx",
     "nbsphinx",
     "sphinx-rtd-theme>=0.5.0",
+    "ipykernel",
 ]
 feed = [
     "PyYAML", 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

I suspect that the paragraph_index hasn`t been fed in a while, as running the build script added an extra "-e" to the front matter of the html-files, resulting in empty feed for me.  

Improves the chunking to docsearch from pyvespa:
- [x] Updated the bash script to fix the issue mentioned above.
- [x] Removed empty jupyter cell references. 
- [x] Fixes too long chunks for `reference-api.html` by splitting on class methods.
- [x] Fixes bad formatting due to double escaping of backslashes.

Link to previous test run: https://github.com/vespa-engine/pyvespa/actions/runs/10370895936/job/28709859043
Seem to give better results for reference docs, eg:
- https://search.vespa.ai/search?query=pyvespa%20reference%20feed_iterable&namespace=pyvespa-p
- https://search.vespa.ai/search?query=pyvespa%20reference%20VespaCloud&namespace=pyvespa-p