### PR TITLE
Write clients.pem cert file when deploying from `application_root`

### DIFF
--- a/vespa/deployment.py
+++ b/vespa/deployment.py
@@ -1788,10 +1788,10 @@ class VespaCloud(VespaDeployment):
                 clients_pem.write(
                     self.data_certificate.public_bytes(serialization.Encoding.PEM)
                 )
-        else:
-            raise FileExistsError(
-                f"Certificate already exists at {cert_path}. Use 'overwrite=True' to overwrite it.",
-                file=self.output,
+        elif os.path.exists(cert_path):
+            logging.info(
+                f"Will use existing file at {cert_path}."
+                f"Remove it to add new clients.pem-file on deployment."
             )
 
     def _start_prod_deployment(


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

We did not add the generated certificate to the package before zipping when deploying from `application_root`-directory.
We did so when deploying from pyvespa-defined `application_package`. 

This PR make sure a `clients.pem`-file is added to package before zipping if it does not previously exist also when deploying from `application_root`
If it does exist prior to deployment, the existing one will be used (and remain unchanged). 