### PR TITLE
chore(CI): change workflow trigger rules

### DIFF
--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -5,7 +5,9 @@ on:
   pull_request:
     branches:
       - master
-
+  push:
+    branches:
+      - master
 jobs:
   docs-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-cloud.yml
+++ b/.github/workflows/integration-cloud.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - master
   schedule:
-   - cron: '0 11 * * *'
+   - cron: '0 11 * * 1'
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/integration-cloud.yml
+++ b/.github/workflows/integration-cloud.yml
@@ -5,8 +5,11 @@ on:
   pull_request:
     branches:
       - master
+  push:
+    branches:
+      - master
   schedule:
-   - cron: '0 11 * * 1'
+   - cron: '0 11 * * 0'
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/integration-except-cloud.yml
+++ b/.github/workflows/integration-except-cloud.yml
@@ -5,8 +5,9 @@ on:
   pull_request:
     branches:
       - master
-  schedule:
-   - cron: '0 11 * * *'
+  push:
+    branches:
+      - master
 
 jobs:
   integration-except-cloud:

--- a/.github/workflows/notebooks-cloud.yml
+++ b/.github/workflows/notebooks-cloud.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - master
   schedule:
-   - cron: '0 11 * * 1'
+   - cron: '0 11 * * 0'
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/notebooks-cloud.yml
+++ b/.github/workflows/notebooks-cloud.yml
@@ -5,8 +5,11 @@ on:
   pull_request:
     branches:
       - master
+  push:
+    branches:
+      - master
   schedule:
-   - cron: '0 11 * * *'
+   - cron: '0 11 * * 1'
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/notebooks-except-cloud.yml
+++ b/.github/workflows/notebooks-except-cloud.yml
@@ -5,8 +5,9 @@ on:
   pull_request:
     branches:
       - master
-  schedule:
-   - cron: '0 11 * * *'
+  push:
+    branches:
+      - master
 
 jobs:
   get-non-cloud-notebooks:

--- a/.github/workflows/pyvespa-unit-tests.yml
+++ b/.github/workflows/pyvespa-unit-tests.yml
@@ -5,8 +5,9 @@ on:
   pull_request:
     branches:
       - master
-  schedule:
-   - cron: '0 11 * * *'
+  push:
+    branches:
+      - master
 
 jobs:
   test:


### PR DESCRIPTION
## What

- Adding "push: {default-branch}" for testing final integration of changes with mainline
- Remove schedule from GH Actions workflows where is not providing any additional value
- Updated schedule to be weekly (Sunday) where remains useful

## Why

This streamlines the tests to run when is necessary and avoid unnecessary additional runs.

---

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
