### PR TITLE
(CI) add apt update to notebooks using apt install command

### DIFF
--- a/docs/sphinx/source/examples/colpali-document-retrieval-vision-language-models-cloud.ipynb
+++ b/docs/sphinx/source/examples/colpali-document-retrieval-vision-language-models-cloud.ipynb
@@ -77,7 +77,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "!sudo apt-get update && sudo apt-get installget install poppler-utils -y"
+                "!sudo apt-get update && sudo apt-get install poppler-utils -y"
             ]
         },
         {

--- a/docs/sphinx/source/examples/colpali-document-retrieval-vision-language-models-cloud.ipynb
+++ b/docs/sphinx/source/examples/colpali-document-retrieval-vision-language-models-cloud.ipynb
@@ -77,7 +77,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "!sudo apt get update && sudo apt get install poppler-utils -y"
+                "!sudo apt-get update && sudo apt-get installget install poppler-utils -y"
             ]
         },
         {

--- a/docs/sphinx/source/examples/colpali-document-retrieval-vision-language-models-cloud.ipynb
+++ b/docs/sphinx/source/examples/colpali-document-retrieval-vision-language-models-cloud.ipynb
@@ -77,7 +77,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "!sudo apt-get install poppler-utils -y"
+                "!sudo apt get update && sudo apt get install poppler-utils -y"
             ]
         },
         {

--- a/docs/sphinx/source/examples/pdf-retrieval-with-ColQwen2-vlm_Vespa-cloud.ipynb
+++ b/docs/sphinx/source/examples/pdf-retrieval-with-ColQwen2-vlm_Vespa-cloud.ipynb
@@ -64,7 +64,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "!sudo apt-get install poppler-utils -y"
+                "!sudo apt get update && sudo apt get install poppler-utils -y"
             ]
         },
         {

--- a/docs/sphinx/source/examples/pdf-retrieval-with-ColQwen2-vlm_Vespa-cloud.ipynb
+++ b/docs/sphinx/source/examples/pdf-retrieval-with-ColQwen2-vlm_Vespa-cloud.ipynb
@@ -64,7 +64,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "!sudo apt get update && sudo apt get install poppler-utils -y"
+                "!sudo apt-get update && sudo apt-get installget install poppler-utils -y"
             ]
         },
         {

--- a/docs/sphinx/source/examples/pdf-retrieval-with-ColQwen2-vlm_Vespa-cloud.ipynb
+++ b/docs/sphinx/source/examples/pdf-retrieval-with-ColQwen2-vlm_Vespa-cloud.ipynb
@@ -64,7 +64,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "!sudo apt-get update && sudo apt-get installget install poppler-utils -y"
+                "!sudo apt-get update && sudo apt-get install poppler-utils -y"
             ]
         },
         {

--- a/docs/sphinx/source/examples/simplified-retrieval-with-colpali-vlm_Vespa-cloud.ipynb
+++ b/docs/sphinx/source/examples/simplified-retrieval-with-colpali-vlm_Vespa-cloud.ipynb
@@ -62,7 +62,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "!sudo apt get update && sudo apt get install poppler-utils -y"
+                "!sudo apt-get update && sudo apt-get installget install poppler-utils -y"
             ]
         },
         {

--- a/docs/sphinx/source/examples/simplified-retrieval-with-colpali-vlm_Vespa-cloud.ipynb
+++ b/docs/sphinx/source/examples/simplified-retrieval-with-colpali-vlm_Vespa-cloud.ipynb
@@ -62,7 +62,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "!sudo apt-get install poppler-utils -y"
+                "!sudo apt get update && sudo apt get install poppler-utils -y"
             ]
         },
         {

--- a/docs/sphinx/source/examples/simplified-retrieval-with-colpali-vlm_Vespa-cloud.ipynb
+++ b/docs/sphinx/source/examples/simplified-retrieval-with-colpali-vlm_Vespa-cloud.ipynb
@@ -62,7 +62,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "!sudo apt-get update && sudo apt-get installget install poppler-utils -y"
+                "!sudo apt-get update && sudo apt-get install poppler-utils -y"
             ]
         },
         {

--- a/docs/sphinx/source/examples/visual_pdf_rag_with_vespa_colpali_cloud.ipynb
+++ b/docs/sphinx/source/examples/visual_pdf_rag_with_vespa_colpali_cloud.ipynb
@@ -121,7 +121,7 @@
             },
             "outputs": [],
             "source": [
-                "!sudo apt-get update && sudo apt-get installget install poppler-utils -y"
+                "!sudo apt-get update && sudo apt-get install poppler-utils -y"
             ]
         },
         {

--- a/docs/sphinx/source/examples/visual_pdf_rag_with_vespa_colpali_cloud.ipynb
+++ b/docs/sphinx/source/examples/visual_pdf_rag_with_vespa_colpali_cloud.ipynb
@@ -121,7 +121,7 @@
             },
             "outputs": [],
             "source": [
-                "!sudo apt-get install poppler-utils -y"
+                "!sudo apt get update && sudo apt get install poppler-utils -y"
             ]
         },
         {

--- a/docs/sphinx/source/examples/visual_pdf_rag_with_vespa_colpali_cloud.ipynb
+++ b/docs/sphinx/source/examples/visual_pdf_rag_with_vespa_colpali_cloud.ipynb
@@ -121,7 +121,7 @@
             },
             "outputs": [],
             "source": [
-                "!sudo apt get update && sudo apt get install poppler-utils -y"
+                "!sudo apt-get update && sudo apt-get installget install poppler-utils -y"
             ]
         },
         {


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Seeing some apt mirror related errors in some jobs, eg. https://github.com/vespa-engine/pyvespa/actions/runs/14853701341/job/41702037999 

Hopefully resolved by running `apt-get update` first. 