### PR TITLE
Switch to new control-plane API

### DIFF
--- a/.github/workflows/notebooks-cloud.yml
+++ b/.github/workflows/notebooks-cloud.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - master
   schedule:
-   - cron: '0 11 * * 0'
+    - cron: "0 11 * * 0"
 
 concurrency:
   group: ${{ github.workflow }}
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.10"
           cache: "pip" # caching pip dependencies
           cache-dependency-path: |
             pyproject.toml

--- a/.github/workflows/notebooks-except-cloud.yml
+++ b/.github/workflows/notebooks-except-cloud.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
           cache: "pip"
           cache-dependency-path: |
             pyproject.toml

--- a/tests/integration/test_integration_vespa_cloud.py
+++ b/tests/integration/test_integration_vespa_cloud.py
@@ -15,6 +15,7 @@ from vespa.package import (
     Document,
     Field,
 )
+import vespa
 import random
 from vespa.io import VespaResponse
 from test_integration_docker import (
@@ -124,6 +125,20 @@ class TestMsmarcoApplication(TestApplicationCommon):
             }
             for i in range(10)
         ]
+
+    def test_control_plane_useragent(self):
+        response = self.vespa_cloud.get_connection_response_with_retry("GET", "/")
+        self.assertEqual(
+            response.request.headers["User-Agent"],
+            f"pyvespa/{vespa.__version__}",
+        )
+
+    def test_data_plane_useragent(self):
+        response = self.app.get_data(schema="msmarco", data_id="1")
+        self.assertEqual(
+            response.request.headers["User-Agent"],
+            f"pyvespa/{vespa.__version__}",
+        )
 
     def test_is_using_http2_client(self):
         asyncio.run(self.async_is_http2_client(app=self.app))

--- a/tests/integration/test_integration_vespa_cloud.py
+++ b/tests/integration/test_integration_vespa_cloud.py
@@ -140,7 +140,9 @@ class TestMsmarcoApplication(TestApplicationCommon):
 
     def test_data_plane_useragent_sync(self):
         with self.app.syncio() as session:
-            response = session.get(self.app.end_point + "/ApplicationStatus")
+            response = session.http_session.get(
+                self.app.end_point + "/ApplicationStatus"
+            )
         self.assertEqual(
             response.request.headers["User-Agent"],
             f"pyvespa/{vespa.__version__}",
@@ -149,7 +151,9 @@ class TestMsmarcoApplication(TestApplicationCommon):
     def test_data_plane_useragent_async(self):
         async def get_resp():
             async with self.app.asyncio() as session:
-                response = await session.get(self.app.end_point + "/ApplicationStatus")
+                response = await session.httpx_client.get(
+                    self.app.end_point + "/ApplicationStatus"
+                )
             return response
 
         response = asyncio.run(get_resp())

--- a/tests/integration/test_integration_vespa_cloud.py
+++ b/tests/integration/test_integration_vespa_cloud.py
@@ -1,6 +1,7 @@
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 import os
+import httpx
 import asyncio
 import shutil
 import pytest
@@ -127,14 +128,31 @@ class TestMsmarcoApplication(TestApplicationCommon):
         ]
 
     def test_control_plane_useragent(self):
-        response = self.vespa_cloud.get_connection_response_with_retry("GET", "/")
+        response: httpx.Response = self.vespa_cloud._request_with_api_key(
+            "GET",
+            f"/application/v4/tenant/{self.vespa_cloud.tenant}/application/{self.vespa_cloud.application}/",
+            return_raw_response=True,
+        )
         self.assertEqual(
             response.request.headers["User-Agent"],
             f"pyvespa/{vespa.__version__}",
         )
 
