### PR TITLE
(ci) increase timeout from 300 to 600

### DIFF
--- a/tests/integration/test_integration_docker.py
+++ b/tests/integration/test_integration_docker.py
@@ -2107,13 +2107,15 @@ class TestCrossencoderPersearchThreads(unittest.TestCase):
         }
 
         # Warm-up query
-        self.app.query(body=query_body)
+        with self.app.syncio() as sess:
+            _ = sess.query(body=query_body)
         query_body_reranking = {
             **query_body,
             "ranking.profile": "reranking",
         }
         # Query with default persearch threads (set to 4)
-        response_default = self.app.query(body=query_body_reranking)
+        with self.app.syncio() as sess:
+            response_default = sess.query(body=query_body_reranking)
 
         # Query with num-threads-per-search overridden to 1
         query_body_one_thread = {
@@ -2121,7 +2123,8 @@ class TestCrossencoderPersearchThreads(unittest.TestCase):
             "ranking.profile": "one-thread-profile",
             "ranking.matching.numThreadsPerSearch": 1,
         }
-        response_one_thread = self.app.query(body=query_body_one_thread)
+        with self.app.syncio() as sess:
+            response_one_thread = sess.query(body=query_body_one_thread)
 
         # Extract query times
         timing_default = response_default.json["timing"]

--- a/tests/integration/test_integration_docker.py
+++ b/tests/integration/test_integration_docker.py
@@ -2078,7 +2078,9 @@ class TestCrossencoderPersearchThreads(unittest.TestCase):
         )
 
         self.vespa_docker = VespaDocker(port=8089)
-        self.app = self.vespa_docker.deploy(application_package=self.app_package)
+        self.app = self.vespa_docker.deploy(
+            application_package=self.app_package, max_wait_deployment=600
+        )
 
     def test_crossencoder_threads(self):
         # Feed sample documents to the application


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

## Why

In [this](https://github.com/vespa-engine/pyvespa/actions/runs/11122172231/job/30909175609) integration tests, 300secs is not enough for the application to come up on the github runner.

## What

Increases timeout from 300s to 600s. 