### PR TITLE
not run on pr

### DIFF
--- a/.github/workflows/notebooks-cloud.yml
+++ b/.github/workflows/notebooks-cloud.yml
@@ -3,8 +3,7 @@ name: Notebooks - cloud
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - master
+    paths: ["docs/sphinx/source/**/*cloud.ipynb", "vespa/deployment.py"]
   push:
     branches:
       - master


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Changing notebooks to only run on PRs when related files change, to avoid cancellation and long runs.