### PR TITLE
Querybuilder fixes

### DIFF
--- a/tests/unit/test_qb.py
+++ b/tests/unit/test_qb.py
@@ -508,6 +508,13 @@ class TestQueryBuilder(unittest.TestCase):
         self.assertEqual(query, expected)
         return query
 
+    def test_param_in_contains(self):
+        condition = qb.QueryField("myfield").contains("@myvalue", stem=False)
+        query = qb.select("*").from_("sd1").where(condition)
+        expected = "select * from sd1 where myfield contains({stem:false}@myvalue)"
+        self.assertEqual(query, expected)
+        return query
+
     def test_userinput_param(self):
         condition = qb.userInput("@animal")
         query = qb.select("*").from_("sd1").where(condition).param("animal", "panda")

--- a/tests/unit/test_qb.py
+++ b/tests/unit/test_qb.py
@@ -509,6 +509,7 @@ class TestQueryBuilder(unittest.TestCase):
         return query
 
     def test_param_in_contains(self):
+        # @myvalue is a parameter, should not be quoted
         condition = qb.QueryField("myfield").contains("@myvalue", stem=False)
         query = qb.select("*").from_("sd1").where(condition)
         expected = "select * from sd1 where myfield contains({stem:false}@myvalue)"

--- a/tests/unit/test_qb.py
+++ b/tests/unit/test_qb.py
@@ -371,6 +371,36 @@ class TestQueryBuilder(unittest.TestCase):
         self.assertEqual(q, expected)
         return q
 
+    def test_grouping_continuation_annotation(self):
+        grouping = G.all(
+            G.group("category"),
+            G.max(10),
+            G.output(G.count()),
+        )
+        q = (
+            qb.select("*")
+            .from_("products")
+            .groupby(grouping, continuations=["BGAAABEBCA"])
+        )
+        expected = "select * from products | { 'continuations':['BGAAABEBCA'] }all(group(category) max(10) output(count()))"
+        self.assertEqual(q, expected)
+        return q
+
+    def test_grouping_multiple_continuation_annotations(self):
+        grouping = G.all(
+            G.group("category"),
+            G.max(10),
+            G.output(G.count()),
+        )
+        q = (
+            qb.select("*")
+            .from_("products")
+            .groupby(grouping, continuations=["BGAAABEBCA", "BGAAABEBCB"])
+        )
+        expected = "select * from products | { 'continuations':['BGAAABEBCA', 'BGAAABEBCB'] }all(group(category) max(10) output(count()))"
+        self.assertEqual(q, expected)
+        return q
+
     def test_userquery_basic(self):
         condition = qb.userQuery("search terms")
         q = qb.select("*").from_("documents").where(condition)

--- a/vespa/querybuilder/builder/builder.py
+++ b/vespa/querybuilder/builder/builder.py
@@ -128,7 +128,11 @@ class QueryField:
     @staticmethod
     def _format_value(value: Any) -> str:
         if isinstance(value, str):
-            return f'"{value}"'
+            # Wrap strings in double quotes, but not for parameters
+            if value.startswith("@"):
+                return value
+            else:
+                return f'"{value}"'
         elif isinstance(value, Condition):
             return value.build()
         else:


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Fixes 2 reported issues with Querybuilder:

1. Quotes must be removed when parameter to `contains` or `matches` is a queryparameter (`@myparam`).
2. Groupby expression did not support continuation annotation for pagination. 