### PR TITLE
feat: added detailed status header check in deployment wait

### DIFF
--- a/vespa/deployment.py
+++ b/vespa/deployment.py
@@ -998,6 +998,8 @@ class VespaCloud(VespaDeployment):
             status = self.check_production_build_status(build_no)
             if status["status"] == "done":
                 return status["deployed"]
+            if "detailed-status" in status and status["detailed-status"] not in ["success", "running"]:
+                raise RuntimeError(f"The build failed with status code: {status['detailed-status']}")
             time.sleep(poll_interval)
         raise TimeoutError(f"Deployment did not finish within {max_wait} seconds. ")
 


### PR DESCRIPTION
In an update of vespa cloud this will give additional information about the deployment instead of just boolean values

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This cannot really destroy anything. I have not run all the integration tests because it takes waaay too much time.

Related to: https://github.com/vespaai/cloud/pull/1968