### PR TITLE
(ci) pin openai version

### DIFF
--- a/docs/sphinx/source/examples/Matryoshka_embeddings_in_Vespa-cloud.ipynb
+++ b/docs/sphinx/source/examples/Matryoshka_embeddings_in_Vespa-cloud.ipynb
@@ -37,7 +37,7 @@
             },
             "outputs": [],
             "source": [
-                "!pip3 install -U pyvespa ir_datasets openai pytrec_eval vespacli"
+                "!pip3 install -U pyvespa ir_datasets openai==1.47.1 pytrec_eval vespacli"
             ]
         },
         {


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Try to see if pinning the version fixes failing [test](https://github.com/vespa-engine/pyvespa/actions/runs/11031367127/job/30637967344?pr=937)