### PR TITLE
Multiple query profiles

### DIFF
--- a/vespa/package.py
+++ b/vespa/package.py
@@ -3026,9 +3026,9 @@ class ApplicationPackage(object):
             query_profile_type (QueryProfileType, optional): QueryProfileType of the application. If None,
                 a default QueryProfileType 'root' will be created. Defaults to None.
             additional_query_profiles (dict, optional): Dictionary of QueryProfile objects for the application. If None, a default
-                QueryProfile with QueryProfileType 'root' will be created. Defaults to None.
+                QueryProfile with QueryProfileType 'root' will be created. Defaults to None, will be converted to empty dict.
             additional_query_profile_types (dict, optional): Dictionary of QueryProfileType objects for the application. If None,
-                a default QueryProfileType 'root' will be created. Defaults to None.
+                a default QueryProfileType 'root' will be created. Defaults to None, will be converted to empty dict.
             stateless_model_evaluation (bool, optional): Enable stateless model evaluation. Defaults to False.
             create_schema_by_default (bool, optional): Include a default Schema if none is provided in the schema
                 argument. Defaults to True.
@@ -3076,8 +3076,8 @@ class ApplicationPackage(object):
         if not query_profile_type and create_query_profile_by_default:
             query_profile_type = QueryProfileType()
         self.query_profile_type = query_profile_type
-        self.additional_query_profiles = additional_query_profiles
-        self.additional_query_profile_types = additional_query_profile_types
+        self.additional_query_profiles = additional_query_profiles or {}
+        self.additional_query_profile_types = additional_query_profile_types or {}
         self.model_ids = []
         self.model_configs = {}
         self.stateless_model_evaluation = stateless_model_evaluation

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -1984,7 +1984,7 @@ class QueryTypeField(object):
 
 
 class QueryProfileType(object):
-    def __init__(self, fields: Optional[List[QueryTypeField]] = None) -> None:
+    def __init__(self, name: str = "root", fields: Optional[List[QueryTypeField]] = None) -> None:
         """
         Create a Vespa Query Profile Type.
 
@@ -2011,7 +2011,7 @@ class QueryProfileType(object):
             # Output: QueryProfileType([QueryTypeField('ranking.features.query(tensor_bert)', 'tensor<float>(x[768])')])
             ```
         """
-        self.name = "root"
+        self.name = name
         self.fields = [] if not fields else fields
 
     def add_fields(self, *fields: QueryTypeField) -> None:
@@ -2085,7 +2085,7 @@ class QueryField(object):
 
 
 class QueryProfile(object):
-    def __init__(self, fields: Optional[List[QueryField]] = None) -> None:
+    def __init__(self, name: str = "default", type: str = "root", fields: Optional[List[QueryField]] = None) -> None:
         """
         Create a Vespa Query Profile.
 
@@ -2098,6 +2098,8 @@ class QueryProfile(object):
         Type checking is turned on by referencing a `QueryProfileType` from the query profile.
 
         Args:
+            name (str): Query profile name.
+            type (str): Query profile type.
             fields (list[QueryField]): A list of `QueryField`.
 
         Example:
@@ -2106,8 +2108,8 @@ class QueryProfile(object):
             # Output: QueryProfile([QueryField('maxHits', 1000)])
             ```
         """
-        self.name = "default"
-        self.type = "root"
+        self.name = name
+        self.type = type
         self.fields = [] if not fields else fields
 
     def add_fields(self, *fields: QueryField) -> None:
@@ -3137,8 +3139,12 @@ class ApplicationPackage(object):
                 )
             )
 
-    @property
-    def query_profile_to_text(self):
+    
+    def query_profile_to_text(self, query_profile_name: str = "default"):
+        if query_profile_name not in self.query_profiles:
+            raise ValueError(
+                f"Query profile named {query_profile_name} not defined in the application package."
+            )
         env = Environment(
             loader=PackageLoader("vespa", "templates"),
             autoescape=select_autoescape(
@@ -3152,8 +3158,11 @@ class ApplicationPackage(object):
         query_profile_template = env.get_template("query_profile.xml")
         return query_profile_template.render(query_profile=self.query_profile)
 
-    @property
-    def query_profile_type_to_text(self):
+    def query_profile_type_to_text(self, query_profile_type_name: str = "root"):
+        if query_profile_type_name not in self.query_profile_types:
+            raise ValueError(
+                f"Query profile type named {query_profile_type_name} not defined in the application package."
+            )
         env = Environment(
             loader=PackageLoader("vespa", "templates"),
             autoescape=select_autoescape(
@@ -3166,7 +3175,7 @@ class ApplicationPackage(object):
         env.lstrip_blocks = True
         query_profile_type_template = env.get_template("query_profile_type.xml")
         return query_profile_type_template.render(
-            query_profile_type=self.query_profile_type
+            query_profile_type=self.query_profile_types[query_profile_type_name]
         )
 
     @property

--- a/vespa/templates/query_profile.xml
+++ b/vespa/templates/query_profile.xml
@@ -1,4 +1,4 @@
-<query-profile id="default" type="root">
+<query-profile id="{{ query_profile.name }}" type="{{ query_profile.type }}">
     {% for field in query_profile.fields %}
     <field name="{{ field.name }}">{{ field.value }}</field>
     {% endfor %}

--- a/vespa/templates/query_profile_type.xml
+++ b/vespa/templates/query_profile_type.xml
@@ -1,4 +1,4 @@
-<query-profile-type id="root">
+<query-profile-type id="{{ query_profile_type.name }}">
     {% for field in query_profile_type.fields %}
     <field name="{{ field.name }}" type="{{ field.type }}" />
     {% endfor %}


### PR DESCRIPTION
Vespa proposes to use different query profiles to ease the configuration on the client side, as well as versioning them and therefore be able to deploy new changes gradually, which I find very useful. It is not yet possible to have other query profiles aside from the 'default'.
This PR proposes BREAKING changes, for ApplicationPackage:
- `query_profile:QueryProfile` is now `query_profiles:Dict[str, QueryProfile]` (note the added s in the name of the attribute)
- `query_profile_type: QueryProfileType` is now `query_profile_types: Dict[str, QueryProfileType]`

I did not yet do the tests, but of course I commit to repair them if this PR is considered interesting value for the package :) 

Automatic message that I read and approve :
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
