### PR TITLE
(ci) remove obsolete references

### DIFF
--- a/docs/sphinx/source/examples/mother-of-all-embedding-models-cloud.ipynb
+++ b/docs/sphinx/source/examples/mother-of-all-embedding-models-cloud.ipynb
@@ -17,7 +17,7 @@
                 "\n",
                 "> M3 stands for Multi-linguality (100+ languages), Multi-granularities (input length up to 8192), Multi-Functionality (unification of dense, lexical, multi-vec (colbert) retrieval).\n",
                 "\n",
-                "This notebook demonstrates how to use the [BGE-M3](https://github.com/FlagOpen/FlagEmbedding/tree/master/FlagEmbedding/BGE_M3) embeddings and\n",
+                "This notebook demonstrates how to use the [BGE-M3](https://github.com/FlagOpen/FlagEmbedding/blob/master/research/BGE_M3/BGE_M3.pdf) embeddings and\n",
                 "represent all three embedding representations in Vespa! Vespa is the only scalable serving engine that can handle all M3 representations.\n",
                 "\n",
                 "This code is inspired by the README from the model hub [BAAI/bge-m3](https://huggingface.co/BAAI/bge-m3).\n",
@@ -217,7 +217,7 @@
                 "- max_sim (The colbert max sim operation)\n",
                 "\n",
                 "Then, we combine these three scoring functions using a linear combination with weights, as suggested\n",
-                "by the authors [here](https://github.com/FlagOpen/FlagEmbedding/tree/master/FlagEmbedding/BGE_M3#compute-score-for-text-pairs).\n"
+                "by the authors [here](https://github.com/FlagOpen/FlagEmbedding/blob/master/research/BGE_M3/BGE_M3.pdf#compute-score-for-text-pairs).\n"
             ]
         },
         {

--- a/vespacli/utils/update_version.py
+++ b/vespacli/utils/update_version.py
@@ -3,12 +3,10 @@
 
 import toml
 import sys
-import re
 from pathlib import Path
 import argparse
 
 PYPROJECT_TOML_PATH = Path(__file__).parent.parent / "pyproject.toml"
-VERSION_FILE_PATH = Path(__file__).parent.parent / "vespacli" / "_version_generated.py"
 
 
 def update_version(new_version: str):
@@ -19,14 +17,6 @@ def update_version(new_version: str):
     with open("pyproject.toml", "w") as f:
         toml.dump(data, f)
 
-    # Update version in vespacli/_version_generated.py
-    with open(VERSION_FILE_PATH, "r") as f:
-        content = f.read()
-    new_content = re.sub(
-        r'vespa_version = ".*"', f'vespa_version = "{new_version}"', content
-    )
-    with open("vespacli/_version_generated.py", "w") as f:
-        f.write(new_content)
     print(f"Updated version to {new_version}")
 
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

## Why?
`vespacli` package release action has been failing - see https://github.com/vespa-engine/pyvespa/actions/runs/11604204584

## What?
Remove obsolete reference to `_version_generated.py`.
This should at least get us one step further. 