### PR TITLE
chore(deps): bump mistune and nokogiri to patch high-severity CVEs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    nokogiri (1.19.1)
+    nokogiri (1.19.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     pathutil (0.16.2)

--- a/uv.lock
+++ b/uv.lock
@@ -2599,14 +2599,14 @@ wheels = [
 
 [[package]]
 name = "mistune"
-version = "3.2.0"
+version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/55/d01f0c4b45ade6536c51170b9043db8b2ec6ddf4a35c7ea3f5f559ac935b/mistune-3.2.0.tar.gz", hash = "sha256:708487c8a8cdd99c9d90eb3ed4c3ed961246ff78ac82f03418f5183ab70e398a", size = 95467, upload-time = "2025-12-23T11:36:34.994Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/84/620cc3f7e3adf6f5067e10f4dbae71295d8f9e16d5d3f9ef97c40f2f592c/mistune-3.2.1.tar.gz", hash = "sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28", size = 98003, upload-time = "2026-05-03T14:33:22.312Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/f7/4a5e785ec9fbd65146a27b6b70b6cdc161a66f2024e4b04ac06a67f5578b/mistune-3.2.0-py3-none-any.whl", hash = "sha256:febdc629a3c78616b94393c6580551e0e34cc289987ec6c35ed3f4be42d0eee1", size = 53598, upload-time = "2025-12-23T11:36:33.211Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7f/a946aa4f8752b37102b41e64dca18a1976ac705c3a0d1dfe74d820a02552/mistune-3.2.1-py3-none-any.whl", hash = "sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048", size = 53749, upload-time = "2026-05-03T14:33:20.551Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Clears the **2 remaining high-severity** Dependabot alerts on `master`. Both are docs-tooling deps not exposed to pyvespa users.

| Package | Lockfile | From | To | Severity | Advisory |
|---|---|---|---|---|---|
| mistune | uv.lock | 3.2.0 | 3.2.1 | high | GHSA-8mp2-v27r-99xp (ReDoS in LINK_TITLE_RE) |
| nokogiri | Gemfile.lock | 1.19.1 | 1.19.3 | high | GHSA-c4rq-3m3g-8wgx (ReDoS in CSS tokenizer) |
| nokogiri | Gemfile.lock | (same bump) | | medium | GHSA-v2fc-qm4h-8hqv (XSLT memory leak) |

`mistune` is pulled in transitively by `nbconvert` (notebook/docs rendering). `nokogiri` is used by the Jekyll docs site. Neither affects what `pip install pyvespa` resolves, so this PR does not narrow version floors for library consumers.

Used `--conservative` on the bundler update to keep the Gemfile.lock diff minimal — only the nokogiri line changed.

## Deferred

The 3 remaining medium-severity `requests` alerts (`<2.32.0`, `<2.32.4`, `<2.33.0`) are still deferred — `requests` is a runtime dep and the `feed` extras pin would need to be widened. Better folded into the planned `requests` → `httpr` migration.

## Test plan

- [ ] CI green (lint, unit tests, doctests)
- [ ] `uv sync --extra notebooks --extra docs` resolves cleanly
- [ ] `bundle install` works for the docs site
- [ ] Dependabot alerts page shows 0 high-severity items after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)