### PR TITLE
(docs) fix docs for servicesconfiguration

### DIFF
--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -15,6 +15,7 @@ Vespa python API
 
    getting-started-pyvespa
    getting-started-pyvespa-cloud
+   advanced-configuration
    authenticating-to-vespa-cloud
    application-packages
    query

--- a/docs/sphinx/source/reference-api.rst
+++ b/docs/sphinx/source/reference-api.rst
@@ -251,6 +251,11 @@ SecondPhaseRanking
    :members:
    :special-members: __init__
 
+ServicesConfiguration
+*********************
+.. autoclass:: vespa.package.ServicesConfiguration
+   :members:
+   :special-members: __init__
 
 Struct
 ******

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -1803,7 +1803,7 @@ class TestServiceConfig(unittest.TestCase):
         app_package = ApplicationPackage(
             name=application_name, services_config=service_config
         )
-        expected_result = '<?xml version="1.0" encoding="UTF-8" ?>\n<services version="1.0">\n  <container id="test_container" version="1.0"></container>\n</services>\n'
+        expected_result = '<?xml version="1.0" encoding="UTF-8" ?>\n<services version="1.0">\n  <container id="test_container" version="1.0"></container>\n</services>'
         self.assertEqual(expected_result, app_package.services_to_text)
         self.assertTrue(
             compare_xml(app_package.services_to_text_vt, expected_result),
@@ -1884,7 +1884,6 @@ class TestServiceConfig(unittest.TestCase):
       <node distribution-key="0" hostalias="node1"></node>
     </nodes>
   </content>
-</services>
-"""
+</services>"""
         self.assertEqual(expected, application_package.services_to_text)
         self.assertTrue(validate_services(application_package.services_to_text))


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This pull request includes updates to documentation and tests related to the `ServicesConfiguration` class in `vespa/package.py`. The most important changes include adding a new section to the documentation, improving the `ServicesConfiguration` class with examples, and refining the `build_services_vt` method.

Documentation updates:

* [`docs/sphinx/source/index.rst`](diffhunk://#diff-d8e61caa7471e4ae7a5eee5975c5b22c171384effcd970bc49d81f89b786136cR18): Added a new section for advanced configuration. The notebook is already available [here](https://pyvespa.readthedocs.io/en/latest/advanced-configuration.html) but not added to index yet. Please review. 
* [`docs/sphinx/source/reference-api.rst`](diffhunk://#diff-3d3e7a3442a7005fd9c4732bb685fa1c079cae997f7d6e376b87d687f24854e9R254-R258): Introduced the `ServicesConfiguration` class to the API reference.

Enhancements to `ServicesConfiguration`:

* [`vespa/package.py`](diffhunk://#diff-3117e4b092b0bf5c53365ef725d810d6d3317d27f9915494e86fcbdd9a9b2f5fL2387-R2488): Enhanced the `__init__` method of `ServicesConfiguration` to include detailed examples demonstrating both the old and new approaches for generating `services.xml`. [[1]](diffhunk://#diff-3117e4b092b0bf5c53365ef725d810d6d3317d27f9915494e86fcbdd9a9b2f5fL2387-R2488) [[2]](diffhunk://#diff-3117e4b092b0bf5c53365ef725d810d6d3317d27f9915494e86fcbdd9a9b2f5fR2498-R2505)
* [`vespa/package.py`](diffhunk://#diff-3117e4b092b0bf5c53365ef725d810d6d3317d27f9915494e86fcbdd9a9b2f5fL2443): Improved the `build_services_vt` method by removing unnecessary lines and ensuring proper formatting in the `__str__` method. [[1]](diffhunk://#diff-3117e4b092b0bf5c53365ef725d810d6d3317d27f9915494e86fcbdd9a9b2f5fL2443) [[2]](diffhunk://#diff-3117e4b092b0bf5c53365ef725d810d6d3317d27f9915494e86fcbdd9a9b2f5fL2482-R2574)