### PR TITLE
(feat) Support requestthreads persearch

### DIFF
--- a/docs/sphinx/source/advanced-configuration.ipynb
+++ b/docs/sphinx/source/advanced-configuration.ipynb
@@ -57,7 +57,7 @@
    "id": "db637322",
    "metadata": {},
    "source": [
-    "## Setting up document-expiry\n",
+    "## Example 1 - Configure document-expiry\n",
     "\n",
     "As an example of a common use case for advanced configuration, we will configure document-expiry. This feature allows you to set a time-to-live for documents in your Vespa application. This is useful when you have documents that are only relevant for a certain period of time, and you want to avoid serving stale data.\n",
     "\n",
@@ -80,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "bd5c2629",
    "metadata": {},
    "outputs": [],
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "05318c34",
    "metadata": {},
    "outputs": [],
@@ -258,7 +258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "canadian-blood",
    "metadata": {},
    "outputs": [
@@ -301,7 +301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "e9d3facd",
    "metadata": {},
    "outputs": [],
@@ -330,7 +330,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "6185fbce",
    "metadata": {},
    "outputs": [],
@@ -359,7 +359,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "450a925f",
    "metadata": {},
    "outputs": [
@@ -370,11 +370,11 @@
        "  'documents': [{'id': 'id:music:music::2',\n",
        "    'fields': {'artist': 'Dr.Dre',\n",
        "     'title': 'Still D.R.E',\n",
-       "     'timestamp': 1727175623}}],\n",
+       "     'timestamp': 1727428957}}],\n",
        "  'documentCount': 1}]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -401,15 +401,399 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28591491",
+   "id": "5a96c679",
    "metadata": {},
    "source": [
-    "## Cleanup\n"
+    "### Clean up\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
+   "id": "60892e1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vespa_docker.container.stop()\n",
+    "vespa_docker.container.remove()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acc5e8fa",
+   "metadata": {},
+   "source": [
+    "## Example 2 - Configuring `requestthreads` per search\n",
+    "\n",
+    "In Vespa, there are several configuration options that might be tuned to optimize the serving latency of your application.\n",
+    "For an overview, see the [Vespa documentation - Vespa Serving Scaling Guide](https://docs.vespa.ai/en/performance/sizing-search.html).\n",
+    "An example of a configuration that one might want to tune is the `requestthreads` `persearch` [parameter](https://docs.vespa.ai/en/reference/services-content.html#requestthreads). This parameter controls the number of search threads that are used to handle each search on the content nodes. The default value is 1.\n",
+    "\n",
+    "For some applications, where a significant portion of the work per query is linear with the number of documents, increasing the number of `requestthreads` `persearch` can improve the serving latency, as it allows more parallelism in the search phase.\n",
+    "\n",
+    "Examples of potentially expensive work that scales linearly with the number of documents, and thus are likely to benefit from increasing `requestthreads` `persearch` are: - Xgboost inference with a large GDBT-model - ONNX inference, e.g with a [Crossencoder](examples/cross-encoders-for-global-reranking.html). - MaxSim-operations for late interaction scoring, as in ColBERT and ColPali. - Exact nearest neighbor search.\n",
+    "\n",
+    "Example of query operators that are less likely to benefit from increasing `requestthreads` `persearch` are: - `wand`/`weakAnd`, see [Using wand with Vespa](https://docs.vespa.ai/en/using-wand-with-vespa.html). - Approximate nearest neighbor search with HNSW.\n",
+    "\n",
+    "In this example, we will demonstrate an example of configuring `requestthreads` `persearch` to 4 for an application where a Crossencoder is used in first-phase ranking. The demo is based on the [Cross-encoders for global reranking](cross-encoders-for-global-reranking.html) guide, but here we will use a cross-encoder in first-phase instead of global-phase. First-phase and second-phase ranking are executed on the content nodes, while global-phase ranking is executed on the container node. See [Phased ranking](https://docs.vespa.ai/en/phased-ranking.html) for more details.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40e7135d",
+   "metadata": {},
+   "source": [
+    "### Download the crossencoder-model\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "7706ca0e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model already exists, skipping download.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pathlib import Path\n",
+    "import requests\n",
+    "from vespa.deployment import VespaDocker\n",
+    "\n",
+    "# Download the model if it doesn't exist\n",
+    "url = \"https://huggingface.co/mixedbread-ai/mxbai-rerank-xsmall-v1/resolve/main/onnx/model.onnx\"\n",
+    "local_model_path = \"model/model.onnx\"\n",
+    "if not Path(local_model_path).exists():\n",
+    "    print(\"Downloading the mxbai-rerank model...\")\n",
+    "    r = requests.get(url)\n",
+    "    Path(local_model_path).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    with open(local_model_path, \"wb\") as f:\n",
+    "        f.write(r.content)\n",
+    "        print(f\"Downloaded model to {local_model_path}\")\n",
+    "else:\n",
+    "    print(\"Model already exists, skipping download.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ca18d13",
+   "metadata": {},
+   "source": [
+    "### Define a schema\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "379121de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from vespa.package import (\n",
+    "    OnnxModel,\n",
+    "    RankProfile,\n",
+    "    Schema,\n",
+    "    ApplicationPackage,\n",
+    "    Field,\n",
+    "    FieldSet,\n",
+    "    Function,\n",
+    "    FirstPhaseRanking,\n",
+    "    Document,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "application_name = \"requestthreads\"\n",
+    "\n",
+    "# Define the reranking, as we will use it for two different rank profiles\n",
+    "reranking = FirstPhaseRanking(\n",
+    "    keep_rank_count=8,\n",
+    "    expression=\"sigmoid(onnx(crossencoder).logits{d0:0,d1:0})\",\n",
+    ")\n",
+    "\n",
+    "# Define the schema\n",
+    "schema = Schema(\n",
+    "    name=\"doc\",\n",
+    "    document=Document(\n",
+    "        fields=[\n",
+    "            Field(name=\"id\", type=\"string\", indexing=[\"summary\", \"attribute\"]),\n",
+    "            Field(\n",
+    "                name=\"text\",\n",
+    "                type=\"string\",\n",
+    "                indexing=[\"index\", \"summary\"],\n",
+    "                index=\"enable-bm25\",\n",
+    "            ),\n",
+    "            Field(\n",
+    "                name=\"body_tokens\",\n",
+    "                type=\"tensor<float>(d0[512])\",\n",
+    "                indexing=[\n",
+    "                    \"input text\",\n",
+    "                    \"embed tokenizer\",\n",
+    "                    \"attribute\",\n",
+    "                    \"summary\",\n",
+    "                ],\n",
+    "                is_document_field=False,  # Indicates a synthetic field\n",
+    "            ),\n",
+    "        ],\n",
+    "    ),\n",
+    "    fieldsets=[FieldSet(name=\"default\", fields=[\"text\"])],\n",
+    "    models=[\n",
+    "        OnnxModel(\n",
+    "            model_name=\"crossencoder\",\n",
+    "            model_file_path=f\"{local_model_path}\",\n",
+    "            inputs={\n",
+    "                \"input_ids\": \"input_ids\",\n",
+    "                \"attention_mask\": \"attention_mask\",\n",
+    "            },\n",
+    "            outputs={\"logits\": \"logits\"},\n",
+    "        )\n",
+    "    ],\n",
+    "    rank_profiles=[\n",
+    "        RankProfile(name=\"bm25\", first_phase=\"bm25(text)\"),\n",
+    "        RankProfile(\n",
+    "            name=\"reranking\",\n",
+    "            inherits=\"default\",\n",
+    "            inputs=[(\"query(q)\", \"tensor<float>(d0[64])\")],\n",
+    "            functions=[\n",
+    "                Function(\n",
+    "                    name=\"input_ids\",\n",
+    "                    expression=\"customTokenInputIds(1, 2, 512, query(q), attribute(body_tokens))\",\n",
+    "                ),\n",
+    "                Function(\n",
+    "                    name=\"attention_mask\",\n",
+    "                    expression=\"tokenAttentionMask(512, query(q), attribute(body_tokens))\",\n",
+    "                ),\n",
+    "            ],\n",
+    "            first_phase=reranking,\n",
+    "            summary_features=[\n",
+    "                \"query(q)\",\n",
+    "                \"input_ids\",\n",
+    "                \"attention_mask\",\n",
+    "                \"onnx(crossencoder).logits\",\n",
+    "            ],\n",
+    "        ),\n",
+    "        RankProfile(\n",
+    "            name=\"one-thread-profile\",\n",
+    "            first_phase=reranking,\n",
+    "            inherits=\"reranking\",\n",
+    "            num_threads_per_search=1,\n",
+    "        ),\n",
+    "    ],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a39afb6",
+   "metadata": {},
+   "source": [
+    "### Define the ServicesConfiguration\n",
+    "\n",
+    "Note that the ServicesConfiguration may be used to define any configuration in the `services.xml` file. In this example, we are only configuring the `requestthreads` `persearch` parameter, but you can use the same approach to configure any other parameter.\n",
+    "\n",
+    "For a full reference of the available configuration options, see the [Vespa documentation - services.xml](https://docs.vespa.ai/en/reference/services.html).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "ad07c782",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from vespa.configuration.services import *\n",
+    "from vespa.package import ServicesConfiguration\n",
+    "\n",
+    "# Define services configuration with persearch threads set to 4\n",
+    "services_config = ServicesConfiguration(\n",
+    "    application_name=f\"{application_name}\",\n",
+    "    services_config=services(\n",
+    "        container(id=f\"{application_name}_default\", version=\"1.0\")(\n",
+    "            component(\n",
+    "                model(\n",
+    "                    url=\"https://huggingface.co/mixedbread-ai/mxbai-rerank-xsmall-v1/raw/main/tokenizer.json\"\n",
+    "                ),\n",
+    "                id=\"tokenizer\",\n",
+    "                type=\"hugging-face-tokenizer\",\n",
+    "            ),\n",
+    "            document_api(),\n",
+    "            search(),\n",
+    "        ),\n",
+    "        content(id=f\"{application_name}\", version=\"1.0\")(\n",
+    "            min_redundancy(\"1\"),\n",
+    "            documents(document(type=\"doc\", mode=\"index\")),\n",
+    "            engine(\n",
+    "                proton(\n",
+    "                    tuning(\n",
+    "                        searchnode(requestthreads(persearch(\"4\"))),\n",
+    "                    ),\n",
+    "                ),\n",
+    "            ),\n",
+    "        ),\n",
+    "        version=\"1.0\",\n",
+    "        minimum_required_vespa_version=\"8.311.28\",\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae39395a",
+   "metadata": {},
+   "source": [
+    "Now, we are ready to deploy our application-package with the defined `ServiceConfiguration`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c5fdfc8",
+   "metadata": {},
+   "source": [
+    "### Deploy the application package\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "f4850126",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app_package = ApplicationPackage(\n",
+    "    name=f\"{application_name}\",\n",
+    "    schema=[schema],\n",
+    "    services_config=services_config,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "ea454535",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app_package.to_files(\"deleteme\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "1c2be2f2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Waiting for configuration server, 0/60 seconds...\n",
+      "Waiting for application to come up, 0/300 seconds.\n",
+      "Waiting for application to come up, 5/300 seconds.\n",
+      "Waiting for application to come up, 10/300 seconds.\n",
+      "Waiting for application to come up, 15/300 seconds.\n",
+      "Waiting for application to come up, 20/300 seconds.\n",
+      "Waiting for application to come up, 25/300 seconds.\n",
+      "Application is up!\n",
+      "Finished deployment.\n"
+     ]
+    }
+   ],
+   "source": [
+    "vespa_docker = VespaDocker(port=8089)\n",
+    "app = vespa_docker.deploy(application_package=app_package)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b5d47b1",
+   "metadata": {},
+   "source": [
+    "### Feed some sample documents\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "a6eeaa9d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Query time with 4 threads: 0.72s\n",
+      "Query time with 1 thread: 1.24s\n",
+      "4 threads is approximately 1.72x faster than 1 thread\n"
+     ]
+    }
+   ],
+   "source": [
+    "sample_docs = [\n",
+    "    {\"id\": i, \"fields\": {\"text\": text}}\n",
+    "    for i, text in enumerate(\n",
+    "        [\n",
+    "            \"'To Kill a Mockingbird' is a novel by Harper Lee published in 1960. It was immediately successful, winning the Pulitzer Prize, and has become a classic of modern American literature. The novel 'Moby-Dick' was written by Herman Melville and first published in 1851. Harper Lee, an American novelist widely known for her novel 'To Kill a Mockingbird'. It is considered a masterpiece of American literature and deals with complex themes of obsession, revenge, and the conflict between good and evil.\",\n",
+    "            \"was born in 1926 in Monroeville, Alabama. She received the Pulitzer Prize for Fiction in 1961. Jane Austen was an English novelist known primarily for her six major novels, \",\n",
+    "            \"which interpret, critique and comment upon the British landed gentry at the end of the 18th century. The 'Harry Potter' series, which consists of seven fantasy novels written by British author J.K. Rowling, \",\n",
+    "            \"is among the most popular and critically acclaimed books of the modern era. 'The Great Gatsby', a novel written by American author F. Scott Fitzgerald, was published in 1925. The story is set in the Jazz Age and follows the life of millionaire Jay Gatsby and his pursuit of Daisy Buchanan.\",\n",
+    "        ]\n",
+    "    )\n",
+    "]\n",
+    "app.feed_iterable(sample_docs, schema=\"doc\")\n",
+    "\n",
+    "# Define the query body\n",
+    "query_body = {\n",
+    "    \"yql\": \"select * from sources * where userQuery();\",\n",
+    "    \"query\": \"who wrote to kill a mockingbird?\",\n",
+    "    \"timeout\": \"10s\",\n",
+    "    \"input.query(q)\": \"embed(tokenizer, @query)\",\n",
+    "    \"presentation.timing\": \"true\",\n",
+    "}\n",
+    "\n",
+    "# Warm-up query\n",
+    "app.query(body=query_body)\n",
+    "query_body_reranking = {\n",
+    "    **query_body,\n",
+    "    \"ranking.profile\": \"reranking\",\n",
+    "}\n",
+    "# Query with default persearch threads (set to 4)\n",
+    "with app.syncio() as sess:\n",
+    "    response_default = app.query(body=query_body_reranking)\n",
+    "\n",
+    "# Query with num-threads-per-search overridden to 1\n",
+    "query_body_one_thread = {\n",
+    "    **query_body,\n",
+    "    \"ranking.profile\": \"one-thread-profile\",\n",
+    "    # \"ranking.matching.numThreadsPerSearch\": 1, Could potentiall also set numThreadsPerSearch in query parameters.\n",
+    "}\n",
+    "with app.syncio() as sess:\n",
+    "    response_one_thread = sess.query(body=query_body_one_thread)\n",
+    "\n",
+    "# Extract query times\n",
+    "timing_default = response_default.json[\"timing\"][\"querytime\"]\n",
+    "timing_one_thread = response_one_thread.json[\"timing\"][\"querytime\"]\n",
+    "# Beautifully formatted statement of - num threads and ratio of query times\n",
+    "print(f\"Query time with 4 threads: {timing_default:.2f}s\")\n",
+    "print(f\"Query time with 1 thread: {timing_one_thread:.2f}s\")\n",
+    "ratio = timing_one_thread / timing_default\n",
+    "print(f\"4 threads is approximately {ratio:.2f}x faster than 1 thread\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28591491",
+   "metadata": {},
+   "source": [
+    "### Cleanup\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
    "id": "e5064bd2",
    "metadata": {},
    "outputs": [],
@@ -445,7 +829,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.10.14"
   },
   "vscode": {
    "interpreter": {

--- a/docs/sphinx/source/advanced-configuration.ipynb
+++ b/docs/sphinx/source/advanced-configuration.ipynb
@@ -431,11 +431,11 @@
     "\n",
     "For some applications, where a significant portion of the work per query is linear with the number of documents, increasing the number of `requestthreads` `persearch` can improve the serving latency, as it allows more parallelism in the search phase.\n",
     "\n",
-    "Examples of potentially expensive work that scales linearly with the number of documents, and thus are likely to benefit from increasing `requestthreads` `persearch` are: - Xgboost inference with a large GDBT-model - ONNX inference, e.g with a [Crossencoder](examples/cross-encoders-for-global-reranking.html). - MaxSim-operations for late interaction scoring, as in ColBERT and ColPali. - Exact nearest neighbor search.\n",
+    "Examples of potentially expensive work that scales linearly with the number of documents, and thus are likely to benefit from increasing `requestthreads` `persearch` are: - Xgboost inference with a large GDBT-model - ONNX inference, e.g with a crossencoder. - MaxSim-operations for late interaction scoring, as in ColBERT and ColPali. - Exact nearest neighbor search.\n",
     "\n",
     "Example of query operators that are less likely to benefit from increasing `requestthreads` `persearch` are: - `wand`/`weakAnd`, see [Using wand with Vespa](https://docs.vespa.ai/en/using-wand-with-vespa.html). - Approximate nearest neighbor search with HNSW.\n",
     "\n",
-    "In this example, we will demonstrate an example of configuring `requestthreads` `persearch` to 4 for an application where a Crossencoder is used in first-phase ranking. The demo is based on the [Cross-encoders for global reranking](cross-encoders-for-global-reranking.html) guide, but here we will use a cross-encoder in first-phase instead of global-phase. First-phase and second-phase ranking are executed on the content nodes, while global-phase ranking is executed on the container node. See [Phased ranking](https://docs.vespa.ai/en/phased-ranking.html) for more details.\n"
+    "In this example, we will demonstrate an example of configuring `requestthreads` `persearch` to 4 for an application where a Crossencoder is used in first-phase ranking. The demo is based on the [Cross-encoders for global reranking](https://pyvespa.readthedocs.io/en/latest/examples/cross-encoders-for-global-reranking.html) guide, but here we will use a cross-encoder in first-phase instead of global-phase. First-phase and second-phase ranking are executed on the content nodes, while global-phase ranking is executed on the container node. See [Phased ranking](https://docs.vespa.ai/en/phased-ranking.html) for more details.\n"
    ]
   },
   {

--- a/tests/integration/test_integration_docker.py
+++ b/tests/integration/test_integration_docker.py
@@ -26,11 +26,16 @@ from vespa.package import (
     AuthClient,
     Struct,
     ServicesConfiguration,
+    FirstPhaseRanking,
+    SecondPhaseRanking,
+    Function,
+    OnnxModel,
 )
 from vespa.configuration.services import *
 from vespa.deployment import VespaDocker
 from vespa.application import VespaSync
 from vespa.exceptions import VespaError
+from pathlib import Path
 
 CONTAINER_STOP_TIMEOUT = 10
 RESOURCES_DIR = get_resource_path()
@@ -1720,6 +1725,416 @@ class TestDocumentExpiry(unittest.TestCase):
         # Visit results: [{'pathId': '/document/v1/music/music/docid/', 'documents': [{'id': 'id:music:music::2', 'fields': {'artist': 'Dr. Dre', 'title': 'Still D.R.E', 'timestamp': 1726836495}}], 'documentCount': 1}]
         self.assertEqual(len(visit_results), 1)
         self.assertEqual(visit_results[0]["documentCount"], 1)
+
+    def tearDown(self) -> None:
+        self.vespa_docker.container.stop(timeout=CONTAINER_STOP_TIMEOUT)
+        self.vespa_docker.container.remove()
+
+
+class TestColBERTLong(unittest.TestCase):
+    # Also tests ServiceConfiguration with setting requestthreads persearch
+    def setUp(self) -> None:
+        application_name = "colbert"
+        schema = Schema(
+            name="doc",
+            document=Document(
+                fields=[
+                    Field(
+                        name="id",
+                        type="string",
+                        indexing=["summary"],
+                    ),
+                    Field(
+                        name="text",
+                        type="array<string>",
+                        indexing=["index", "summary"],
+                        index="enable-bm25",
+                    ),
+                    Field(
+                        name="colbert",
+                        type="tensor<int8>(context{}, token{}, v[16])",
+                        indexing=[
+                            "input text",
+                            "embed colbert context",
+                            "attribute",
+                        ],
+                        attribute=["paged"],
+                        is_document_field=False,
+                    ),
+                ],
+            ),
+            fieldsets=[FieldSet(name="default", fields=["text"])],
+            rank_profiles=[
+                RankProfile(
+                    name="bm25",
+                    inputs=[("query(qt)", "tensor<float>(querytoken{}, v[128])")],
+                    first_phase="bm25(text)",
+                    rank_properties=[
+                        ("bm25(text).k1", 0.9),
+                        ("bm25(text).b", 0.4),
+                    ],
+                ),
+                RankProfile(
+                    name="colbert-max-sim-context-level",
+                    inputs=[("query(qt)", "tensor<float>(querytoken{}, v[128])")],
+                    first_phase="bm25(text)",
+                    second_phase=SecondPhaseRanking(
+                        rerank_count=400,
+                        expression="reduce(max_sim_per_context, max, context)",
+                    ),
+                    inherits="bm25",
+                    functions=[
+                        Function(
+                            name="max_sim_per_context",
+                            expression="""
+                            sum(
+                                reduce(
+                                    sum(
+                                        query(qt) * unpack_bits(attribute(colbert)) , v
+                                    ),
+                                    max, token
+                                ),
+                                querytoken
+                            )
+                            """,
+                        )
+                    ],
+                ),
+                RankProfile(
+                    name="colbert-max-sim-cross-context",
+                    first_phase="bm25(text)",
+                    inputs=[("query(qt)", "tensor<float>(querytoken{}, v[128])")],
+                    second_phase=SecondPhaseRanking(
+                        rerank_count=400, expression="cross_max_sim"
+                    ),
+                    inherits="bm25",
+                    functions=[
+                        Function(
+                            name="cross_max_sim",
+                            expression="""
+                                        sum(
+                                            reduce(
+                                                sum(
+                                                    query(qt) * unpack_bits(attribute(colbert)) , v
+                                                ),
+                                                max, token, context
+                                            ),
+                                            querytoken
+                                        )
+                                        """,
+                        )
+                    ],
+                ),
+                RankProfile(
+                    name="one-thread-profile",
+                    first_phase="bm25(text)",
+                    inputs=[("query(qt)", "tensor<float>(querytoken{}, v[128])")],
+                    second_phase=SecondPhaseRanking(
+                        rerank_count=400, expression="cross_max_sim"
+                    ),
+                    inherits="bm25",
+                    functions=[
+                        Function(
+                            name="cross_max_sim",
+                            expression="""
+                                        sum(
+                                            reduce(
+                                                sum(
+                                                    query(qt) * unpack_bits(attribute(colbert)) , v
+                                                ),
+                                                max, token, context
+                                            ),
+                                            querytoken
+                                        )
+                                        """,
+                        )
+                    ],
+                    rank_properties=[("num-threads-per-search", 1)],
+                ),
+            ],
+        )
+        services_config = ServicesConfiguration(
+            application_name=f"{application_name}",
+            services_config=services(
+                container(id=f"{application_name}_default", version="1.0")(
+                    component(id="colbert", type="colbert-embedder")(
+                        transformer_model(
+                            url="https://huggingface.co/colbert-ir/colbertv2.0/resolve/main/model.onnx"
+                        ),
+                        tokenizer_model(
+                            url="https://huggingface.co/colbert-ir/colbertv2.0/raw/main/tokenizer.json"
+                        ),
+                    ),
+                    document_api(),
+                    search(),
+                ),
+                content(id=f"{application_name}", version="1.0")(
+                    min_redundancy("2"),
+                    documents(document(type="doc", mode="index")),
+                    engine(
+                        proton(
+                            tuning(
+                                searchnode(requestthreads(persearch("4"))),
+                            ),
+                        ),
+                    ),
+                ),
+                version="1.0",
+                minimum_required_vespa_version="8.311.28",
+            ),
+        )
+        self.app_package = ApplicationPackage(
+            name=f"{application_name}",
+            schema=[schema],
+            services_config=services_config,
+        )
+        self.app_package.to_files("deleteme")
+        self.vespa_docker = VespaDocker(port=8089)
+        self.app = self.vespa_docker.deploy(application_package=self.app_package)
+
+    def test_colbert_long(self):
+        texts = [
+            "Consider a query example is cdg airport in main paris? from the MS Marco Passage Ranking query set. If we run this query over the 8.8M passage documents using OR we retrieve and rank 7,926,256 documents out of 8,841,823 documents.",
+            "If we instead change to the boolean retrieval logic to AND, we only retrieve 2 documents and fail to retrieve the relevant document(s).",
+            "The WAND algorithm tries to address this problem by starting the search for candidate documents using OR,",
+            "but then re-ranking the documents using AND. The WAND algorithm is a two-stage algorithm that first retrieves documents using OR and then re-ranks the documents using AND.",
+        ]
+        docs_to_feed = [
+            {
+                "id": i,
+                "fields": {
+                    "text": [text],
+                },
+            }
+            for i, text in enumerate(texts)
+        ]
+
+        def callback(response, id):
+            print(response.json)
+
+        query = "this is a test"
+        self.app.feed_iterable(docs_to_feed, schema="doc", callback=callback)
+        # Response with 4 threads (set by requestthreads persearch)
+        query_body = {
+            "yql": "select * from doc where true;",
+            "input.query(qt)": f"embed({query})",
+            "presentation.timing": True,
+            "tracelevel": 3,
+        }
+        _response_warmup = self.app.query(
+            body={
+                **query_body,
+                "ranking": "colbert-max-sim-context-level",
+            }
+        )
+        response_default = self.app.query(
+            body={
+                **query_body,
+                "ranking": "colbert-max-sim-context-level",
+            }
+        )
+        # Response with single thread, overriding the default setting to 1.
+        response_single_thread = self.app.query(
+            body={
+                **query_body,
+                "ranking": "one-thread-profile",
+                "ranking.matching.numThreadsPerSearch": 1,
+            }
+        )
+        self.assertEqual(response_default.number_documents_retrieved, len(texts))
+        self.assertEqual(response_single_thread.number_documents_retrieved, len(texts))
+
+    def tearDown(self) -> None:
+        self.vespa_docker.container.stop(timeout=CONTAINER_STOP_TIMEOUT)
+        self.vespa_docker.container.remove()
+
+
+class TestCrossencoderPersearchThreads(unittest.TestCase):
+    def setUp(self) -> None:
+        application_name = "crossencoder"
+        # Download the model if it doesn't exist
+        url = "https://huggingface.co/mixedbread-ai/mxbai-rerank-xsmall-v1/resolve/main/onnx/model_quantized.onnx"
+        local_model_path = "model/model.onnx"
+        if not Path(local_model_path).exists():
+            print("Downloading the mxbai-rerank model...")
+            r = requests.get(url)
+            Path(local_model_path).parent.mkdir(parents=True, exist_ok=True)
+            with open(local_model_path, "wb") as f:
+                f.write(r.content)
+                print(f"Downloaded model to {local_model_path}")
+        else:
+            print("Model already exists, skipping download.")
+
+        reranking = FirstPhaseRanking(
+            keep_rank_count=8,
+            expression="sigmoid(onnx(crossencoder).logits{d0:0,d1:0})",
+        )
+
+        # Define the schema
+        schema = Schema(
+            name="doc",
+            document=Document(
+                fields=[
+                    Field(name="id", type="string", indexing=["summary", "attribute"]),
+                    Field(
+                        name="text",
+                        type="string",
+                        indexing=["index", "summary"],
+                        index="enable-bm25",
+                    ),
+                    Field(
+                        name="body_tokens",
+                        type="tensor<float>(d0[512])",
+                        indexing=[
+                            "input text",
+                            "embed tokenizer",
+                            "attribute",
+                            "summary",
+                        ],
+                        is_document_field=False,  # Indicates a synthetic field
+                    ),
+                ],
+            ),
+            fieldsets=[FieldSet(name="default", fields=["text"])],
+            models=[
+                OnnxModel(
+                    model_name="crossencoder",
+                    model_file_path=f"{local_model_path}",
+                    inputs={
+                        "input_ids": "input_ids",
+                        "attention_mask": "attention_mask",
+                    },
+                    outputs={"logits": "logits"},
+                )
+            ],
+            rank_profiles=[
+                RankProfile(name="bm25", first_phase="bm25(text)"),
+                RankProfile(
+                    name="reranking",
+                    inherits="default",
+                    inputs=[("query(q)", "tensor<float>(d0[64])")],
+                    functions=[
+                        Function(
+                            name="input_ids",
+                            expression="customTokenInputIds(1, 2, 512, query(q), attribute(body_tokens))",
+                        ),
+                        Function(
+                            name="attention_mask",
+                            expression="tokenAttentionMask(512, query(q), attribute(body_tokens))",
+                        ),
+                    ],
+                    first_phase=reranking,
+                    summary_features=[
+                        "query(q)",
+                        "input_ids",
+                        "attention_mask",
+                        "onnx(crossencoder).logits",
+                    ],
+                ),
+                RankProfile(
+                    name="one-thread-profile",
+                    first_phase=reranking,
+                    inherits="reranking",
+                    rank_properties=[("num-threads-per-search", 1)],
+                ),
+            ],
+        )
+
+        # Define services configuration with persearch threads set to 4
+        services_config = ServicesConfiguration(
+            application_name=f"{application_name}",
+            services_config=services(
+                container(id=f"{application_name}_default", version="1.0")(
+                    component(
+                        model(
+                            url="https://huggingface.co/mixedbread-ai/mxbai-rerank-xsmall-v1/raw/main/tokenizer.json"
+                        ),
+                        id="tokenizer",
+                        type="hugging-face-tokenizer",
+                    ),
+                    document_api(),
+                    search(),
+                ),
+                content(id=f"{application_name}", version="1.0")(
+                    min_redundancy("1"),
+                    documents(document(type="doc", mode="index")),
+                    engine(
+                        proton(
+                            tuning(
+                                searchnode(requestthreads(persearch("4"))),
+                            ),
+                        ),
+                    ),
+                ),
+                version="1.0",
+                minimum_required_vespa_version="8.311.28",
+            ),
+        )
+
+        self.app_package = ApplicationPackage(
+            name=f"{application_name}",
+            schema=[schema],
+            services_config=services_config,
+        )
+
+        self.vespa_docker = VespaDocker(port=8089)
+        self.app = self.vespa_docker.deploy(application_package=self.app_package)
+
+    def test_crossencoder_threads(self):
+        # Feed sample documents to the application
+        sample_docs = [
+            {"id": i, "fields": {"text": text}}
+            for i, text in enumerate(
+                [
+                    "'To Kill a Mockingbird' is a novel by Harper Lee published in 1960. It was immediately successful, winning the Pulitzer Prize, and has become a classic of modern American literature. The novel 'Moby-Dick' was written by Herman Melville and first published in 1851. Harper Lee, an American novelist widely known for her novel 'To Kill a Mockingbird'. It is considered a masterpiece of American literature and deals with complex themes of obsession, revenge, and the conflict between good and evil.",
+                    "was born in 1926 in Monroeville, Alabama. She received the Pulitzer Prize for Fiction in 1961. Jane Austen was an English novelist known primarily for her six major novels, ",
+                    "which interpret, critique and comment upon the British landed gentry at the end of the 18th century. The 'Harry Potter' series, which consists of seven fantasy novels written by British author J.K. Rowling, ",
+                    "is among the most popular and critically acclaimed books of the modern era. 'The Great Gatsby', a novel written by American author F. Scott Fitzgerald, was published in 1925. The story is set in the Jazz Age and follows the life of millionaire Jay Gatsby and his pursuit of Daisy Buchanan.",
+                ]
+            )
+        ]
+        self.app.feed_iterable(sample_docs, schema="doc")
+
+        # Define the query body
+        query_body = {
+            "yql": "select * from sources * where userQuery();",
+            "query": "who wrote to kill a mockingbird?",
+            "timeout": "5s",
+            "input.query(q)": "embed(tokenizer, @query)",
+            "presentation.timing": "true",
+        }
+
+        # Warm-up query
+        self.app.query(body=query_body)
+        query_body_reranking = {
+            **query_body,
+            "ranking.profile": "reranking",
+        }
+        # Query with default persearch threads (set to 4)
+        response_default = self.app.query(body=query_body_reranking)
+
+        # Query with num-threads-per-search overridden to 1
+        query_body_one_thread = {
+            **query_body,
+            "ranking.profile": "one-thread-profile",
+            "ranking.matching.numThreadsPerSearch": 1,
+        }
+        response_one_thread = self.app.query(body=query_body_one_thread)
+
+        # Extract query times
+        timing_default = response_default.json["timing"]
+        timing_one_thread = response_one_thread.json["timing"]
+
+        print("Default threads timing:", timing_default)
+        print("One thread timing:", timing_one_thread)
+        print("Response default:", response_default.json)
+        print("Response one thread:", response_one_thread.json)
+
+        # Assert that the query time with one thread is greater
+        self.assertGreater(
+            timing_one_thread["querytime"],
+            timing_default["querytime"],
+        )
 
     def tearDown(self) -> None:
         self.vespa_docker.container.stop(timeout=CONTAINER_STOP_TIMEOUT)

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -525,6 +525,7 @@ class TestApplicationPackage(unittest.TestCase):
                     name="bm25",
                     first_phase="bm25(title) + bm25(body)",
                     inherits="default",
+                    num_threads_per_search=4,
                 ),
                 RankProfile(
                     name="bert",
@@ -672,6 +673,7 @@ class TestApplicationPackage(unittest.TestCase):
             "                bm25(title) + bm25(body)\n"
             "            }\n"
             "        }\n"
+            "        num-threads-per-search: 4\n"
             "    }\n"
             "    rank-profile bert inherits default {\n"
             "        constants {\n"

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -1114,6 +1114,7 @@ class RankProfile(object):
         match_features: Optional[List] = None,
         second_phase: Optional[SecondPhaseRanking] = None,
         global_phase: Optional[GlobalPhaseRanking] = None,
+        num_threads_per_search: Optional[int] = None,
         **kwargs: Unpack[RankProfileFields],
     ) -> None:
         """
@@ -1146,6 +1147,7 @@ class RankProfile(object):
             See :class:`SecondPhaseRanking`.
         :param global_phase: Optional config specifying the global phase of ranking.
             See :class:`GlobalPhaseRanking`.
+        :param num_threads_per_search: Overrides the global `persearch` value for this rank profile to a **lower** value.
         :key weight: A list of tuples containing the field and their weight
         :key rank_type: A list of tuples containing a field and the rank-type-name.
             `More info <https://docs.vespa.ai/en/reference/schema-reference.html#rank-type>`__ about rank-type.
@@ -1195,21 +1197,21 @@ class RankProfile(object):
         ...     first_phase = "nativeRank(title, body)",
         ...     weight = [("title", 200), ("body", 100)]
         ... )
-        RankProfile('default', 'nativeRank(title, body)', None, None, None, None, None, None, None, [('title', 200), ('body', 100)], None, None, None, None)
+        RankProfile('default', 'nativeRank(title, body)', None, None, None, None, None, None, None, None, [('title', 200), ('body', 100)], None, None, None)
 
         >>> RankProfile(
         ...     name = "default",
         ...     first_phase = "nativeRank(title, body)",
         ...     rank_type = [("body", "about")]
         ... )
-        RankProfile('default', 'nativeRank(title, body)', None, None, None, None, None, None, None, None, [('body', 'about')], None, None, None)
+        RankProfile('default', 'nativeRank(title, body)', None, None, None, None, None, None, None, None, None, [('body', 'about')], None, None)
 
         >>> RankProfile(
         ...     name = "default",
         ...     first_phase = "nativeRank(title, body)",
         ...     rank_properties = [("fieldMatch(title).maxAlternativeSegmentations", "10")]
         ... )
-        RankProfile('default', 'nativeRank(title, body)', None, None, None, None, None, None, None, None, None, [('fieldMatch(title).maxAlternativeSegmentations', '10')], None, None)
+        RankProfile('default', 'nativeRank(title, body)', None, None, None, None, None, None, None, None, None, None, [('fieldMatch(title).maxAlternativeSegmentations', '10')], None)
 
         >>> RankProfile(
         ...    name = "default",
@@ -1217,6 +1219,12 @@ class RankProfile(object):
         ... )
         RankProfile('default', FirstPhaseRanking('nativeRank(title, body)', 50, None), None, None, None, None, None, None, None, None, None, None, None, None)
 
+        >>> RankProfile(
+        ...     name = "default",
+        ...     first_phase = "nativeRank(title, body)",
+        ...     num_threads_per_search = 2
+        ... )
+        RankProfile('default', 'nativeRank(title, body)', None, None, None, None, None, None, None, 2, None, None, None, None)
         """
         self.name = name
         self.first_phase = first_phase
@@ -1227,6 +1235,9 @@ class RankProfile(object):
         self.match_features = kwargs.get("match_features", match_features)
         self.second_phase = kwargs.get("second_phase", second_phase)
         self.global_phase = kwargs.get("global_phase", global_phase)
+        self.num_threads_per_search = kwargs.get(
+            "num_threads_per_search", num_threads_per_search
+        )
         self.weight = kwargs.get("weight", None)
         self.rank_type = kwargs.get("rank_type", None)
         self.rank_properties = kwargs.get("rank_properties", None)
@@ -1246,6 +1257,7 @@ class RankProfile(object):
             and self.match_features == other.match_features
             and self.second_phase == other.second_phase
             and self.global_phase == other.global_phase
+            and self.num_threads_per_search == other.num_threads_per_search
             and self.weight == other.weight
             and self.rank_type == other.rank_type
             and self.rank_properties == other.rank_properties
@@ -1265,11 +1277,11 @@ class RankProfile(object):
             repr(self.match_features),
             repr(self.second_phase),
             repr(self.global_phase),
+            repr(self.num_threads_per_search),
             repr(self.weight),
             repr(self.rank_type),
             repr(self.rank_properties),
             repr(self.inputs),
-            repr(self.mutate),
         )
 
 

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -2364,7 +2364,7 @@ class EmptyDeploymentConfiguration(DeploymentConfiguration):
 class ServicesConfiguration(object):
     def __init__(
         self,
-        application_name,
+        application_name: str,
         schemas: Optional[List[Schema]] = None,
         configurations: List[ApplicationConfiguration] = [],
         stateless_model_evaluation: Optional[bool] = False,
@@ -2385,12 +2385,18 @@ class ServicesConfiguration(object):
         Create a ServicesConfiguration, adopting the VespaTag (VT) approach, rather than Jinja templates.
         Intended to be used in ApplicationPackage, to generate services.xml based on either:
         - A passed `services_config` (VT) object, or
-        - A set of configurations, schemas, components, auth_clients, and clusters.
+        - A set of configurations, schemas, components, auth_clients, and clusters. (the old approach)
 
         The latter will be done in code by calling `build_services_vt()` to generate the VT object.
 
-        :param application_name: The name of the application.
-        
+        :param application_name: str, Application name. 
+        :param schemas: Optional[List[Schema]], List of :class:`Schema`s of the application.
+        :param configurations: Optional[List[ApplicationConfiguration]], List of :class:`ApplicationConfiguration` that contains configurations for the application.
+        :param stateless_model_evaluation: Optional[bool], Enable stateless model evaluation. Default to False.
+        :param components: Optional[List[Component]], List of :class:`Component` that contains configurations for application components.
+        :param auth_clients: Optional[List[AuthClient]], List of :class:`AuthClient
+        :param clusters: Optional[List[Cluster]], List of :class:`Cluster` that contains configurations for content or container clusters.
+        :param services_config: Optional[VT], :class:`VT` object that contains the services configuration.
         """
 
     def build_services_vt(self):
@@ -2468,6 +2474,9 @@ class ServicesConfiguration(object):
 
     def _repr_markdown_(self):
         return
+
+    def validate(self):
+        return validate_services(str(self.services_config.to_xml()))
 
 
 class ApplicationPackage(object):

--- a/vespa/templates/schema.txt
+++ b/vespa/templates/schema.txt
@@ -201,6 +201,9 @@ schema {{ schema_name }}{% if schema.inherits %} inherits {{ schema.inherits }}{
             {% endfor %}
         }
         {% endif %}
+        {% if value.num_threads_per_search %}
+        num-threads-per-search: {{ value.num_threads_per_search }}
+        {% endif %}
         {% if value.mutate %}
         mutate {
             {% if value.mutate.on_match %}


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

# Why

The goal of the PR is to demonstrate how the new `ServicesConfiguration` can be used to define arbitrary `services.xml` configurations, with `requestthreads` `persearch` threads as an example, ref #895 

The demonstration is added to the `advanced_configurations.ipynb`-notebook. 

# What 

This pull request some minor changes to the `vespa` package, focusing on adding support for `num_threads_per_search` in rank profiles and improving XML service configuration validation. The most important changes are grouped into three themes: new features and test enhancements.

## New Features:
* Added `num_threads_per_search` parameter to the `RankProfile` class, allowing customization of the number of threads per search. (`vespa/package.py`, `vespa/templates/schema.txt`) [[1]](diffhunk://#diff-3117e4b092b0bf5c53365ef725d810d6d3317d27f9915494e86fcbdd9a9b2f5fR1117) [[2]](diffhunk://#diff-3117e4b092b0bf5c53365ef725d810d6d3317d27f9915494e86fcbdd9a9b2f5fR1150) [[3]](diffhunk://#diff-3117e4b092b0bf5c53365ef725d810d6d3317d27f9915494e86fcbdd9a9b2f5fL1198-R1227) [[4]](diffhunk://#diff-3117e4b092b0bf5c53365ef725d810d6d3317d27f9915494e86fcbdd9a9b2f5fR1238-R1240) [[5]](diffhunk://#diff-3117e4b092b0bf5c53365ef725d810d6d3317d27f9915494e86fcbdd9a9b2f5fR1260) [[6]](diffhunk://#diff-3117e4b092b0bf5c53365ef725d810d6d3317d27f9915494e86fcbdd9a9b2f5fR1280-L1272) [[7]](diffhunk://#diff-1d07a90ed82c9e1c191db0ad1f2898d44136491b1dc65f52ee134f8c3865d388R204-R206)
* Updated `test_package.py` to include `num_threads_per_search` in the rank profile tests. (`tests/unit/test_package.py`) [[1]](diffhunk://#diff-8a9837ab4b37d381d78221870e2164713b8b361186f63e9cddf39e390e4b19ccR528) [[2]](diffhunk://#diff-8a9837ab4b37d381d78221870e2164713b8b361186f63e9cddf39e390e4b19ccR676)

### Test Enhancements:
* Introduced `TestColbertLongServicesConfiguration` class to validate XML service configurations and generate XML dynamically for testing. (`tests/unit/test_configuration.py`)
* Simplified XML validation in existing tests by removing redundant conversion to `etree` objects. (`tests/unit/test_configuration.py`) [[1]](diffhunk://#diff-385ea4175fc1cfef0a322eeac69adb9015880f91182c10cf4be4d575151611cfL575-R674) [[2]](diffhunk://#diff-385ea4175fc1cfef0a322eeac69adb9015880f91182c10cf4be4d575151611cfL606-R703)

These changes aim to improve the flexibility of rank profile configurations and ensure robust validation of service configurations.

CC: @jobergum 