### PR TITLE
model-evaluation: add a full response body in case of errors

### DIFF
--- a/vespa/application.py
+++ b/vespa/application.py
@@ -1350,7 +1350,11 @@ class VespaSync(object):
             if response.status_code == 200:
                 return response.json()
             else:
-                return {"status_code": response.status_code, "message": response.reason}
+                return {
+                    "status_code": response.status_code,
+                    "response": response.json(),
+                    "message": response.reason,
+                }
         except ConnectionError:
             response = None
         return response

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -1352,7 +1352,7 @@ class VespaSync(object):
             else:
                 return {
                     "status_code": response.status_code,
-                    "response": response.json(),
+                    "body": response.json(),
                     "message": response.reason,
                 }
         except ConnectionError:


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Currently, when evaluating the model with e.g. missing input Pyvespa returns:

```python
{
  "status_code": 400,
  "reason": "Bad Request"
}
```

This PR add the full response body, which contains detailed information on what is missing, e.g.:

```python
{
  "status_code": 400,
  "body": {
    "error": "Argument 'some_attribute' must be bound to a value of type tensor<float>(d0[])"
  },
  "reason": "Bad Request"
}
```

Also, when the ONNX output function is incorrectly specified:

Before:
```json
{'status_code': 404,
 'reason': 'Not Found'}
```

After:
```json
{'status_code': 404,
 'body': {'error': "No function 'output' in model 'model_foo'. Available functions: correct_output"},
 'reason': 'Not Found'}
```

Related to #1123