### PR TITLE
Fix type annotations in `feed_data_point`

### DIFF
--- a/vespa/application.py
+++ b/vespa/application.py
@@ -1651,9 +1651,9 @@ class VespaAsync(object):
         schema: str,
         data_id: str,
         fields: Dict,
-        namespace: str = None,
-        groupname: str = None,
-        semaphore: asyncio.Semaphore = None,
+        namespace: str | None = None,
+        groupname: str | None = None,
+        semaphore: asyncio.Semaphore | None = None,
         **kwargs,
     ) -> VespaResponse:
         path = self.app.get_document_v1_path(

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -1651,9 +1651,9 @@ class VespaAsync(object):
         schema: str,
         data_id: str,
         fields: Dict,
-        namespace: str | None = None,
-        groupname: str | None = None,
-        semaphore: asyncio.Semaphore | None = None,
+        namespace: Optional[str] = None,
+        groupname: Optional[str] = None,
+        semaphore: Optional[asyncio.Semaphore] = None,
         **kwargs,
     ) -> VespaResponse:
         path = self.app.get_document_v1_path(


### PR DESCRIPTION
In `feed_data_point`, `namespace`, `groupname`, and `semaphore` should be annotated as Optional, as they are `None` by default.