### PR TITLE
(CI) pin transformers version in colbert-notebooks

### DIFF
--- a/docs/sphinx/source/examples/colbert_standalone_Vespa-cloud.ipynb
+++ b/docs/sphinx/source/examples/colbert_standalone_Vespa-cloud.ipynb
@@ -42,7 +42,7 @@
             },
             "outputs": [],
             "source": [
-                "!pip3 install -U pyvespa colbert-ai numpy torch"
+                "!pip3 install -U pyvespa colbert-ai numpy torch transformers<=4.49.0"
             ]
         },
         {

--- a/docs/sphinx/source/examples/colbert_standalone_long_context_Vespa-cloud.ipynb
+++ b/docs/sphinx/source/examples/colbert_standalone_long_context_Vespa-cloud.ipynb
@@ -38,7 +38,7 @@
             },
             "outputs": [],
             "source": [
-                "!pip3 install -U pyvespa colbert-ai numpy torch vespacli"
+                "!pip3 install -U pyvespa colbert-ai numpy torch vespacli transformers<=4.49.0"
             ]
         },
         {


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Fix faling notebooks due to incompatibility with latest version of transformers. Seems [a fix](https://github.com/stanford-futuredata/ColBERT/pull/390) is on the way, though. Once merged, we can unpin.