### PR TITLE
Revert "infer auth method without request"

### DIFF
--- a/vespa/application.py
+++ b/vespa/application.py
@@ -8,6 +8,7 @@ from typing import Optional, Dict, Generator, List, IO, Iterable, Callable, Tupl
 from concurrent.futures import ThreadPoolExecutor, Future, as_completed
 from queue import Queue, Empty
 import threading
+import requests
 from requests import Session
 from requests.models import Response
 from requests.exceptions import ConnectionError, HTTPError, JSONDecodeError
@@ -124,7 +125,7 @@ class Vespa(object):
             token = environ.get(VESPA_CLOUD_SECRET_TOKEN, None)
             if token is not None:
                 self.vespa_cloud_secret_token = token
-        self.auth_method = self._get_valid_auth_method()
+        self.auth_method = None
 
     def asyncio(
         self, connections: Optional[int] = 8, total_timeout: int = 10
@@ -255,20 +256,55 @@ class Vespa(object):
 
         :return: Auth method used for Vespa connection. Either 'token','mtls_key_cert','mtls_cert' or 'http'. None if not able to authenticate.
         """
+        endpoint = f"{self.end_point}/ApplicationStatus"
+
+        if self.auth_method:
+            return self.auth_method
+
+        # Plain HTTP
+        response = requests.get(endpoint, headers=self.base_headers)
+        if response.status_code == 200:
+            print(
+                f"Using plain HTTP to connect to Vespa endpoint {self.end_point}",
+                file=self.output_file,
+            )
+            return "http"
+
         # Vespa Cloud Secret Token
         if self.vespa_cloud_secret_token is not None:
-            return "token"
+            headers = {"Authorization": f"Bearer {self.vespa_cloud_secret_token}"}
+            response = requests.get(endpoint, headers={**self.base_headers, **headers})
+            if response.status_code == 200:
+                print(
+                    f"Using Vespa Cloud Secret Token to connect to Vespa endpoint {self.end_point}",
+                    file=self.output_file,
+                )
+                return "token"
 
         # Mutual TLS with key and cert
-        elif self.key and self.cert:
-            return "mtls_key_cert"
+        if self.key and self.cert:
+            response = requests.get(
+                endpoint, headers=self.base_headers, cert=(self.cert, self.key)
+            )
+            if response.status_code == 200:
+                print(
+                    f"Using Mutual TLS with key and cert to connect to Vespa endpoint {self.end_point}",
+                    file=self.output_file,
+                )
+                return "mtls_key_cert"
 
         # Mutual TLS with cert
-        elif self.cert:
-            return "mtls_cert"
-        # Plain HTTP
-        else:
-            return "http"
+        if self.cert:
+            response = requests.get(endpoint, headers=self.base_headers, cert=self.cert)
+            if response.status_code == 200:
+                print(
+                    f"Using Mutual TLS with cert to connect to Vespa endpoint {self.end_point}",
+                    file=self.output_file,
+                )
+                return "mtls_cert"
+
+        # There may be some cases where ApplicationStatus is not available, such as http://api.cord19.vespa.ai
+        return None
 
     def get_application_status(self) -> Optional[Response]:
         """
@@ -1018,6 +1054,7 @@ class VespaSync(object):
             self.cert = (self.app.cert, self.app.key)
         else:
             self.cert = self.app.cert
+        self.app.auth_method = self.app._get_valid_auth_method()
         self.headers = self.app.base_headers.copy()
         if self.app.auth_method == "token" and self.app.vespa_cloud_secret_token:
             # Bearer and user-agent
@@ -1435,6 +1472,7 @@ class VespaAsync(object):
         self.httpx_client = None
         self.connections = connections
         self.total_timeout = total_timeout
+        self.app.auth_method = self.app._get_valid_auth_method()
         self.headers = self.app.base_headers.copy()
         if self.app.auth_method == "token" and self.app.vespa_cloud_secret_token:
             # Bearer and user-agent


### PR DESCRIPTION
## What

Reverts vespa-engine/pyvespa#894


## Why

We noticed some issues on authenticating with mtls to recently deployed applications on this version. 
Still not sure if this is a real issue, as it was observed locally, but not in integration tests, or Colab.