### PR TITLE
Fixed hardcoded id_field in VespaMatchEvaluator

### DIFF
--- a/vespa/evaluation.py
+++ b/vespa/evaluation.py
@@ -1004,10 +1004,10 @@ class VespaMatchEvaluator(VespaEvaluatorBase):
 
             # Add recall parameter based on relevant docs
             if isinstance(relevant_docs, set):
-                recall_string = " ".join([f"id:{doc_id}" for doc_id in relevant_docs])
+                recall_string = " ".join([f"{self.id_field}:{doc_id}" for doc_id in relevant_docs])
             elif isinstance(relevant_docs, dict):
                 recall_string = " ".join(
-                    [f"id:{doc_id}" for doc_id in relevant_docs.keys()]
+                    [f"{self.id_field}:{doc_id}" for doc_id in relevant_docs.keys()]
                 )
             else:
                 raise ValueError(


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

In VespaMatchEvaluator, the recall param is currently hard-coded to use `'id'` instead of the `id_field` param, so doesn't work with custom id fields. This minor change fixes that.