### PR TITLE
(docs) Change name in toc

### DIFF
--- a/docs/sphinx/source/examples.rst
+++ b/docs/sphinx/source/examples.rst
@@ -23,5 +23,5 @@ Examples
    examples/feed_performance_cloud.ipynb
    examples/cross-encoders-for-global-reranking.ipynb
    examples/evaluating-with-snowflake-arctic-embed.ipynb
-   examples/colpali-document-retrieval-vision-language-models.ipynb
    examples/simplified-retrieval-with-colpali-vlm_Vespa-cloud.ipynb
+   examples/colpali-document-retrieval-vision-language-models-cloud.ipynb


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

The toc wasn't updated after renaming the notebook with *cloud-suffix. 