### PR TITLE
Update video_search_twelvelabs_cloud.ipynb

### DIFF
--- a/docs/sphinx/source/examples/video_search_twelvelabs_cloud.ipynb
+++ b/docs/sphinx/source/examples/video_search_twelvelabs_cloud.ipynb
@@ -2828,12 +2828,6 @@
         "  Your browser does not support the video tag.\n",
         "</video>\n",
         "\n",
-        "<script>\n",
-        "  var video = document.getElementById(\"myVideo\");\n",
-        "  video.addEventListener('loadedmetadata', function() {{\n",
-        "    video.currentTime = {middle_point};\n",
-        "  }}, false);\n",
-        "</script>\n",
         "\"\"\"\n",
         "\n",
         "HTML(video_player)"


### PR DESCRIPTION
Remove middle-point code in video player, as this was unnecessary code. It will error out otherwise, as the python code to determine the middle point has been deleted.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
