### PR TITLE
Thomasht86/add unittest matches

### DIFF
--- a/tests/unit/test_qb.py
+++ b/tests/unit/test_qb.py
@@ -99,6 +99,13 @@ class TestQueryBuilder(unittest.TestCase):
         self.assertEqual(q, expected)
         return q
 
+    def test_matches_with_regex(self):
+        condition = qb.QueryField("f1").matches("^TestText$")
+        q = qb.select("*").from_("sd1").where(condition)
+        expected = 'select * from sd1 where f1 matches "^TestText$"'
+        self.assertEqual(q, expected)
+        return q
+
     def test_nested_queries(self):
         nested_query = (
             qb.QueryField("f2").contains("2") & qb.QueryField("f3").contains("3")


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Adding a test for matches with regex, to reply to https://stackoverflow.com/questions/79372000/escaping-special-characters-in-a-vespa-yql-matches-query 