### PR TITLE
fix(CI): json access in script checking the current pypi version

### DIFF
--- a/vespacli/utils/check_latest_version.py
+++ b/vespacli/utils/check_latest_version.py
@@ -7,9 +7,9 @@ from packaging import version
 def get_latest_pypi_version() -> version.Version:
     response = requests.get(
         "https://pypi.org/simple/vespacli/",
-        headers={"Accept": "application/vnd.pypi.simple.v1+json"}
+        headers={"Accept": "application/vnd.pypi.simple.v1+json"},
     )
-    latest_version = response.json()["releases"][-1]["version"]
+    latest_version = response.json()["versions"][-1]
     return version.parse(latest_version)
 
 
@@ -22,7 +22,7 @@ if __name__ == "__main__":
     gh_release = get_latest_github_version()
     pypi_release = get_latest_pypi_version()
     if gh_release > pypi_release:
-        print(f"{0}" % gh_release)
+        print(f"{gh_release}")
     else:
         print("NA")
     sys.exit(0)


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

**Why** 

Workflow is [failling](https://github.com/vespa-engine/pyvespa/actions/runs/10913595559), due to incorrect parsing of pypi version.

**What**

Fixes the script that retrieves the version. 
