### PR TITLE
chore: replace deprecated endpoints for vespa search feeding

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,19 +51,24 @@ search:
   do_feed: true
   do_index_removal_before_feed: false
   feed_endpoints:
-    - url: https://vespacloud-docsearch.vespa-team.aws-us-east-1c.z.vespa-app.cloud/
+    # vespacloud-docsearch // aws // us-east-1c
+    - url: https://b671e1db.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - pyvespa_index.json
-    - url: https://vespacloud-docsearch.vespa-team.gcp-us-central1-f.z.vespa-app.cloud/
+    # vespacloud-docsearch // gcp // us-central1-f
+    - url: https://a341952a.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - pyvespa_index.json
-    - url: https://vespacloud-docsearch.vespa-team.aws-eu-west-1a.z.vespa-app.cloud/
+    # vespacloud-docsearch // aws // eu-west-1a
+    - url: https://ed053d52.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - pyvespa_index.json
-    - url: https://enclave.vespacloud-docsearch.vespa-team.aws-us-east-1c.z.vespa-app.cloud/
+    # vespacloud-docsearch // aws (enclave) // us-west-1c
+    - url: https://f10d3607.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - pyvespa_index.json
-    - url: https://enclave.vespacloud-docsearch.vespa-team.gcp-us-central1-f.z.vespa-app.cloud/
+    # vespacloud-docsearch // gcp (enclave) // us-central1-f
+    - url: https://ac5f3559.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - pyvespa_index.json
 

--- a/_paragraphs_config.yml
+++ b/_paragraphs_config.yml
@@ -6,18 +6,23 @@ search:
   do_feed  : true
   do_index_removal_before_feed: false
   feed_endpoints:
-    - url: https://vespacloud-docsearch.vespa-team.aws-us-east-1c.z.vespa-app.cloud/
-      indexes:
-        - paragraph_index.json 
-    - url: https://vespacloud-docsearch.vespa-team.gcp-us-central1-f.z.vespa-app.cloud/
-      indexes:
-        - paragraph_index.json 
-    - url: https://vespacloud-docsearch.vespa-team.aws-eu-west-1a.z.vespa-app.cloud/
-      indexes:
-        - paragraph_index.json 
-    - url: https://enclave.vespacloud-docsearch.vespa-team.aws-us-east-1c.z.vespa-app.cloud/
+    # vespacloud-docsearch // aws // us-east-1c
+    - url: https://b671e1db.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - paragraph_index.json
-    - url: https://enclave.vespacloud-docsearch.vespa-team.gcp-us-central1-f.z.vespa-app.cloud/
+    # vespacloud-docsearch // gcp // us-central1-f
+    - url: https://a341952a.b68a8c0d.z.vespa-app.cloud/
+      indexes:
+        - paragraph_index.json
+    # vespacloud-docsearch // aws // eu-west-1a
+    - url: https://ed053d52.b68a8c0d.z.vespa-app.cloud/
+      indexes:
+        - paragraph_index.json
+    # vespacloud-docsearch // aws (enclave) // us-west-1c
+    - url: https://f10d3607.b68a8c0d.z.vespa-app.cloud/
+      indexes:
+        - paragraph_index.json
+    # vespacloud-docsearch // gcp (enclave) // us-central1-f
+    - url: https://ac5f3559.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - paragraph_index.json

--- a/_suggestions_config.yml
+++ b/_suggestions_config.yml
@@ -6,18 +6,23 @@ search:
   do_feed  : true
   do_index_removal_before_feed: false
   feed_endpoints:
-    - url: https://vespacloud-docsearch.vespa-team.aws-us-east-1c.z.vespa-app.cloud/
-      indexes:
-        - suggestions_index.json 
-    - url: https://vespacloud-docsearch.vespa-team.gcp-us-central1-f.z.vespa-app.cloud/
-      indexes:
-        - suggestions_index.json 
-    - url: https://vespacloud-docsearch.vespa-team.aws-eu-west-1a.z.vespa-app.cloud/
-      indexes:
-        - suggestions_index.json 
-    - url: https://enclave.vespacloud-docsearch.vespa-team.aws-us-east-1c.z.vespa-app.cloud/
+    # vespacloud-docsearch // aws // us-east-1c
+    - url: https://b671e1db.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - suggestions_index.json
-    - url: https://enclave.vespacloud-docsearch.vespa-team.gcp-us-central1-f.z.vespa-app.cloud/
+    # vespacloud-docsearch // gcp // us-central1-f
+    - url: https://a341952a.b68a8c0d.z.vespa-app.cloud/
+      indexes:
+        - suggestions_index.json
+    # vespacloud-docsearch // aws // eu-west-1a
+    - url: https://ed053d52.b68a8c0d.z.vespa-app.cloud/
+      indexes:
+        - suggestions_index.json
+    # vespacloud-docsearch // aws (enclave) // us-west-1c
+    - url: https://f10d3607.b68a8c0d.z.vespa-app.cloud/
+      indexes:
+        - suggestions_index.json
+    # vespacloud-docsearch // gcp (enclave) // us-central1-f
+    - url: https://ac5f3559.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - suggestions_index.json


### PR DESCRIPTION
## What

- Replace the custom vespa cloud endpoints with the generated ones.

## Why

- The custom endpoints are deprecated and will be removed in the future.

## Additional Info

Related PRs:
- https://github.com/vespa-engine/documentation/pull/3327
- https://github.com/vespa-engine/sample-apps/pull/1445

---
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
