### PR TITLE
fix: correct type hints in deployment.py

### DIFF
--- a/vespa/deployment.py
+++ b/vespa/deployment.py
@@ -1498,7 +1498,7 @@ class VespaCloud(VespaDeployment):
         instance: Optional[str] = "default",
         region: Optional[str] = None,
         environment: Optional[str] = "dev",
-    ) -> List[Dict[str, str]]:
+    ) -> List[str]:
         """
         Get all endpoints for the application package content in the specified region and environment.
        
@@ -1531,7 +1531,7 @@ class VespaCloud(VespaDeployment):
         instance: Optional[str] = "default",
         region: Optional[str] = None,
         environment: Optional[str] = "dev",
-    ) -> List[Dict[str, str]]:
+    ) -> List[str]:
         """
         Get all schemas for the application instance in the specified environment and region.
        


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Corrects two type hints typos in deployment.py from latest commit