### PR TITLE
test(mteb): loosen NDCG tolerance for HNSW ANN variance

### DIFF
--- a/tests/integration/test_integration_vespa_cloud_mteb.py
+++ b/tests/integration/test_integration_vespa_cloud_mteb.py
@@ -42,6 +42,11 @@ class TestVespaMTEBEvaluatorCloud(unittest.TestCase):
         self.assertIn("results", results)
         self.assertIn("NanoMSMARCORetrieval", results["results"])
         self.assertIsNotNone(results["metadata"]["benchmark_finished_at"])
+        # Tolerance: HNSW is approximate and the app is redeployed per run
+        # (auto_cleanup=True), so the graph is rebuilt from scratch each time
+        # over a concurrent feed. Insertion-order variance shifts a few queries
+        # near the top-k cliff, drifting NDCG@10 by up to ~0.03 between runs.
+        ndcg_tol = 0.05
         # Finished evaluation for 'NanoMSMARCORetrieval' with 'semantic':
         # NDCG@10: 0.62092
         self.assertAlmostEqual(
@@ -49,7 +54,7 @@ class TestVespaMTEBEvaluatorCloud(unittest.TestCase):
                 0
             ]["ndcg_at_10"],
             0.62092,
-            places=5,
+            delta=ndcg_tol,
         )
         # Finished evaluation for 'NanoMSMARCORetrieval' with 'bm25':
         # NDCG@10: 0.52063
@@ -58,7 +63,7 @@ class TestVespaMTEBEvaluatorCloud(unittest.TestCase):
                 "ndcg_at_10"
             ],
             0.52063,
-            places=5,
+            delta=ndcg_tol,
         )
         # Finished evaluation for 'NanoMSMARCORetrieval' with 'fusion':
         # NDCG@10: 0.60338
@@ -67,7 +72,7 @@ class TestVespaMTEBEvaluatorCloud(unittest.TestCase):
                 "ndcg_at_10"
             ],
             0.60338,
-            places=5,
+            delta=ndcg_tol,
         )
         # Finished evaluation for 'NanoMSMARCORetrieval' with 'atan_norm':
         # NDCG@10: 0.62851
@@ -76,7 +81,7 @@ class TestVespaMTEBEvaluatorCloud(unittest.TestCase):
                 0
             ]["ndcg_at_10"],
             0.62851,
-            places=5,
+            delta=ndcg_tol,
         )
         # Finished evaluation for 'NanoMSMARCORetrieval' with 'norm_linear':
         # NDCG@10: 0.64687
@@ -85,5 +90,5 @@ class TestVespaMTEBEvaluatorCloud(unittest.TestCase):
                 "train"
             ][0]["ndcg_at_10"],
             0.64687,
-            places=5,
+            delta=ndcg_tol,
         )


### PR DESCRIPTION
## Summary
- The cloud MTEB integration test flaked on master after PR #1290 ([failing run](https://github.com/vespa-engine/pyvespa/actions/runs/25788555086/job/75747899576)): semantic NDCG@10 came back as `0.59092` vs the asserted `0.62092` (`places=5`). A re-run on the same commit passed cleanly. Have also seen similar changes for this in earlier runs. 
- Root cause is most likely HNSW non-determinism, not the upstream mteb change:
  - The test redeploys the app on every run (`auto_cleanup=True`), so the HNSW graph is rebuilt from scratch.
  - `feed_iterable` feeds documents concurrently, so insertion order — and the resulting graph topology — varies between runs.
  - A handful of queries near the top-k recall cliff swap in/out of the top-10, drifting NDCG@10 by up to ~0.03.
  - Verified by re-running the same job on the same SHA and getting different scores ([0.59092 → 0.62092](https://github.com/vespa-engine/pyvespa/actions/runs/25792500867/job/75761400894)); numpy/torch/mteb versions were identical across both runs, ruling those out.
- Switch the five `assertAlmostEqual` checks from `places=5` to `delta=0.05` and add a short comment explaining the source of the variance. The expected reference values are unchanged.

## Test plan
- [x] `uv run ruff check` / `ruff format --check` pass
- [ ] CI `integration-cloud-mteb` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)