### PR TITLE
(chore): Fix dependencies to build docs (readthedocs.yaml)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -26,4 +26,9 @@ sphinx:
 # Optionally declare the Python requirements required to build your docs
 python:
   install:
-    - requirements: docs/sphinx/source/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - dev
+        - docs
+        - notebooks


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

**What?**

Change the readthedocs-config yaml to install from `pyproject.toml` instead. 
Used reference: https://docs.readthedocs.io/en/stable/config-file/v2.html#python-install

**Why?**

The latest doc builds failed because we moved the `requirements.txt` into `pyproject.toml`.