### PR TITLE
(ci) shorter application name

### DIFF
--- a/tests/integration/test_integration_vespa_cloud_vector_search.py
+++ b/tests/integration/test_integration_vespa_cloud_vector_search.py
@@ -76,7 +76,7 @@ class TestVectorSearch(unittest.TestCase):
         self.app_package = create_vector_ada_application_package()
         self.vespa_cloud = VespaCloud(
             tenant="vespa-team",
-            application="pyvespa-int-vsearch-dev",
+            application="pyvespa-vsearch-dev",
             key_content=os.getenv("VESPA_TEAM_API_KEY").replace(r"\n", "\n"),
             application_package=self.app_package,
         )


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

```python
HTTP 400 reason: Bad Request error_text: {"error-code":"BAD_REQUEST","message":"Invalid id 'pyvespa-int-vsearch-dev'. Tenant, application and instance names must start with a letter, may contain no more than 20 characters, and may only contain lowercase letters, digits or dashes, but no double-dashes."} for /application/v4/tenant/vespa-team/application/pyvespa-int-vsearch-dev/instance/default/deploy/dev-aws-us-east-1c
```
