### PR TITLE
(fix) unpin requests version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 keywords = ["vespa", "search engine", "data science"]
 classifiers = ["License :: OSI Approved :: Apache Software License"]
 dependencies = [
-    "requests==2.31",
+    "requests",
     "requests_toolbelt",
     "docker",
     "jinja2",

--- a/uv.lock
+++ b/uv.lock
@@ -3353,7 +3353,7 @@ requires-dist = [
     { name = "pyvespa", extras = ["build"], marker = "extra == 'dev'" },
     { name = "pyvespa", extras = ["unittest"], marker = "extra == 'dev'" },
     { name = "pyyaml", marker = "extra == 'feed'" },
-    { name = "requests", specifier = "==2.31" },
+    { name = "requests" },
     { name = "requests", marker = "extra == 'feed'", specifier = "<=2.31.0" },
     { name = "requests-mock", marker = "extra == 'unittest'" },
     { name = "requests-toolbelt" },


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Earlier, there were issues with `requests==2.32.0-1`, see https://pypi.org/project/requests/2.32.3/#history. 
These versions are now yanked, so we should unpin version here, to avoid possible incompatibility with other packages that might depend on a higher `requests`-version. 