### PR TITLE
adjust var name to not override builtin

### DIFF
--- a/docs/sphinx/source/examples/colpali-document-retrieval-vision-language-models-cloud.ipynb
+++ b/docs/sphinx/source/examples/colpali-document-retrieval-vision-language-models-cloud.ipynb
@@ -142,19 +142,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "if torch.cuda.is_available():\n",
     "    device = torch.device(\"cuda\")\n",
-    "    type = torch.bfloat16\n",
+    "    dtype = torch.bfloat16\n",
     "elif torch.backends.mps.is_available():\n",
     "    device = torch.device(\"mps\")\n",
-    "    type = torch.float32\n",
+    "    dtype = torch.float32\n",
     "else:\n",
     "    device = torch.device(\"cpu\")\n",
-    "    type = torch.float32"
+    "    dtype = torch.float32"
    ]
   },
   {
@@ -339,7 +339,7 @@
    "source": [
     "model_name = \"vidore/colpali-v1.2\"\n",
     "model = ColPali.from_pretrained(\n",
-    "    \"vidore/colpaligemma-3b-pt-448-base\", torch_dtype=type\n",
+    "    \"vidore/colpaligemma-3b-pt-448-base\", torch_dtype=dtype\n",
     ").eval()\n",
     "model.load_adapter(model_name)\n",
     "model = model.eval()\n",


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Currently the code block in provided notebook 

```python3
if torch.cuda.is_available():
    device = torch.device("cuda")
    type = torch.bfloat16
elif torch.backends.mps.is_available():
    device = torch.device("mps")
    type = torch.float32
else:
    device = torch.device("cpu")
    type = torch.float32
```
overrides builtin function `type`. This PR renames the portion to use `dtype` instead of type to address this issue.