### PR TITLE
(ci) fix integrationtest vectorsearch

### DIFF
--- a/.github/workflows/integration-cloud.yml
+++ b/.github/workflows/integration-cloud.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - thomasht86/fix-integrationtest-vectorsearch
   schedule:
     - cron: "0 11 * * 0"
 
@@ -13,20 +14,58 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  integration-cloud:
+  setup-environment:
     runs-on: ubuntu-latest
+    outputs:
+      python-cache-key: ${{ steps.cache-python.outputs.cache-hit }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Python
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Cache dependencies
+        id: cache-python
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+
+      - name: Install dependencies
+        if: steps.cache-python.outputs.cache-hit != 'true'
+        run: |
+          pip install -e .[dev]
+
+      - name: Upload Python environment
+        uses: actions/upload-artifact@v3
+        with:
+          name: python-environment
+          path: ~/.cache/pip
+
+  integration-cloud:
+    runs-on: ubuntu-latest
+    needs: setup-environment
+    steps:
+      - uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
-          cache: "pip"
-          cache-dependency-path: |
-            pyproject.toml
+          python-version: "3.10"
+
+      - name: Download Python environment
+        uses: actions/download-artifact@v3
+        with:
+          name: python-environment
+          path: ~/.cache/pip
+
       - name: Install dependencies
         run: |
           pip install -e .[dev]
+
       - name: Run integration tests
         env:
           VESPA_TEAM_API_KEY: ${{ secrets.VESPA_TEAM_API_KEY }}
@@ -35,42 +74,54 @@ jobs:
 
   integration-cloud-token:
     runs-on: ubuntu-latest
-    needs: integration-cloud
+    needs: setup-environment
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
-          cache: "pip"
-          cache-dependency-path: |
-            pyproject.toml
+          python-version: "3.10"
+
+      - name: Download Python environment
+        uses: actions/download-artifact@v3
+        with:
+          name: python-environment
+          path: ~/.cache/pip
+
       - name: Install dependencies
         run: |
           pip install -e .[dev]
+
       - name: Run integration tests
         env:
           VESPA_TEAM_API_KEY: ${{ secrets.VESPA_TEAM_API_KEY }}
           VESPA_CLOUD_SECRET_TOKEN: ${{ secrets.VESPA_CLOUD_SECRET_TOKEN }}
-          VESPA_CLIENT_TOKEN_ID: ${{ secrets.VESPA_CLIENT_TOKEN_ID}}
+          VESPA_CLIENT_TOKEN_ID: ${{ secrets.VESPA_CLIENT_TOKEN_ID }}
         run: |
           pytest tests/integration/test_integration_vespa_cloud_token.py -s -v
 
   integration-cloud-vector-search:
     runs-on: ubuntu-latest
-    needs: integration-cloud-token
+    needs: setup-environment
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
-          cache: "pip"
-          cache-dependency-path: |
-            pyproject.toml
+          python-version: "3.10"
+
+      - name: Download Python environment
+        uses: actions/download-artifact@v3
+        with:
+          name: python-environment
+          path: ~/.cache/pip
+
       - name: Install dependencies
         run: |
           pip install -e .[dev]
+
       - name: Run integration tests
         env:
           VESPA_TEAM_API_KEY: ${{ secrets.VESPA_TEAM_API_KEY }}

--- a/tests/integration/test_integration_vespa_cloud_vector_search.py
+++ b/tests/integration/test_integration_vespa_cloud_vector_search.py
@@ -21,7 +21,6 @@ from vespa.package import (
     ContainerCluster,
     Nodes,
     DeploymentConfiguration,
-    EmptyDeploymentConfiguration,
     Validation,
     ValidationID,
 )
@@ -298,32 +297,33 @@ class TestProdDeploymentFromDisk(unittest.TestCase):
     def test_vector_indexing_and_query(self):
         super().test_vector_indexing_and_query()
 
-    @unittest.skip("Do not run when not waiting for deployment.")
-    def tearDown(self) -> None:
-        self.app.delete_all_docs(
-            content_cluster_name="vector_content",
-            schema="vector",
-            namespace="benchmark",
-        )
-        time.sleep(5)
-        with self.app.syncio() as sync_session:
-            response: VespaResponse = sync_session.query(
-                {"yql": "select id from sources * where true", "hits": 10}
-            )
-            self.assertEqual(response.get_status_code(), 200)
-            self.assertEqual(len(response.hits), 0)
-            print(response.get_json())
+    # DO NOT skip tearDown-method, as test will not exit.
+    # @unittest.skip("Do not run when not waiting for deployment.")
+    # def tearDown(self) -> None:
+    #     self.app.delete_all_docs(
+    #         content_cluster_name="vector_content",
+    #         schema="vector",
+    #         namespace="benchmark",
+    #     )
+    #     time.sleep(5)
+    #     with self.app.syncio() as sync_session:
+    #         response: VespaResponse = sync_session.query(
+    #             {"yql": "select id from sources * where true", "hits": 10}
+    #         )
+    #         self.assertEqual(response.get_status_code(), 200)
+    #         self.assertEqual(len(response.hits), 0)
+    #         print(response.get_json())
 
-        # Deployment is deleted by deploying with an empty deployment.xml file.
-        self.app_package.deployment_config = EmptyDeploymentConfiguration()
+    #     # Deployment is deleted by deploying with an empty deployment.xml file.
+    #     self.app_package.deployment_config = EmptyDeploymentConfiguration()
 
-        # Vespa won't push the deleted deployment.xml file unless we add a validation override
-        tomorrow = datetime.now() + timedelta(days=1)
-        formatted_date = tomorrow.strftime("%Y-%m-%d")
-        self.app_package.validations = [
-            Validation(ValidationID("deployment-removal"), formatted_date)
-        ]
-        self.app_package.to_files(self.application_root)
-        # This will delete the deployment
-        self.vespa_cloud._start_prod_deployment(self.application_root)
-        shutil.rmtree(self.application_root, ignore_errors=True)
+    #     # Vespa won't push the deleted deployment.xml file unless we add a validation override
+    #     tomorrow = datetime.now() + timedelta(days=1)
+    #     formatted_date = tomorrow.strftime("%Y-%m-%d")
+    #     self.app_package.validations = [
+    #         Validation(ValidationID("deployment-removal"), formatted_date)
+    #     ]
+    #     self.app_package.to_files(self.application_root)
+    #     # This will delete the deployment
+    #     self.vespa_cloud._start_prod_deployment(self.application_root)
+    #     shutil.rmtree(self.application_root, ignore_errors=True)

--- a/tests/integration/test_integration_vespa_cloud_vector_search.py
+++ b/tests/integration/test_integration_vespa_cloud_vector_search.py
@@ -93,7 +93,7 @@ class TestVectorSearch(unittest.TestCase):
 
         from datasets import load_dataset
 
-        sample_size = 1000
+        sample_size = 100
         # streaming=True pages the data from S3. This is needed to avoid memory issues when loading the dataset.
         dataset = load_dataset(
             "KShivendu/dbpedia-entities-openai-1M", split="train", streaming=True
@@ -164,9 +164,7 @@ class TestVectorSearch(unittest.TestCase):
         ok = 0
         callbacks = 0
         start_time = time.time()
-        dataset = load_dataset(
-            "KShivendu/dbpedia-entities-openai-1M", split="train", streaming=True
-        ).take(100)
+
         feed_with_wrong_field = dataset.map(
             lambda x: {
                 "id": x["_id"],
@@ -186,9 +184,7 @@ class TestVectorSearch(unittest.TestCase):
         self.assertEqual(callbacks, 100)
 
         ok = 0
-        dataset = load_dataset(
-            "KShivendu/dbpedia-entities-openai-1M", split="train", streaming=True
-        ).take(sample_size)
+
         # Run update - assign all docs with a meta field
 
         updates = dataset.map(lambda x: {"id": x["_id"], "fields": {"meta": "stuff"}})
@@ -239,7 +235,7 @@ class TestVectorSearch(unittest.TestCase):
 
 
 class TestProdDeploymentFromDisk(unittest.TestCase):
-    def setUp(self) -> None:
+    def test_setup(self) -> None:
         self.app_package = create_vector_ada_application_package()
         prod_region = "aws-us-east-1c"
         self.app_package.clusters = [


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This integration test has been unstable and slooow. 🐌 
Some updates to improve stability and speed. 

- [x] reuse common environment and run workflows in parallel
- [x] comment out prod deployment (not only skip)
- [x] switch to Python 3.10

PR run here: https://github.com/vespa-engine/pyvespa/actions/runs/11970588855  