### PR TITLE
Fix 'alias component: component_alias' feature

### DIFF
--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -1582,12 +1582,18 @@ class TestFieldAlias(unittest.TestCase):
                         alias=["single_aliased_field_alias"],
                     ),
                     Field(
+                        name="single_component_aliased_field",
+                        type="string",
+                        alias=["component:component_alias"],
+                    ),
+                    Field(
                         name="multiple_aliased_field",
                         type="string",
                         alias=[
                             "first_alias",
                             "second_alias",
                             "third_alias",
+                            "fourth_component: fourth_alias",
                         ],
                     ),
                 ]
@@ -1606,10 +1612,14 @@ class TestFieldAlias(unittest.TestCase):
             "        field single_aliased_field type string {\n"
             "            alias: single_aliased_field_alias\n"
             "        }\n"
+            "        field single_component_aliased_field type string {\n"
+            "            alias component: component_alias\n"
+            "        }\n"
             "        field multiple_aliased_field type string {\n"
             "            alias: first_alias\n"
             "            alias: second_alias\n"
             "            alias: third_alias\n"
+            "            alias fourth_component: fourth_alias\n"
             "        }\n"
             "    }\n"
             "}"
@@ -2005,6 +2015,7 @@ class TestPredicateField(unittest.TestCase):
         print()
         print(expected_result)
         self.assertEqual(self.app_package.schema.schema_to_text, expected_result)
+
 
 class TestRankProfileCustomSettings(unittest.TestCase):
     def test_rank_profile_with_filter_and_weakand(self):

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -323,6 +323,12 @@ class StructField:
 
 
 class FieldConfiguration(TypedDict, total=False):
+    """
+    alias (list[str]): Add alias to the field.
+        Use the format "component: component_alias" to add an alias to a field's component.
+        See [Vespa documentation](https://docs.vespa.ai/en/reference/schema-reference.html#uri) for an example.
+    """
+
     indexing: List[str]
     attribute: List[str]
     index: str
@@ -380,6 +386,7 @@ class Field(object):
             query_command (list, optional): Add configuration for query-command of the field.
             struct_fields (list, optional): Add struct-fields to the field.
             alias (list, optional): Add alias to the field.
+                Use the format "component: component_alias" to add an alias to a field's component. See [Vespa documentation](https://docs.vespa.ai/en/reference/schema-reference.html#uri) for an example.
 
         Example:
             ```python
@@ -492,9 +499,9 @@ class Field(object):
             Field(
                 name = "artist",
                 type = "string",
-                alias = ["artist_name"],
+                alias = ["artist_name", "component: component_alias"],
             )
-            Field('artist', 'string', None, None, None, None, None, None, None, None, True, None, None, None, [], ['artist_name'])
+            Field('artist', 'string', None, None, None, None, None, None, None, None, True, None, None, None, [], ['artist_name', 'component: component_alias'])
             ```
         """
 
@@ -2438,9 +2445,11 @@ class ContainerCluster(Cluster):
             *[search(), document_api(), document_processing()],
             *[c.to_vt() for c in self.components or []],
             *[
-                clients(a.to_vt() for a in self.auth_clients or [])
-                if self.auth_clients
-                else None
+                (
+                    clients(a.to_vt() for a in self.auth_clients or [])
+                    if self.auth_clients
+                    else None
+                )
             ],
         )
 
@@ -2521,9 +2530,11 @@ class ContentCluster(Cluster):
         return content(
             id=self.id,
             version=self.version,
-            *self.nodes.to_vt()
-            if self.nodes
-            else [nodes(node(distribution_key="0", hostalias="node1"))],
+            *(
+                self.nodes.to_vt()
+                if self.nodes
+                else [nodes(node(distribution_key="0", hostalias="node1"))]
+            ),
             *[min_redundancy(self.min_redundancy)],
             *[documents(document(type=self.document_name, mode="index"))],
         )
@@ -2917,16 +2928,16 @@ class ApplicationPackage(object):
 
     @property
     def schema(self):
-        assert (
-            len(self.schemas) <= 1
-        ), "Your application has more than one Schema, use get_schema instead."
+        assert len(self.schemas) <= 1, (
+            "Your application has more than one Schema, use get_schema instead."
+        )
         return self.schemas[0] if self.schemas else None
 
     def get_schema(self, name: Optional[str] = None):
         if not name:
-            assert (
-                len(self.schemas) <= 1
-            ), "Your application has more than one Schema, specify name argument."
+            assert len(self.schemas) <= 1, (
+                "Your application has more than one Schema, specify name argument."
+            )
             return self.schema
         return self._schema[name]
 

--- a/vespa/templates/macros.txt
+++ b/vespa/templates/macros.txt
@@ -71,7 +71,11 @@ field {{ field.name }} type {{ field.type }} {
     {% endif %}
     {% if field.alias %}
     {% for alias in field.alias %}
+    {% if ':' in alias %}
+    alias {{ alias }}
+    {% else %}
     alias: {{ alias }}
+    {% endif %}
     {% endfor %}
     {% endif %}
     {% if field.struct_fields %}

--- a/vespa/templates/schema.txt
+++ b/vespa/templates/schema.txt
@@ -80,7 +80,11 @@ schema {{ schema_name }}{% if schema.inherits %} inherits {{ schema.inherits }}{
                 {% endif %}
                 {% if field.alias %}
                 {% for alias in field.alias %}
+                {% if ':' in alias %}
+                alias {{ alias }}
+                {% else %}
                 alias: {{ alias }}
+                {% endif %}
                 {% endfor %}
                 {% endif %}
             }


### PR DESCRIPTION
In the vespa documentation, it is [mentioned](https://docs.vespa.ai/en/reference/schema-reference.html#uri) that we can alias directly a component of a field, which is not yet possible in pyvespa.
I propose this very simple contribution, that would allow to use this feature in pyvespa, simply using the pattern "component: component_alias".
I added some documentation for this.
In some places, this might break the spirit of some examples. Feel free to point this as over-documented and I'll remove it.

Automatic comment which I read and approved :

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
