### PR TITLE
Create data-plane tokens and refresh getting-started

### DIFF
--- a/docs/sphinx/source/getting-started-pyvespa-cloud.ipynb
+++ b/docs/sphinx/source/getting-started-pyvespa-cloud.ipynb
@@ -36,7 +36,7 @@
             "id": "148d275b",
             "metadata": {},
             "source": [
-                "**Pre-requisite**: Create a tenant at [cloud.vespa.ai](https://cloud.vespa.ai/), save the tenant name.\n",
+                "**Pre-requisite**: Create a tenant at [cloud.vespa.ai](https://cloud.vespa.ai/) and remember the tenant name — you'll need it below.\n",
                 "\n",
                 "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vespa-engine/pyvespa/blob/master/docs/sphinx/source/getting-started-pyvespa-cloud.ipynb)\n"
             ]
@@ -48,9 +48,9 @@
             "source": [
                 "## Install\n",
                 "\n",
-                "Install [pyvespa](https://pyvespa.readthedocs.io/) >= 0.45\n",
-                "and the [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html).\n",
-                "The Vespa CLI is used for data and control plane key management ([Vespa Cloud Security Guide](https://cloud.vespa.ai/en/security/guide)).\n"
+                "This notebook needs two Python packages: [pyvespa](https://pyvespa.readthedocs.io/) (the API) and `vespacli`\n",
+                "(a Python wrapper for the [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html) that pyvespa calls internally\n",
+                "for configuration and credential management).\n"
             ]
         },
         {
@@ -80,7 +80,7 @@
             "source": [
                 "# Replace with your tenant name from the Vespa Cloud Console\n",
                 "tenant_name = \"vespa-team\"\n",
-                "# Replace with your application name (does not need to exist yet)\n",
+                "# Replace with your application name (does not need to exist yet, note that the name cannot have `-` or `_`)\n",
                 "application = \"hybridsearch\""
             ]
         },
