### PR TITLE
docs: Use correct function type for example

### DIFF
--- a/vespa/application.py
+++ b/vespa/application.py
@@ -626,7 +626,7 @@ class Vespa(object):
                 {"id": "1", "fields": {"field1": "value1"}},
                 {"id": "2", "fields": {"field1": "value2"}},
             ]
-            async def callback(response, id):
+            def callback(response, id):
                 print(f"Response for id {id}: {response.status_code}")
             app.feed_async_iterable(data, schema="schema_name", callback=callback)
             ```


### PR DESCRIPTION
Whilst this is for the async version of `feed_iterable`, thee callback isn't awaited on[^1].

[^1]: https://github.com/jesse-c/pyvespa/blob/master/vespa/application.py#L682

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
