### PR TITLE
Exclude visual_pdf_rag colpali notebook from cloud CI

### DIFF
--- a/.github/workflows/notebooks-cloud.yml
+++ b/.github/workflows/notebooks-cloud.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set output variable (Make sure it is this quote format - "[path/to/notebook1.ipynb", "path/to/notebook2.ipynb]")
         id: set_output
         run: |
-          notebooks=$(find docs/sphinx/source -name '*cloud.ipynb' ! -name 'pdf-retrieval-with-ColQwen2-vlm_Vespa-cloud.ipynb' ! -name 'mother-of-all-embedding-models-cloud.ipynb' ! -name 'scaling-personal-ai-assistants-with-streaming-mode-cloud.ipynb' ! -name 'colpali-benchmark-vqa-vlm_Vespa-cloud.ipynb' ! -name 'video_search_twelvelabs_cloud.ipynb' ! -name 'simplified-retrieval-with-colpali-vlm_Vespa-cloud.ipynb' | jq -R -s -c 'split("\n")[:-1]')
+          notebooks=$(find docs/sphinx/source -name '*cloud.ipynb' ! -name 'pdf-retrieval-with-ColQwen2-vlm_Vespa-cloud.ipynb' ! -name 'mother-of-all-embedding-models-cloud.ipynb' ! -name 'scaling-personal-ai-assistants-with-streaming-mode-cloud.ipynb' ! -name 'colpali-benchmark-vqa-vlm_Vespa-cloud.ipynb' ! -name 'video_search_twelvelabs_cloud.ipynb' ! -name 'simplified-retrieval-with-colpali-vlm_Vespa-cloud.ipynb' ! -name 'visual_pdf_rag_with_vespa_colpali_cloud.ipynb' | jq -R -s -c 'split("\n")[:-1]')
           # Print all notebooks echo
           echo $notebooks
           echo "notebooks=$notebooks" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- Exclude `visual_pdf_rag_with_vespa_colpali_cloud.ipynb` from the `notebooks-cloud` CI workflow matrix

## Motivation

Same root cause as #1231: the notebook pins `pillow==10.4.0`, which conflicts with the `pillow>=12.1.1` UV constraint added in the security bump (#1229).

I checked all remaining cloud notebooks — this is the only other one that references pillow with an incompatible version. The already-excluded `colpali-benchmark-vqa-vlm_Vespa-cloud.ipynb` also uses pillow but doesn't pin a conflicting version.

## Test plan

- [ ] Verify the `find` command in the workflow no longer includes the excluded notebook
- [ ] Confirm remaining cloud notebooks continue to run as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)