@@ -205,20 +205,14 @@
         },
         {
             "cell_type": "markdown",
-            "id": "2c5e2943",
-            "metadata": {},
-            "source": [
-                "Note that the name cannot have `-` or `_`.\n"
-            ]
-        },
-        {
-            "cell_type": "markdown",
             "id": "careful-savage",
             "metadata": {},
             "source": [
                 "## Deploy to Vespa Cloud\n",
                 "\n",
                 "The app is now defined and ready to deploy to Vespa Cloud.\n",
+                "\n",
+                "The first time you do this, you'll be prompted to log in to Vespa Cloud if you are not already logged in. Confirm in the terminal and a browser window will open. pyvespa remembers your credentials after that.\n",
                 "\n",
                 "Deploy `package` to Vespa Cloud, by creating an instance of\n",
                 "[VespaCloud](https://vespa-engine.github.io/pyvespa/api/vespa/deployment.html#vespa.deployment.VespaCloud):\n"
@@ -265,8 +259,6 @@
             "id": "197c0a27",
             "metadata": {},
             "source": [
-                "For more details on different authentication options and methods, see [authenticating-to-vespa-cloud](https://vespa-engine.github.io/pyvespa/authenticating-to-vespa-cloud.html).\n",
-                "\n",
                 "The following will upload the application package to Vespa Cloud Dev Zone (`aws-us-east-1c`), read more about [Vespa Zones](https://cloud.vespa.ai/en/reference/zones.html).\n",
                 "The Vespa Cloud Dev Zone is considered as a sandbox environment where resources are down-scaled and idle deployments are expired automatically.\n",
                 "For information about production deployments, see the following [method](https://vespa-engine.github.io/pyvespa/api/vespa/deployment.html#vespa.deployment.VespaCloud.deploy_to_prod).\n",
@@ -342,19 +334,15 @@
             "id": "aaae2f91",
             "metadata": {},
             "source": [
-                "If the deployment failed, it is possible you forgot to add the key in the Vespa Cloud Console in the `vespa auth api-key` step above.\n",
-                "\n",
-                "If you can authenticate, you should see lines like the following\n",
+                "While deploying, you'll see lines like:\n",
                 "\n",
                 "```\n",
                 " Deployment started in run 1 of dev-aws-us-east-1c for mytenant.hybridsearch.\n",
                 "```\n",
                 "\n",
-                "The deployment takes a few minutes the first time while Vespa Cloud sets up the resources for your Vespa application\n",
+                "The first deployment takes a few minutes while Vespa Cloud sets up the resources for your application.\n",
                 "\n",
-                "`app` now holds a reference to a [Vespa](https://vespa-engine.github.io/pyvespa/api/vespa/application.html#vespa.application.Vespa) instance. We can access the\n",
-                "mTLS protected endpoint name using the control-plane (vespa_cloud) instance. This endpoint we can query and feed to (data plane access) using the\n",
-                "mTLS certificate generated in previous steps.\n"
+                "`app` is a [`Vespa`](https://vespa-engine.github.io/pyvespa/api/vespa/application.html#vespa.application.Vespa) instance that lets you query and feed documents. It connects to the secure (mTLS) endpoint where your app is now running:\n"
             ]
         },
         {
@@ -740,6 +728,70 @@
                 "Browse the site to learn more about schemas, feeding and queries -\n",
                 "find more complex applications in\n",
                 "[examples](https://vespa-engine.github.io/pyvespa/examples).\n"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "163c23d2",
+            "metadata": {},
+            "source": [
+                "## Example: Querying with a token\n",
+                "\n",
+                "By default pyvespa queries Vespa over mTLS, using a certificate it manages for you. If you'd rather use a token (e.g. to paste into `curl` or share with a teammate), pyvespa can create one. Re-deploy with token access enabled:\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "302fdc50",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "vespa_cloud_with_token = VespaCloud(\n",
+                "    tenant=tenant_name,\n",
+                "    application=application,\n",
+                "    key_content=key,\n",
+                "    application_package=package,\n",
+                "    auth_client_token_id=\"default-token\",\n",
+                ")\n",
+                "vespa_cloud_with_token.deploy()"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "d0a80fd0",
+            "metadata": {},
+            "source": [
+                "Now create the token. It's valid for 14 days. Copy the printed value if you\n",
+                "want to use it from outside this notebook — Vespa Cloud can't show it to you\n",
+                "again.\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "a81a1bea",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "token = vespa_cloud_with_token.create_dataplane_token()\n",
+                "print(\"Token id:\", token.id)\n",
+                "print(\"Expires: \", token.expiration)\n",
+                "# token.token holds the secret — capture it now if you need it outside this notebook (Vespa Cloud only shows it once)\n",
+                "\n",
+                "token_app = vespa_cloud_with_token.get_application(\n",
+                "    endpoint_type=\"token\",\n",
+                "    vespa_cloud_secret_token=token.token,\n",
+                ")\n",
+                "\n",
+                "with token_app.syncio(connections=1) as session:\n",
+                "    response = session.query(\n",
+                "        yql=\"select * from sources * where userQuery() limit 3\",\n",
+                "        query=\"How Fruits and Vegetables Can Treat Asthma?\",\n",
+                "        ranking=\"bm25\",\n",
+                "    )\n",
+                "    assert response.is_successful()\n",
+                "    print(display_hits_as_df(response, [\"id\", \"title\"]))"
             ]
         },
         {

--- a/tests/integration/test_integration_vespa_cloud_token.py
+++ b/tests/integration/test_integration_vespa_cloud_token.py
@@ -316,3 +316,58 @@ class TestMsmarcoProdApplicationWithTokenAuth(TestApplicationCommon):
         # This will delete the deployment
         self.vespa_cloud._start_prod_deployment(self.application_root)
         shutil.rmtree(self.application_root, ignore_errors=True)
+
+
+class TestCreateDataplaneTokenAndAutoInjectedAuthClients(unittest.TestCase):
+    """End-to-end coverage for VespaCloud.create_dataplane_token() and
+    auto-injection of <auth-clients> when auth_client_token_id is set
+    without explicit auth_clients on the application package."""
+
+    def setUp(self) -> None:
+        # No auth_clients passed — VespaCloud should auto-inject them.
+        self.app_package = create_msmarco_application_package()
+        self.assertIsNone(self.app_package.auth_clients)
+
+        self.vespa_cloud = VespaCloud(
+            tenant="vespa-team",
+            application="pyvespa-integration",
+            key_content=os.getenv("VESPA_TEAM_API_KEY").replace(r"\n", "\n"),
+            application_package=self.app_package,
+            auth_client_token_id=CLIENT_TOKEN_ID,
+        )
+        self.disk_folder = os.path.join(os.getcwd(), "sample_application_create_token")
+        self.instance_name = "create-token"
+
+    def test_auto_inject_then_create_token_and_query(self):
+        # Auto-injection should have populated auth_clients on the package.
+        injected_ids = {ac.id for ac in self.app_package.auth_clients}
+        self.assertEqual(injected_ids, {"mtls", "token"})
+        token_client = next(
+            ac for ac in self.app_package.auth_clients if ac.id == "token"
+        )
+        token_param = next(p for p in token_client.parameters if p.name == "token")
+        self.assertEqual(token_param.args["id"], CLIENT_TOKEN_ID)
+
+        # Deploy using the auto-injected services.xml.
+        self.vespa_cloud.deploy(
+            instance=self.instance_name, disk_folder=self.disk_folder
+        )
+
+        # Create a fresh data-plane token and use it to reach the app.
+        result = self.vespa_cloud.create_dataplane_token()
+        self.assertEqual(result.id, CLIENT_TOKEN_ID)
+        self.assertTrue(result.token)
+        self.assertTrue(result.fingerprint)
+        self.assertTrue(result.expiration)
+
+        app = self.vespa_cloud.get_application(
+            instance=self.instance_name,
+            environment="dev",
+            endpoint_type="token",
+            vespa_cloud_secret_token=result.token,
+        )
+        app.wait_for_application_up(max_wait=APP_INIT_TIMEOUT)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.disk_folder, ignore_errors=True)
+        self.vespa_cloud.delete(instance=self.instance_name)

--- a/tests/unit/test_deployment.py
+++ b/tests/unit/test_deployment.py
@@ -3,7 +3,16 @@ from tempfile import TemporaryDirectory
 import os
 from unittest.mock import patch, MagicMock
 
-from vespa.deployment import VespaCloud
+from urllib3.exceptions import HTTPError
+
+from vespa.deployment import VespaCloud, DataplaneToken
+from vespa.package import (
+    ApplicationPackage,
+    AuthClient,
+    ContainerCluster,
+    Nodes,
+    Parameter,
+)
 
 
 class TestVespaCloud(unittest.TestCase):
@@ -583,6 +592,131 @@ class TestDevRegion(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             self.vc.get_dev_region("invalid-region")
         self.assertIn("Invalid dev region", str(ctx.exception))
+
+
+class TestEnsureAuthClientsForToken(unittest.TestCase):
+    def setUp(self):
+        VespaCloud._try_get_access_token = MagicMock(return_value="fake_access_token")
+
+    def _make_pkg(self, auth_clients=None, clusters=None):
+        return ApplicationPackage(
+            name="myapp",
+            auth_clients=auth_clients,
+            clusters=clusters,
+        )
+
+    def test_no_op_when_token_id_not_set(self):
+        pkg = self._make_pkg()
+        VespaCloud(
+            tenant="t",
+            application="myapp",
+            application_package=pkg,
+        )
+        self.assertIn(pkg.auth_clients, (None, []))
+
+    def test_injects_both_when_no_auth_clients_set(self):
+        pkg = self._make_pkg()
+        VespaCloud(
+            tenant="t",
+            application="myapp",
+            application_package=pkg,
+            auth_client_token_id="myapp",
+        )
+        self.assertIsNotNone(pkg.auth_clients)
+        ids = [ac.id for ac in pkg.auth_clients]
+        self.assertIn("mtls", ids)
+        self.assertIn("token", ids)
+        mtls_ac = next(ac for ac in pkg.auth_clients if ac.id == "mtls")
+        self.assertEqual(len(mtls_ac.parameters), 1)
+        self.assertEqual(mtls_ac.parameters[0].name, "certificate")
+        self.assertEqual(mtls_ac.parameters[0].args, {"file": "security/clients.pem"})
+        token_ac = next(ac for ac in pkg.auth_clients if ac.id == "token")
+        self.assertEqual(token_ac.permissions, ["read", "write"])
+        self.assertEqual(token_ac.parameters[0].name, "token")
+        self.assertEqual(token_ac.parameters[0].args, {"id": "myapp"})
+
+    def test_preserves_existing_mtls_client(self):
+        existing = [AuthClient(id="mtls", permissions=["read"])]
+        pkg = self._make_pkg(auth_clients=list(existing))
+        VespaCloud(
+            tenant="t",
+            application="myapp",
+            application_package=pkg,
+            auth_client_token_id="myapp",
+        )
+        ids = [ac.id for ac in pkg.auth_clients]
+        self.assertEqual(ids.count("mtls"), 1)
+        mtls_ac = next(ac for ac in pkg.auth_clients if ac.id == "mtls")
+        self.assertEqual(mtls_ac.permissions, ["read"])
+        self.assertIn("token", ids)
+
+    def test_does_not_double_add_matching_token_client(self):
+        token_ac = AuthClient(
+            id="token",
+            permissions=["read", "write"],
+            parameters=[Parameter("token", {"id": "myapp"})],
+        )
+        pkg = self._make_pkg(auth_clients=[token_ac])
+        VespaCloud(
+            tenant="t",
+            application="myapp",
+            application_package=pkg,
+            auth_client_token_id="myapp",
+        )
+        token_clients = [ac for ac in pkg.auth_clients if ac.id == "token"]
+        self.assertEqual(len(token_clients), 1)
+
+
+class TestDataplaneToken(unittest.TestCase):
+    def setUp(self):
+        self.application_package = MagicMock()
+        VespaCloud._try_get_access_token = MagicMock(return_value="fake_access_token")
+        self.vc = VespaCloud(
+            tenant="t",
+            application="myapp",
+            application_package=self.application_package,
+        )
+        self.fake_response = {
+            "id": "myapp",
+            "token": "vespa_cloud_abc123",
+            "fingerprint": "ab:cd:ef",
+            "expiration": "2026-05-13T00:00:00Z",
+        }
+
+    @patch("vespa.deployment.VespaCloud._request")
+    def test_create_dataplane_token_default_token_id_is_application(self, mock_request):
+        mock_request.return_value = self.fake_response
+
+        self.vc.create_dataplane_token()
+
+        method, path = mock_request.call_args[0][:2]
+        self.assertEqual(method, "POST")
+        self.assertIn("/application/v4/tenant/t/token/myapp", path)
+
+    @patch("vespa.deployment.VespaCloud._request")
+    def test_create_dataplane_token_default_prefers_auth_client_token_id(
+        self, mock_request
+    ):
+        mock_request.return_value = self.fake_response
+
+        self.vc.auth_client_token_id = "default-token"
+        self.vc.create_dataplane_token()
+
+        path = mock_request.call_args[0][1]
+        self.assertIn("/tenant/t/token/default-token", path)
+        self.assertNotIn("/token/myapp", path)
+
+    @patch("vespa.deployment.VespaCloud._request")
+    def test_create_dataplane_token_custom_expiration_passes_through(
+        self, mock_request
+    ):
+        mock_request.return_value = self.fake_response
+
+        self.vc.create_dataplane_token(expiration="P30D")
+
+        path = mock_request.call_args[0][1]
+        self.assertIn("expiration=P30D", path)
+        self.assertNotIn("expiration=P14D", path)
 
 
 if __name__ == "__main__":

--- a/vespa/deployment.py
+++ b/vespa/deployment.py
@@ -8,6 +8,7 @@ import zipfile
 import logging
 import xml.etree.ElementTree as ET
 from base64 import standard_b64encode
+from dataclasses import dataclass
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
@@ -21,7 +22,7 @@ import shlex
 import select
 from dateutil import parser
 import time
-from urllib.parse import urlparse
+from urllib.parse import quote, urlencode, urlparse
 
 import docker
 
@@ -32,7 +33,7 @@ from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 
 from vespa.application import Vespa
-from vespa.package import ApplicationPackage
+from vespa.package import ApplicationPackage, AuthClient, Parameter
 import vespa
 
 # Get the Vespa home directory
@@ -588,7 +589,7 @@ class VespaCloud(VespaDeployment):
             application_package (ApplicationPackage): Application package to be deployed. Either this or application_root must be set.
             key_location (str, optional): Location of the control plane key used for signing HTTP requests to the Vespa Cloud.
             key_content (str, optional): Content of the control plane key used for signing HTTP requests to the Vespa Cloud. Use only when the key file is not available.
-            auth_client_token_id (str, optional): Token-based data plane authentication. This token name must be configured in the Vespa Cloud Console. It configures Vespa's services.xml, and the token must have read and write permissions.
+            auth_client_token_id (str, optional): Token-based data-plane authentication. When set with an ``application_package``, pyvespa injects mTLS + token ``<auth-clients>`` into ``services.xml`` (existing entries preserved).
             output_file (str, optional): Output file to write output messages. Default is sys.stdout.
             application_root (str, optional): Directory for the application root (location of services.xml, models/, schemas/, etc.). If the application is packaged with Maven, use the generated `<myapp>/target/application` directory.
             cluster (str, optional): Name of the cluster to target when retrieving endpoints. This affects which endpoints are used for initializing the :class:`Vespa` instance in `VespaCloud.get_application` and `VespaCloud.deploy`.
@@ -663,11 +664,7 @@ class VespaCloud(VespaDeployment):
         self.cluster = cluster
         if auth_client_token_id is not None:
             if self.application_package is not None:
-                # TODO: Should add some check to see if the auth_client_token_id is added to AuthClients.
-                print(
-                    "Auth client token id set. Make sure that corresponding auth_client is configured and added to ApplicationPackage.",
-                    file=self.output,
-                )
+                self._ensure_auth_clients_for_token(auth_client_token_id)
             else:
                 print(
                     "Auth client token id set, but no application package provided. Make sure that services.xml is configured to use the provided token_id.",
@@ -2131,6 +2128,146 @@ class VespaCloud(VespaDeployment):
         """
         return self.get_endpoint("token", instance, region, environment, cluster)
 
+    def create_dataplane_token(
+        self,
+        token_id: Optional[str] = None,
+        expiration: str = "P14D",
+    ) -> "DataplaneToken":
+        """Create a Vespa Cloud data-plane bearer token.
+
+        Calls the Vespa Cloud control-plane to create a new token version.
+        The returned secret value is shown only once; capture
+        ``result.token`` immediately if you need it later.
+
+        The token is tenant- and ``token_id``-scoped, not zone-scoped: the
+        same token works in any deployment whose ``services.xml`` accepts a
+        token with this ``token_id``. Pass ``token_id`` as
+        ``auth_client_token_id`` when constructing :class:`VespaCloud` so the
+        deployed app accepts it.
+
+        Example usage:
+            ```python
+            vespa_cloud = VespaCloud(
+                tenant="my-tenant",
+                application="my-app",
+                application_package=app_package,
+                auth_client_token_id="my-app",
+            )
+            vespa_cloud.deploy()
+            result = vespa_cloud.create_dataplane_token()
+            app = vespa_cloud.get_application(
+                endpoint_type="token",
+                vespa_cloud_secret_token=result.token,
+            )
+            ```
+
+        Args:
+            token_id (str, optional): Token name. Defaults to
+                ``self.auth_client_token_id`` if it was set on the
+                :class:`VespaCloud` constructor, otherwise to
+                ``self.application``. Multiple calls with the same
+                ``token_id`` create additional active versions, each
+                with its own fingerprint.
+            expiration (str, optional): How long the token is valid. Accepts
+                an ISO-8601 period (e.g. ``"P14D"``, ``"P30D"``), the literal
+                ``"default"`` (Vespa Cloud's 30-day default), the literal
+                ``"none"`` (no expiry — discouraged), or an absolute ISO-8601
+                instant such as ``"2026-12-31T00:00:00Z"``. Defaults to
+                ``"P14D"``
+
+        Returns:
+            DataplaneToken: The newly created token. ``token`` is the secret
+                value — capture it immediately; Vespa Cloud cannot show it
+                again.
+
+        Raises:
+            urllib3.exceptions.HTTPError: If Vespa Cloud rejects the
+                request (e.g. insufficient permissions, malformed expiration,
+                missing tenant).
+        """
+        token_id = token_id or self.auth_client_token_id or self.application
+        query = urlencode({"expiration": expiration})
+        response = self._request(
+            "POST",
+            f"/application/v4/tenant/{self.tenant}"
+            f"/token/{quote(token_id, safe='')}?{query}",
+        )
+        return DataplaneToken(
+            id=response["id"],
+            token=response["token"],
+            fingerprint=response["fingerprint"],
+            expiration=response["expiration"],
+        )
+
+    def _ensure_auth_clients_for_token(self, token_id: str) -> None:
+        """Ensure ``self.application_package`` exposes a token data-plane endpoint.
+
+        When ``auth_client_token_id`` is set on :class:`VespaCloud` together with
+        an ``application_package``, the deployed ``services.xml`` must declare a
+        matching ``<auth-clients>`` block — otherwise the deployed application
+        has only an mTLS endpoint and bearer-token requests are rejected. This
+        private helper auto-injects the missing entries on the package.
+
+        Behavior:
+        - Adds an mTLS auth-client (id ``"mtls"``) if none is configured.
+        - Adds a token auth-client (id ``"token"``) with a ``<token id="...">``
+          parameter matching ``token_id`` if no equivalent already exists.
+        - Existing entries are preserved; nothing is replaced.
+        - If the package uses ``clusters`` (advanced topology), auth-clients
+          live on each :class:`ContainerCluster` and pyvespa does not modify
+          them — a notice is printed instead.
+        """
+        package = self.application_package
+        if package.clusters:
+            print(
+                "Auth client token id set, and application_package uses clusters. "
+                "Make sure each ContainerCluster has matching AuthClients; "
+                "pyvespa does not auto-configure auth-clients in this case.",
+                file=self.output,
+            )
+            return
+
+        existing = list(package.auth_clients or [])
+        existing_ids = {ac.id for ac in existing}
+        existing_token_ids = {
+            (p.args or {}).get("id")
+            for ac in existing
+            if ac.id == "token"
+            for p in (ac.parameters or [])
+            if p.name == "token"
+        }
+
+        added = []
+        if "mtls" not in existing_ids:
+            added.append(
+                AuthClient(
+                    id="mtls",
+                    permissions=["read", "write"],
+                    parameters=[
+                        Parameter("certificate", {"file": "security/clients.pem"})
+                    ],
+                )
+            )
+        if token_id not in existing_token_ids:
+            added.append(
+                AuthClient(
+                    id="token",
+                    permissions=["read", "write"],
+                    parameters=[Parameter("token", {"id": token_id})],
+                )
+            )
+
+        if added:
+            package.auth_clients = existing + added
+            added_ids = ", ".join(
+                f"id={ac.id!r}" + (f" (token={token_id!r})" if ac.id == "token" else "")
+                for ac in added
+            )
+            print(
+                f"Auto-configured AuthClient on the application package: {added_ids}.",
+                file=self.output,
+            )
+
     def _application_root_has_tests(self, application_root: str) -> bool:
         """Check if the application contains tests folder (recursively)"""
         for root, dirs, files in os.walk(application_root):
@@ -2458,3 +2595,34 @@ class VespaCloud(VespaDeployment):
                 "{:<7} [{}]  {}".format(entry["type"].upper(), timestamp, message),
                 file=self.output,
             )
+
+@dataclass
+class DataplaneToken:
+    """A Vespa Cloud data-plane bearer token returned by
+    :meth:`VespaCloud.create_dataplane_token`.
+
+    The ``token`` field holds the secret value — treat it like a password.
+    Vespa Cloud cannot show it again after creation. The token is bound to a
+    tenant and a token name (``id``); it works in any zone where the deployed
+    application's ``services.xml`` has an ``<auth-clients>`` entry matching
+    ``id``.
+
+    Attributes:
+        id: The token name (the ``tokenid`` in the Vespa Cloud Console). Pass
+            this same value as ``auth_client_token_id`` when constructing
+            :class:`VespaCloud` so the deployed app accepts the token.
+        token: The secret token value. Use as the
+            ``vespa_cloud_secret_token`` argument to
+            :meth:`VespaCloud.get_application` or as a bearer header against
+            the data-plane endpoint. Store securely; this value is shown only
+            once at creation time.
+        fingerprint: SHA-256 fingerprint identifying this specific token
+            version; required if you later revoke it.
+        expiration: ISO-8601 timestamp at which the token expires.
+    """
+
+    id: str
+    token: str
+    fingerprint: str
+    expiration: str
+


### PR DESCRIPTION
🤖 **AI declaration:** _[Claude Code](https://claude.com/claude-code) wrote this PR title and description. The code is partly written with Claude; I have reviewed all code and commits myself._

- New `VespaCloud.create_dataplane_token()` returning a `DataplaneToken` (id, secret, fingerprint, expiration); when `auth_client_token_id` is set together with an `application_package`, pyvespa now auto-injects the matching mTLS + token `<auth-clients>` entries into `services.xml` (existing entries preserved).
- Refreshes the Vespa Cloud getting-started notebook: streamlined intro, login/auth copy, and adds a token-based querying example using the new method.