### PR TITLE
Add integration test to test for accept-encoding: gzip

### DIFF
--- a/tests/integration/test_integration_docker.py
+++ b/tests/integration/test_integration_docker.py
@@ -1135,7 +1135,7 @@ class TestQaApplication(TestApplicationCommon):
         self.app.delete_all_docs(content_cluster_name="qa_content", schema="sentence")
 
     def test_sync_client_accept_encoding(self):
-        self.sync_client_accept_encoding(app=self.app)
+        self.sync_client_accept_encoding_gzip(app=self.app)
 
     def test_async_client_accept_encoding(self):
         asyncio.run(self.async_client_accept_encoding_gzip(app=self.app))

--- a/tests/integration/test_integration_docker.py
+++ b/tests/integration/test_integration_docker.py
@@ -283,6 +283,32 @@ class TestApplicationCommon(unittest.TestCase):
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.http_version, "HTTP/2")
 
+    def sync_client_accept_encoding_gzip(self, app):
+        data = {
+            "yql": "select * from sources * where true",
+            "hits": 10,
+        }
+        with app.syncio() as sync_app:
+            response = sync_app.http_session.post(app.search_end_point, json=data)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.headers["content-encoding"], "gzip")
+            # Check that gzip is in request headers
+            self.assertIn("gzip", response.request.headers["Accept-Encoding"])
+
+    async def async_client_accept_encoding_gzip(self, app):
+        data = {
+            "yql": "select * from sources * where true",
+            "hits": 10,
+        }
+        async with app.asyncio() as async_app:
+            response = await async_app.httpx_client.post(
+                app.search_end_point, json=data
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.headers["content-encoding"], "gzip")
+            # Check that gzip is in request headers
+            self.assertIn("gzip", response.request.headers["Accept-Encoding"])
+
     def execute_data_operations(
         self,
         app,
@@ -946,6 +972,12 @@ class TestMsmarcoApplication(TestApplicationCommon):
     def test_is_using_http2_client(self):
         asyncio.run(self.async_is_http2_client(app=self.app))
 
+    def test_sync_client_accept_encoding(self):
+        self.sync_client_accept_encoding_gzip(app=self.app)
+
+    def test_async_client_accept_encoding(self):
+        asyncio.run(self.async_client_accept_encoding_gzip(app=self.app))
+
     def test_handle_longlived_connection(self):
         asyncio.run(self.handle_longlived_connection(app=self.app))
 
@@ -1101,6 +1133,12 @@ class TestQaApplication(TestApplicationCommon):
             len(self.fields_to_send_sentence),
         )
         self.app.delete_all_docs(content_cluster_name="qa_content", schema="sentence")
+
+    def test_sync_client_accept_encoding(self):
+        self.sync_client_accept_encoding(app=self.app)
+
+    def test_async_client_accept_encoding(self):
+        asyncio.run(self.async_client_accept_encoding_gzip(app=self.app))
 
     def tearDown(self) -> None:
         self.vespa_docker.container.stop(timeout=CONTAINER_STOP_TIMEOUT)


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Ref #872.

It turns out both `requests` and `httpx` adds a default header with `Accept-Encoding: gzip, deflate`. 
The Vespa container also replies with `content-encoding: gzip`

The behavior can be verified with

```python
import requests
import httpx

# Using requests
requests_response = requests.get('https://httpbin.org')
print("Requests - Accept-Encoding header:", requests_response.request.headers.get('Accept-Encoding'))

# Using httpx
httpx_response = httpx.get('https://httpbin.org')
print("HTTPX - Accept-Encoding header:", httpx_response.request.headers.get('Accept-Encoding'))
```

They will also be decompressed automatically.
See:

- From [httpx docs](https://www.python-httpx.org/quickstart/):
> Any gzip and deflate HTTP response encodings will automatically be decoded for you.
- From [requests FAQ](https://requests.readthedocs.io/en/latest/community/faq/):
> Requests automatically decompresses gzip-encoded responses, and does its best to decode response content to unicode when possible.

This PR adds integration tests to test for this. 