-    def test_data_plane_useragent(self):
-        response = self.app.get_data(schema="msmarco", data_id="1")
+    def test_data_plane_useragent_sync(self):
+        with self.app.syncio() as session:
+            response = session.get(self.app.end_point + "/ApplicationStatus")
+        self.assertEqual(
+            response.request.headers["User-Agent"],
+            f"pyvespa/{vespa.__version__}",
+        )
+
+    def test_data_plane_useragent_async(self):
+        async def get_resp():
+            async with self.app.asyncio() as session:
+                response = await session.get(self.app.end_point + "/ApplicationStatus")
+            return response
+
+        response = asyncio.run(get_resp())
         self.assertEqual(
             response.request.headers["User-Agent"],
             f"pyvespa/{vespa.__version__}",

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -298,7 +298,7 @@ class Vespa(object):
         """
         endpoint = f"{self.end_point}/ApplicationStatus"
         with self.syncio() as sync_sess:
-            response = sync_sess.get(endpoint)
+            response = sync_sess.http_session.get(endpoint)
         return response
 
     def get_model_endpoint(self, model_id: Optional[str] = None) -> Optional[Response]:

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -973,7 +973,7 @@ class CustomHTTPAdapter(HTTPAdapter):
         super().__init__(*args, **kwargs)
 
         retry_strategy = Retry(
-            total=3,
+            total=10,
             backoff_factor=1,
             raise_on_status=False,
             status_forcelist=[503],
@@ -1015,6 +1015,7 @@ class VespaSync(object):
         self.adapter = CustomHTTPAdapter(
             pool_maxsize=pool_maxsize,
             pool_connections=pool_connections,
+            max_retries=10,
             num_retries_429=10,
             pool_block=True,
         )

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -297,8 +297,8 @@ class Vespa(object):
         :return:
         """
         endpoint = f"{self.end_point}/ApplicationStatus"
-        with self.syncio() as sync_app:
-            response = sync_app.http_session.get(endpoint)
+        with self.syncio() as sync_sess:
+            response = sync_sess.get(endpoint)
         return response
 
     def get_model_endpoint(self, model_id: Optional[str] = None) -> Optional[Response]:

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -35,7 +35,7 @@ from vespa.exceptions import VespaError
 from vespa.io import VespaQueryResponse, VespaResponse, VespaVisitResponse
 from vespa.package import ApplicationPackage
 import httpx
-
+import vespa
 
 VESPA_CLOUD_SECRET_TOKEN: str = "VESPA_CLOUD_SECRET_TOKEN"
 
@@ -114,7 +114,8 @@ class Vespa(object):
         self.key = key
         self.vespa_cloud_secret_token = vespa_cloud_secret_token
         self._application_package = application_package
-
+        self.pyvespa_version = vespa.__version__
+        self.base_headers = {"User-Agent": f"pyvespa/{self.pyvespa_version}"}
         if port is None:
             self.end_point = self.url
         else:
@@ -1021,9 +1022,7 @@ class VespaSync(object):
         else:
             self.cert = self.app.cert
         self.app.auth_method = self.app._get_valid_auth_method()
-        self.headers = {
-            "User-Agent": "pyvespa syncio client",
-        }
+        self.headers = self.app.base_headers.copy()
         if self.app.auth_method == "token" and self.app.vespa_cloud_secret_token:
             # Bearer and user-agent
             self.headers.update(
@@ -1050,7 +1049,7 @@ class VespaSync(object):
             return
 
         self.http_session = Session()
-        self.http_session.headers.update({"User-Agent": "pyvespa syncio client"})
+        self.http_session.headers.update(self.headers)
         self.http_session.mount("https://", self.adapter)
         self.http_session.mount("http://", self.adapter)
         if self.app.auth_method == "token" and self.app.vespa_cloud_secret_token:
@@ -1426,9 +1425,7 @@ class VespaAsync(object):
         self.connections = connections
         self.total_timeout = total_timeout
         self.app.auth_method = self.app._get_valid_auth_method()
-        self.headers = {
-            "User-Agent": "pyvespa asyncio client",
-        }
+        self.headers = self.app.base_headers.copy()
         if self.app.auth_method == "token" and self.app.vespa_cloud_secret_token:
             # Bearer and user-agent
             self.headers.update(

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -238,9 +238,7 @@ class Vespa(object):
         """
         Get auth method for Vespa connection.
 
-        :return: Auth method used for Vespa connection. Either 'token','mtls_key_cert','mtls_cert' or 'http'.
-
-        :raises ConnectionError: If not able to connect to endpoint using any of the available auth methods.
+        :return: Auth method used for Vespa connection. Either 'token','mtls_key_cert','mtls_cert' or 'http'. None if not able to authenticate.
         """
         endpoint = f"{self.end_point}/ApplicationStatus"
 
@@ -289,9 +287,8 @@ class Vespa(object):
                 )
                 return "mtls_cert"
 
-        raise ConnectionError(
-            "Unable to connect to endpoint using any of the available auth methods."
-        )
+        # There may be some cases where ApplicationStatus is not available, such as http://api.cord19.vespa.ai
+        return None
 
     def get_application_status(self) -> Optional[Response]:
         """

--- a/vespa/deployment.py
+++ b/vespa/deployment.py
@@ -1182,8 +1182,7 @@ class VespaCloud(VespaDeployment):
             base_url=self.base_url,
             headers=self.base_headers,
             timeout=10,
-            http1=False,
-            http2=True,
+            http1=True,
             limits=self.httpx_limits,
         ) as client:
             response = client.request(

--- a/vespa/deployment.py
+++ b/vespa/deployment.py
@@ -1174,15 +1174,19 @@ class VespaCloud(VespaDeployment):
             data = None
             content = None
         with httpx.Client(
-            base_url=self.base_url, headers=self.base_headers, timeout=10, http2=True
+            base_url=self.base_url,
+            headers=self.base_headers,
+            timeout=10,
+            http1=False,
+            http2=True,
         ) as client:
             response = client.request(
                 method, path, data=data, content=content, headers=headers
             )
-            if response.status_code != 200:
-                raise HTTPError(
-                    f"HTTP {response.status_code} error: {response.reason_phrase} for {path}"
-                )
+            # if response.status_code != 200:
+            #     raise HTTPError(
+            #         f"HTTP {response.status_code} error: {response.reason_phrase} for {path}"
+            #     )
         return response
 
     def _try_get_access_token(self) -> str:

--- a/vespa/deployment.py
+++ b/vespa/deployment.py
@@ -1181,7 +1181,7 @@ class VespaCloud(VespaDeployment):
         with httpx.Client(
             base_url=self.base_url,
             headers=self.base_headers,
-            timeout=10,
+            timeout=None,  # Need to set timeout to None to avoid httpx timeout on e.g. deployment requests
             http1=True,
             limits=self.httpx_limits,
         ) as client:

--- a/vespa/deployment.py
+++ b/vespa/deployment.py
@@ -554,6 +554,9 @@ class VespaCloud(VespaDeployment):
         self.data_cert_path = None
         self.data_key_path = None
         self.data_key, self.data_certificate = self._load_certificate_pair()
+        self.default_timeout = (
+            15  # seconds, default in httpx is 5. Eg. deployment may take longer.
+        )
         self.base_url = "https://api-ctl.vespa-cloud.com:4443"
         self.pyvespa_version = vespa.__version__
         self.base_headers = {"User-Agent": f"pyvespa/{self.pyvespa_version}"}
@@ -1170,7 +1173,9 @@ class VespaCloud(VespaDeployment):
         else:
             data = None
             content = None
-        with httpx.Client(base_url=self.base_url, headers=self.base_headers) as client:
+        with httpx.Client(
+            base_url=self.base_url, headers=self.base_headers, timeout=10, http2=True
+        ) as client:
             response = client.request(
                 method, path, data=data, content=content, headers=headers
             )

--- a/vespa/deployment.py
+++ b/vespa/deployment.py
@@ -1157,7 +1157,9 @@ class VespaCloud(VespaDeployment):
         wait=wait_exponential(multiplier=1, max=3),
         reraise=True,
     )
-    def get_connection_response_with_retry(self, method, path, body, headers):
+    def get_connection_response_with_retry(
+        self, method, path, body: Optional[BytesIO] = None, headers: Dict = {}
+    ) -> httpx.Response:
         with httpx.Client(base_url=self.base_url, headers=self.base_headers) as client:
             response = client.request(
                 method, path, data=body.getvalue(), headers=headers
@@ -1274,10 +1276,10 @@ class VespaCloud(VespaDeployment):
         body.seek(0)
         response = self.get_connection_response_with_retry(method, path, body, headers)
         parsed = json.load(response)
-        if response.status != 200:
+        if response.status_code != 200:
             print(parsed)
             raise HTTPError(
-                f"HTTP {response.status} error: {response.reason} for {url}"
+                f"HTTP {response.status_code} error: {response.reason_phrase} for {url}"
             )
         return parsed
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Took the opportunity to clean up a bit for a more consolidatet http-client usage. 
Think this will also remove instability in integration tests (where http.connection was used previously)

- [x] Use new control plane-API
- [x] Hardcode dev region (similar to vespacli)
- [x] Switch to httpx-client for more unified usage
- [x] Add common user-agent header for all clients with version
- [x] Add integration tests for user-agent header