### PR TITLE
remove caveat - `deploy_to_prod` 

### DIFF
--- a/vespa/deployment.py
+++ b/vespa/deployment.py
@@ -743,12 +743,7 @@ class VespaCloud(VespaDeployment):
         Raises:
             RuntimeError: If deployment fails or if there are issues with the deployment process.
 
-        Note:
-            This feature is still experimental and may not have full stability in production. Future releases will provide better support for this functionality.
         """
-        logging.warning(
-            "Deploying to production is in beta and may fail in unexpected ways. Expect better support in future releases."
-        )
         if application_root is None:
             if self.application_root is None:
                 application_root = os.path.join(os.getcwd(), self.application)


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This has been running for a while in tests now, so we can remove the caveat 