### PR TITLE
(ci) remove __init__ from version update

### DIFF
--- a/vespa/utils/update_version.py
+++ b/vespa/utils/update_version.py
@@ -1,7 +1,6 @@
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 # This script should modify top level pyproject.toml to update the version of pyvespa
-# And modify vespa/__init__.py to update the version of pyvespa
 
 import sys
 import re
@@ -9,7 +8,6 @@ from pathlib import Path
 import argparse
 
 PYPROJECT_TOML_PATH = Path(__file__).parent.parent.parent / "pyproject.toml"
-VERSION_FILE_PATH = Path(__file__).parent.parent / "__init__.py"
 
 
 def update_version(new_version: str):
@@ -18,15 +16,6 @@ def update_version(new_version: str):
         content = f.read()
     new_content = re.sub(r'version = ".*"', f'version = "{new_version}"', content)
     with open(PYPROJECT_TOML_PATH, "w") as f:
-        f.write(new_content)
-
-    # Update version in vespacli/_version_generated.py
-    with open(VERSION_FILE_PATH, "r") as f:
-        content = f.read()
-    new_content = re.sub(
-        r'__version__ = ".*"', f'__version__ = "{new_version}"', content
-    )
-    with open(VERSION_FILE_PATH, "w") as f:
         f.write(new_content)
     print(f"Updated version to {new_version}")
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

**Why** 

The update version script tries to update __init__.py, which no longer has the version variable
Need this for release pipeline to work.

**How** 

Removed reference to the file.