### PR TITLE
(CI) Remove erroneous fieldset to fix integration test

### DIFF
--- a/tests/integration/test_integration_docker.py
+++ b/tests/integration/test_integration_docker.py
@@ -1366,11 +1366,6 @@ def create_update_application_package() -> ApplicationPackage:
     schema = Schema(
         name="testupdates",
         document=document,
-        fieldsets=[
-            FieldSet(
-                name="default", fields=["title", "tensorfield", "contact", "price"]
-            )
-        ],
         rank_profiles=[RankProfile(name="default", first_phase="nativeRank(title)")],
     )
     return ApplicationPackage(name="testupdates", schema=[schema])


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

`tests/integration/test_integration_docker.py` started failing with:

```txt
RuntimeError: Deployment failed, code: 400, message: {'error-code': 'INVALID_APPLICATION_PACKAGE', 'message': "Invalid application: For schema 'testupdates', fieldset 'default': Illegal mixing of tensor fields ['tensorfield'] and non-tensor fields ['contact','price','title']"}
```
[Link to job](https://github.com/vespa-engine/pyvespa/actions/runs/13278114832/job/37073266752)

This was incorrect in the test, but previously did not cause deploymenterror. 