### PR TITLE
fix(docsearch-feed): change enclave endpoint url for feeding to docsearch

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -60,9 +60,13 @@ search:
     - url: https://vespacloud-docsearch.vespa-team.aws-eu-west-1a.z.vespa-app.cloud/
       indexes:
         - pyvespa_index.json
+    # vespacloud-docsearch.cloud-enclave
+    # prod.aws-us-east-1c
     - url: https://c967e4f5.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - pyvespa_index.json
+    # vespacloud-docsearch.cloud-enclave
+    # prod.gcp-us-central1-f
     - url: https://d13733c3.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - pyvespa_index.json

--- a/_config.yml
+++ b/_config.yml
@@ -60,10 +60,10 @@ search:
     - url: https://vespacloud-docsearch.vespa-team.aws-eu-west-1a.z.vespa-app.cloud/
       indexes:
         - pyvespa_index.json
-    - url: https://enclave.vespacloud-docsearch.vespa-team.aws-us-east-1c.z.vespa-app.cloud/
+    - url: https://c967e4f5.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - pyvespa_index.json
-    - url: https://enclave.vespacloud-docsearch.vespa-team.gcp-us-central1-f.z.vespa-app.cloud/
+    - url: https://d13733c3.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - pyvespa_index.json
 

--- a/_paragraphs_config.yml
+++ b/_paragraphs_config.yml
@@ -15,9 +15,13 @@ search:
     - url: https://vespacloud-docsearch.vespa-team.aws-eu-west-1a.z.vespa-app.cloud/
       indexes:
         - paragraph_index.json 
+    # vespacloud-docsearch.cloud-enclave
+    # prod.aws-us-east-1c
     - url: https://c967e4f5.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - paragraph_index.json
+    # vespacloud-docsearch.cloud-enclave
+    # prod.gcp-us-central1-f
     - url: https://d13733c3.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - paragraph_index.json

--- a/_paragraphs_config.yml
+++ b/_paragraphs_config.yml
@@ -15,9 +15,9 @@ search:
     - url: https://vespacloud-docsearch.vespa-team.aws-eu-west-1a.z.vespa-app.cloud/
       indexes:
         - paragraph_index.json 
-    - url: https://enclave.vespacloud-docsearch.vespa-team.aws-us-east-1c.z.vespa-app.cloud/
+    - url: https://c967e4f5.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - paragraph_index.json
-    - url: https://enclave.vespacloud-docsearch.vespa-team.gcp-us-central1-f.z.vespa-app.cloud/
+    - url: https://d13733c3.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - paragraph_index.json

--- a/_suggestions_config.yml
+++ b/_suggestions_config.yml
@@ -15,9 +15,13 @@ search:
     - url: https://vespacloud-docsearch.vespa-team.aws-eu-west-1a.z.vespa-app.cloud/
       indexes:
         - suggestions_index.json 
+    # vespacloud-docsearch.cloud-enclave
+    # prod.aws-us-east-1c
     - url: https://c967e4f5.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - suggestions_index.json
+    # vespacloud-docsearch.cloud-enclave
+    # prod.gcp-us-central1-f
     - url: https://d13733c3.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - suggestions_index.json

--- a/_suggestions_config.yml
+++ b/_suggestions_config.yml
@@ -15,9 +15,9 @@ search:
     - url: https://vespacloud-docsearch.vespa-team.aws-eu-west-1a.z.vespa-app.cloud/
       indexes:
         - suggestions_index.json 
-    - url: https://enclave.vespacloud-docsearch.vespa-team.aws-us-east-1c.z.vespa-app.cloud/
+    - url: https://c967e4f5.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - suggestions_index.json
-    - url: https://enclave.vespacloud-docsearch.vespa-team.gcp-us-central1-f.z.vespa-app.cloud/
+    - url: https://d13733c3.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - suggestions_index.json


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

## Why

Feeding to docsearch fails due to deprecated endpoints. 

## What

This pull request includes updates to the URL-endpoints to feed to. 

Please double-check that the correct endpoints are used. 
