### PR TITLE
ci(linkcheck): ignore realpython.com links (HTTP 403)

### DIFF
--- a/.github/scripts/ignore_urls.txt
+++ b/.github/scripts/ignore_urls.txt
@@ -13,3 +13,4 @@ https://playground.twelvelabs.io/dashboard/api-key
 https://api.github.com/repos/*
 https://claude.ai/code
 https://openai.com/codex/
+https://realpython\.com/.*


### PR DESCRIPTION
## Problem

The mkdocs linkcheck workflow (`.github/workflows/mktestdocs.yml`) fails because `https://realpython.com/` links return **HTTP 403** to the doc linkchecker's user agent.

## Change

Add a regex pattern `https://realpython\.com/.*` to `.github/scripts/ignore_urls.txt`. The linkchecker matches each entry as a regex (`re.search`) against the URL, so all RealPython links are skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)