### PR TITLE
Exclude colpali-document-retrieval notebook from cloud CI (pillow conflict)

### DIFF
--- a/.github/workflows/notebooks-cloud.yml
+++ b/.github/workflows/notebooks-cloud.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set output variable (Make sure it is this quote format - "[path/to/notebook1.ipynb", "path/to/notebook2.ipynb]")
         id: set_output
         run: |
-          notebooks=$(find docs/sphinx/source -name '*cloud.ipynb' ! -name 'pdf-retrieval-with-ColQwen2-vlm_Vespa-cloud.ipynb' ! -name 'mother-of-all-embedding-models-cloud.ipynb' ! -name 'scaling-personal-ai-assistants-with-streaming-mode-cloud.ipynb' ! -name 'colpali-benchmark-vqa-vlm_Vespa-cloud.ipynb' ! -name 'video_search_twelvelabs_cloud.ipynb' ! -name 'simplified-retrieval-with-colpali-vlm_Vespa-cloud.ipynb' ! -name 'visual_pdf_rag_with_vespa_colpali_cloud.ipynb' | jq -R -s -c 'split("\n")[:-1]')
+          notebooks=$(find docs/sphinx/source -name '*cloud.ipynb' ! -name 'pdf-retrieval-with-ColQwen2-vlm_Vespa-cloud.ipynb' ! -name 'mother-of-all-embedding-models-cloud.ipynb' ! -name 'scaling-personal-ai-assistants-with-streaming-mode-cloud.ipynb' ! -name 'colpali-benchmark-vqa-vlm_Vespa-cloud.ipynb' ! -name 'video_search_twelvelabs_cloud.ipynb' ! -name 'simplified-retrieval-with-colpali-vlm_Vespa-cloud.ipynb' ! -name 'visual_pdf_rag_with_vespa_colpali_cloud.ipynb' ! -name 'colpali-document-retrieval-vision-language-models-cloud.ipynb' | jq -R -s -c 'split("\n")[:-1]')
           # Print all notebooks echo
           echo $notebooks
           echo "notebooks=$notebooks" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- Exclude `colpali-document-retrieval-vision-language-models-cloud.ipynb` from the `notebooks-cloud` CI workflow matrix

## Motivation

Same root cause as #1231 and #1232: the notebook installs `vidore_benchmark==4.0.0` which requires `pillow>=9.2.0,<11.0.0`, conflicting with the `pillow>=12.1.1` UV constraint from the security bump (#1229).

**This is the last cloud notebook with this conflict.** Verified by grepping all `*cloud.ipynb` files for `vidore_benchmark` and `pillow` pins — no other non-excluded notebooks have this dependency.

## Test plan

- [ ] Verify the `find` command no longer includes this notebook
- [ ] Confirm remaining cloud notebooks continue to run

🤖 Generated with [Claude Code](https://claude.com/claude-code)