### PR TITLE
fix: add the missing export_to_onnx method

### DIFF
--- a/vespa/package.py
+++ b/vespa/package.py
@@ -1791,6 +1791,9 @@ class OnnxModel(object):
             repr(self.outputs),
         )
 
+    def export_to_onnx(self, output_path: Path) -> None:
+        copyfile(self.model_file_path, output_path)
+
 
 class SchemaConfiguration(TypedDict, total=False):
     stemming: Optional[str]


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

The support for adding ONNX models to application package is broken.

So, either the `export_to_onnx` method needs to be implemented, or the dance with temporary files needs to be reworked.

This PR add a missing method.

On the good note: it is possible to add ONNX model to the schema.

version 0.61.0 

@thomasht86 