### PR TITLE
(CI) do not assert on message

### DIFF
--- a/tests/integration/test_integration_docker.py
+++ b/tests/integration/test_integration_docker.py
@@ -926,20 +926,12 @@ class TestApplicationCommon(unittest.TestCase):
         self, app, expected_model_endpoint
     ):
         self.assertEqual(
-            app.get_model_endpoint(),
-            {
-                "status_code": 404,
-                "message": "No binding for URI '{}'.".format(expected_model_endpoint),
-            },
+            app.get_model_endpoint()["status_code"],
+            404,
         )
         self.assertEqual(
-            app.get_model_endpoint(model_id="bert_tiny"),
-            {
-                "status_code": 404,
-                "message": "No binding for URI '{}bert_tiny'.".format(
-                    expected_model_endpoint
-                ),
-            },
+            app.get_model_endpoint(model_id="bert_tiny")["status_code"],
+            404,
         )
 
     def get_stateless_prediction_when_model_not_defined(self, app, application_package):


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Integration tests [failed](https://github.com/vespa-engine/pyvespa/actions/runs/13894922912/job/39022627510), as probably the message on 404-requests changed with the Jetty 12 Upgrade. 
Remove the assertion on specific message, and just assert on status code. 