### PR TITLE
feat(ci/cd): set version to 0.dev

### DIFF
--- a/.github/workflows/pyvespa.yml
+++ b/.github/workflows/pyvespa.yml
@@ -1,13 +1,15 @@
 name: pyvespa - Release and upload PyPI
 
 on:
-  workflow_dispatch:
-  # release: Disable auto-release until actions are approved
-  #   types: [published]
+  release:
+    types: [published]
 
 jobs:
   update_version:
     runs-on: ubuntu-latest
+    env:
+      # Workaround to ensure that the version is available
+      RELEASE_REF: ${{ github.ref || format('{0}{1}', 'refs/tags/', github.event.release.tag_name) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -22,9 +24,8 @@ jobs:
       - name: Set version from ref tag that triggered the workflow (strip prefix 'v' from tag)
         id: set_version
         run: |
-          echo "GITHUB_REF=$GITHUB_REF"
           # strip prefix 'v' from version variable
-          version=${GITHUB_REF#refs/tags/v}
+          version=${RELEASE_REF#refs/tags/v}
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Update version

--- a/.github/workflows/pyvespa.yml
+++ b/.github/workflows/pyvespa.yml
@@ -22,15 +22,17 @@ jobs:
       - name: Set version from ref tag that triggered the workflow (strip prefix 'v' from tag)
         id: set_version
         run: |
-          echo "GITHUB_REF=$GITHUB_REF" 
+          echo "GITHUB_REF=$GITHUB_REF"
           # strip prefix 'v' from version variable
           version=${GITHUB_REF#refs/tags/v}
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Update version
+        env:
+          VERSION: ${{ steps.set_version.outputs.version }}
         run: |
-          echo "Updating pyvespa version to ${{ steps.set_version.outputs.version }}"
-          python vespa/utils/update_version.py --version ${{ steps.set_version.outputs.version }}
+          echo "Updating pyvespa version to ${VERSION}"
+          python vespa/utils/update_version.py --version "${VERSION}"
 
       - name: Build
         run: |
@@ -40,19 +42,6 @@ jobs:
         if: github.event_name == 'release'
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_PYVESPA }} #TODO: this must be added to secrets
-        run: python -m twine upload dist/*
-
-      - name: Commit and PR
-        if: github.event_name == 'release'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NEW_BRANCH:  "update-pyvespa-version-${{ steps.set_version.outputs.version }}"
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_PYVESPA }}
         run: |
-          git checkout -b "${NEW_BRANCH}"
-          git commit -a -m "Update pyvespa version to ${{ steps.set_version.outputs.version }}"
-          git push --set-upstream origin "${NEW_BRANCH}"
-          gh pr create -B master -H "${NEW_BRANCH}" \
-            -t "Update pyvespa version to ${{ steps.set_version.outputs.version }}" \
-            -b ":robot: This PR updates the pyvespa version to ${{ steps.set_version.outputs.version }}" 
-
+          python -m twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@
 </picture>
 
 [![Documentation Status](https://readthedocs.org/projects/pyvespa/badge/?version=latest)](https://pyvespa.readthedocs.io/en/latest/?badge=latest)
-<a href="https://cd.screwdriver.cd/pipelines/7055"><img src="https://cd.screwdriver.cd/pipelines/7055/badge"/></a>
+
+![GitHub Release](https://img.shields.io/github/v/release/vespa-engine/pyvespa)
+![PyPI - Version](https://img.shields.io/pypi/v/pyvespa)
+![PyPI - Downloads](https://img.shields.io/pypi/dm/pyvespa)
+
 
 [pyvespa site / documentation](https://pyvespa.readthedocs.io/en/latest/index.html)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyvespa"
-version = "0.48.0"
+version = "0.dev"
 description = "Python API for vespa.ai"
 readme = "README.md"
 keywords = ["vespa", "search engine", "data science"]
@@ -61,13 +61,13 @@ docs = [
     "ipykernel",
 ]
 feed = [
-    "PyYAML", 
-    "spacy", 
-    "mmh3", 
-    "requests<=2.31.0", 
-    "html5lib", 
-    "beautifulsoup4", 
-    "markdownify", 
+    "PyYAML",
+    "spacy",
+    "mmh3",
+    "requests<=2.31.0",
+    "html5lib",
+    "beautifulsoup4",
+    "markdownify",
     "tiktoken",
     "vespacli",
 ]

--- a/vespa/__init__.py
+++ b/vespa/__init__.py
@@ -1,3 +1,3 @@
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-__version__ = "0.48.0"
+__version__ = "0.dev"


### PR DESCRIPTION
## What

- Update versions in the repo to `0.dev`
- Remove the "Create PR" step during. the release process
- Update badges in the README file
- Re-enable the workflows to publish the package when a release is created

##  Why

Before this change each time we would release a new version we would also need to update the version in this repo _(examples [here](https://github.com/vespa-engine/pyvespa/pull/896) and [here](https://github.com/vespa-engine/pyvespa/pull/892), ...)_, this is s superfluous step which was required mostly to ensure that the CI workflows would work when doing `pip install -e .` as this requires a valid version.

After some discussion with @thomasht86 we reached the conclusion that we can set the "<X>.dev" version _(where X is the current major version)_ in those files and we update the version in those files during the release process for pypi.