### PR TITLE
add link to feed_performance_cloud

### DIFF
--- a/docs/sphinx/source/examples.rst
+++ b/docs/sphinx/source/examples.rst
@@ -20,6 +20,7 @@ Examples
    examples/colbert_standalone_Vespa-cloud.ipynb
    examples/colbert_standalone_long_context_Vespa-cloud.ipynb
    examples/feed_performance.ipynb
+   examples/feed_performance_cloud.ipynb
    examples/cross-encoders-for-global-reranking.ipynb
    examples/evaluating-with-snowflake-arctic-embed.ipynb
    examples/colpali-document-retrieval-vision-language-models.ipynb


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Noticed this was missing when trying to link it in newsletter. 