### PR TITLE
Fix langchain-community install for LangChain 1.x

### DIFF
--- a/docs/sphinx/source/examples/chat_with_your_pdfs_using_colbert_langchain_and_Vespa-cloud.ipynb
+++ b/docs/sphinx/source/examples/chat_with_your_pdfs_using_colbert_langchain_and_Vespa-cloud.ipynb
@@ -69,7 +69,7 @@
     "id": "4ffa3cbe"
    },
    "outputs": [],
-   "source": "!pip3 install -U pyvespa langchain langchain-community langchain-openai langchain-text-splitters pypdf==5.0.1 openai vespacli"
+   "source": "!pip3 install -U pyvespa \"langchain[community]\" langchain-openai langchain-text-splitters pypdf==5.0.1 openai vespacli"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- Change pip install from `langchain langchain-community` to `langchain[community]` 

## Context
With LangChain 1.x, community integrations (like `langchain_community.document_loaders.PyPDFLoader`) are now installed via the `langchain[community]` extra instead of a separate `langchain-community` package.

The previous PR fixed the text splitter import, but the notebook was still failing with:
```
ModuleNotFoundError: No module named 'langchain_community'
```

## Test plan
- [ ] CI notebook tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)