### PR TITLE
fix: Change get_schemas to return dictionary containing name and content

### DIFF
--- a/tests/integration/test_integration_vespa_cloud.py
+++ b/tests/integration/test_integration_vespa_cloud.py
@@ -218,8 +218,9 @@ class TestMsmarcoApplication(TestApplicationCommon):
             region="aws-us-east-1c",
             environment="dev"
         )
-        self.assertIsInstance(schemas, list)
-        self.assertTrue(all(isinstance(schema, str) for schema in schemas))
+        self.assertIsInstance(schemas, dict)
+        self.assertTrue(all(isinstance(schema_content, str) for schema_content in schemas.values()))
+        self.assertTrue(all(isinstance(schema_name, str) for schema_name in schemas.keys()))
 
     def test_download_app_package_content(self):
         with TemporaryDirectory() as temp_dir:

--- a/tests/unit/test_deployment.py
+++ b/tests/unit/test_deployment.py
@@ -77,10 +77,11 @@ class TestVespaCloud(unittest.TestCase):
             b"schema2 content"                             # Third call (for schema2)
         ]
         result = self.vespa_cloud.get_schemas("instance", "region", "env")
-        self.assertIsInstance(result, list)
-        self.assertIn("schema1 content", result)
-        self.assertIn("schema2 content", result)
-        self.assertTrue(all(isinstance(schema, str) for schema in result))
+        self.assertIsInstance(result, dict)
+        self.assertIn("schema1 content", result.values())
+        self.assertIn("schema2 content", result.values())
+        self.assertTrue(all(isinstance(schema_content, str) for schema_content in result.values()))
+        self.assertTrue(all(isinstance(schema_name, str) for schema_name in result.keys()))
 
     @patch("vespa.deployment.VespaCloud.get_app_package_contents")
     @patch("vespa.deployment.VespaCloud._request")

--- a/vespa/deployment.py
+++ b/vespa/deployment.py
@@ -1531,7 +1531,7 @@ class VespaCloud(VespaDeployment):
         instance: Optional[str] = "default",
         region: Optional[str] = None,
         environment: Optional[str] = "dev",
-    ) -> List[str]:
+    ) -> Dict[str, str]:
         """
         Get all schemas for the application instance in the specified environment and region.
        
@@ -1541,7 +1541,7 @@ class VespaCloud(VespaDeployment):
             environment (str): Environment (dev/prod). Default is 'dev'.
         
         Returns:
-            list: List of schemas.
+            dict: Dictionary with schema name as key and content as value.
         """
         if region is None:
             if environment == "dev":
@@ -1550,7 +1550,8 @@ class VespaCloud(VespaDeployment):
                 region = self.get_prod_region()
             else:
                 raise ValueError("Invalid environment. Must be 'dev' or 'prod'")
-        schemas = [self._request(
+        schemas = {
+            schema_endpoint.split("/")[-1][:-3] : self._request(
             "GET",
             urlparse(schema_endpoint).path
             ).decode("utf-8") for schema_endpoint in
@@ -1559,7 +1560,7 @@ class VespaCloud(VespaDeployment):
             "/application/v4/tenant/{}/application/{}/instance/{}/environment/{}/region/{}/content/schemas/".format(
                 self.tenant, self.application, instance, environment, region
                 )
-            )]
+            )}
 
         return schemas
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Changed VespaCloud.get_schemas() to return the schemas as a dictionary with name as key and content as value, instead of a list with only content. The affected tests have also been changed to correspond with the updated function.