### PR TITLE
Exclude colpali-vlm notebook from cloud CI due to pillow conflict

### DIFF
--- a/.github/workflows/notebooks-cloud.yml
+++ b/.github/workflows/notebooks-cloud.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set output variable (Make sure it is this quote format - "[path/to/notebook1.ipynb", "path/to/notebook2.ipynb]")
         id: set_output
         run: |
-          notebooks=$(find docs/sphinx/source -name '*cloud.ipynb' ! -name 'pdf-retrieval-with-ColQwen2-vlm_Vespa-cloud.ipynb' ! -name 'mother-of-all-embedding-models-cloud.ipynb' ! -name 'scaling-personal-ai-assistants-with-streaming-mode-cloud.ipynb' ! -name 'colpali-benchmark-vqa-vlm_Vespa-cloud.ipynb' ! -name 'video_search_twelvelabs_cloud.ipynb' | jq -R -s -c 'split("\n")[:-1]')
+          notebooks=$(find docs/sphinx/source -name '*cloud.ipynb' ! -name 'pdf-retrieval-with-ColQwen2-vlm_Vespa-cloud.ipynb' ! -name 'mother-of-all-embedding-models-cloud.ipynb' ! -name 'scaling-personal-ai-assistants-with-streaming-mode-cloud.ipynb' ! -name 'colpali-benchmark-vqa-vlm_Vespa-cloud.ipynb' ! -name 'video_search_twelvelabs_cloud.ipynb' ! -name 'simplified-retrieval-with-colpali-vlm_Vespa-cloud.ipynb' | jq -R -s -c 'split("\n")[:-1]')
           # Print all notebooks echo
           echo $notebooks
           echo "notebooks=$notebooks" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- Exclude `simplified-retrieval-with-colpali-vlm_Vespa-cloud.ipynb` from the `notebooks-cloud` CI workflow matrix

## Motivation

The recent security bump (#1229, `993f4d7e`) added `pillow>=12.1.1` as a `[tool.uv] constraint-dependencies` entry. This conflicts with `vidore_benchmark==4.0.0` (used by this notebook), which requires `pillow>=9.2.0,<11.0.0`.

The workflow first runs `uv sync` (installing pillow>=12.1.1 per the constraint), then `uv pip install -r additional_requirements.txt` (which needs vidore_benchmark with pillow<11). This is unsatisfiable.

No version of `vidore_benchmark` currently supports pillow>=12, so the only viable fix is to exclude the notebook — following the same pattern already used for 5 other notebooks in this workflow.

## Test plan

- [ ] Verify the `find` command in the workflow no longer includes the excluded notebook
- [ ] Confirm remaining cloud notebooks continue to run as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)