### PR TITLE
Add http response.text to deployment error reason

### DIFF
--- a/vespa/deployment.py
+++ b/vespa/deployment.py
@@ -1161,7 +1161,7 @@ class VespaCloud(VespaDeployment):
             )
             if response.status_code != 200:
                 raise HTTPError(
-                    f"HTTP {response.status_code} error: {response.reason_phrase} for {path}"
+                    f"HTTP {response.status_code} reason: {response.reason_phrase} error_text: {response.text} for {path}"
                 )
         return response
 


### PR DESCRIPTION
Before:
```
[2024-10-15 17:29:13] [ERROR - YYY] Failed deploy models HTTP 400 error: Bad Request for /application/v4/tenant/.../application/pages/submit/
Traceback (most recent call last):
```

After:
```
[2024-10-15 20:14:48] [ERROR - YYY] Failed deploy models HTTP 400 reason: Bad Request error_text: {"error-code":"BAD_REQUEST","message":"Malformed input or input contains unmappable characters: search/query-profiles/XXX_vsp.xml"} for /application/v4/tenant/.../application/pages/submit/
Traceback (most recent call last):
```

--
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
