### PR TITLE
(ci) remove obsolete import

### DIFF
--- a/vespacli/utils/download_binaries.py
+++ b/vespacli/utils/download_binaries.py
@@ -6,7 +6,6 @@ from zipfile import ZipFile
 
 import requests
 import argparse
-from vespacli._version_generated import vespa_version
 
 
 class VespaBinaryDownloader:
@@ -38,8 +37,6 @@ class VespaBinaryDownloader:
         )
         if self.version == "latest":
             self.version = self.get_latest_version()
-        elif self.version == "current":
-            self.version = vespa_version
 
     def _validate_version(self, version):
         # Must be either "latest", "current", or a valid version number (X.Y.Z) (optional "v" prefix)


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

**Why**

[Release workflow](https://github.com/vespa-engine/pyvespa/actions/runs/10903428041) is failing due to obsolete import reference.

**What**

Removes obsolete import statement and the imported variable.