### PR TITLE
do not fail if response is not json (e.g. xml)

### DIFF
--- a/vespa/deployment.py
+++ b/vespa/deployment.py
@@ -1284,7 +1284,10 @@ class VespaCloud(VespaDeployment):
         response = self.get_connection_response_with_retry(method, path, body, headers)
         if return_raw_response:
             return response
-        parsed = json.load(response)
+        try:
+            parsed = json.load(response)
+        except json.JSONDecodeError:
+            parsed = response.read()
         if response.status_code != 200:
             print(parsed)
             raise HTTPError(


### PR DESCRIPTION
This PR fixes a bug where non-JSON (e.g. XML) responses will cause failure.
Sister function `_request_with_access_token` has no such bug.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
