### PR TITLE
Fix user auth input also from terminal

### DIFF
--- a/vespa/deployment.py
+++ b/vespa/deployment.py
@@ -31,7 +31,6 @@ from cryptography.hazmat.primitives.asymmetric import ec
 
 from vespa.application import Vespa
 from vespa.package import ApplicationPackage
-from vespa.utils.notebook import is_jupyter_notebook
 import vespa
 
 # Get the Vespa home directory
@@ -1106,7 +1105,6 @@ class VespaCloud(VespaDeployment):
             )
         import pty
 
-        is_notebook = is_jupyter_notebook()
         # Open a new pseudo-terminal
         master, slave = pty.openpty()
 
@@ -1138,8 +1136,8 @@ class VespaCloud(VespaDeployment):
                             finished = True  # Exit the loop after success message
                             break
 
-                        # Check for input only if running in a Jupyter Notebook
-                        if is_notebook and "[Y/n]" in output:
+                        # Check for input if running in a Jupyter Notebook or terminal
+                        if "[Y/n]" in output:
                             user_input = input() + "\n"
                             os.write(master, user_input.encode())
                             sys.stdout.flush()


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Tried to think why this was implemented this way - but can't think of anything other than logging in interactively from notebook was the original use case. 

To test, run eg. 

```python
from vespa.deployment import VespaCloud
import os

vespa_cloud = VespaCloud(
    tenant="vespa-team",
    application="rag-blueprint",
    application_root=".",
)
```
from terminal (REPL or as script, should work). 