### PR TITLE
Fix langchain-community installation (use uv pip)

### DIFF
--- a/docs/sphinx/source/examples/chat_with_your_pdfs_using_colbert_langchain_and_Vespa-cloud.ipynb
+++ b/docs/sphinx/source/examples/chat_with_your_pdfs_using_colbert_langchain_and_Vespa-cloud.ipynb
@@ -69,7 +69,7 @@
     "id": "4ffa3cbe"
    },
    "outputs": [],
-   "source": "!pip3 install -U pyvespa langchain langchain-community langchain-openai langchain-text-splitters pypdf==5.0.1 openai vespacli"
+   "source": "!uv pip install -q pyvespa langchain langchain-community langchain-openai langchain-text-splitters pypdf==5.0.1 openai vespacli"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- Use `!uv pip install` instead of `!pip3 install` in the langchain notebook

## Context
The previous fixes didn't work because:
1. `langchain[community]` extra is commented out in langchain's pyproject.toml
2. `!pip3 install` packages get extracted by the CI script but don't get installed to the correct kernel environment

Using `!uv pip install` works because:
1. The CI script only matches `!pip` lines, so it won't extract/comment this
2. The command runs during notebook execution
3. `uv pip install` installs directly to the active venv (which is what papermill uses)

**Tested locally:** Fresh venv → uv sync → papermill → imports succeed ✅

## Test plan
- [ ] CI notebook tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)