### PR TITLE
test(models): handle HF HTTP 429 rate-limiting in URL validation

### DIFF
--- a/.github/workflows/pyvespa-unit-tests.yml
+++ b/.github/workflows/pyvespa-unit-tests.yml
@@ -33,5 +33,7 @@ jobs:
           pip install -e .[unittest]
 
       - name: Run tests
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           pytest tests/unit -s -v

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,4 +1,5 @@
 import warnings
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -2095,3 +2096,31 @@ class TestHFModelsURLValidation:
                     f"(HTTP 429): {e}"
                 )
             raise
+
+    def test_validation_sends_hf_token_for_huggingface_urls(self, monkeypatch):
+        """An HF_TOKEN in the environment is sent as a Bearer auth header for
+        huggingface.co URLs (authenticated requests avoid HTTP 429 rate limits),
+        but is not leaked to other hosts."""
+        monkeypatch.setenv("HF_TOKEN", "hf_testtoken123")
+        config = ModelConfig(model_id="x", embedding_dim=8)
+
+        captured = {}
+
+        def fake_head(url, **kwargs):
+            captured["headers"] = kwargs.get("headers")
+            response = MagicMock()
+            response.status_code = 200
+            return response
+
+        with patch("vespa.models.requests.head", side_effect=fake_head):
+            config._validate_single_url(
+                "model_url",
+                "https://huggingface.co/foo/resolve/main/model.onnx",
+            )
+        assert captured["headers"].get("Authorization") == "Bearer hf_testtoken123"
+
+        with patch("vespa.models.requests.head", side_effect=fake_head):
+            config._validate_single_url(
+                "model_url", "https://data.vespa-cloud.com/model.onnx"
+            )
+        assert "Authorization" not in captured["headers"]

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -2077,10 +2077,21 @@ class TestHFModelsURLValidation:
         # Explicitly validate URLs by creating a new config with validation enabled
         # (HF_MODELS uses validate_urls=False by default for fast import)
         print(f"Validating URLs for model: {model_name}")
-        ModelConfig(
-            model_id=config.model_id,
-            embedding_dim=config.embedding_dim,
-            model_url=config.model_url,
-            tokenizer_url=config.tokenizer_url,
-            validate_urls=True,  # Explicitly enable validation
-        )
+        try:
+            ModelConfig(
+                model_id=config.model_id,
+                embedding_dim=config.embedding_dim,
+                model_url=config.model_url,
+                tokenizer_url=config.tokenizer_url,
+                validate_urls=True,  # Explicitly enable validation
+            )
+        except ValueError as e:
+            # A 429 means Hugging Face rate-limited us (the CI matrix runs many
+            # jobs in parallel), not that the URL is broken. Treat it as
+            # inconclusive and skip rather than fail the build.
+            if "HTTP 429" in str(e):
+                pytest.skip(
+                    f"Hugging Face rate-limited URL validation for {model_name} "
+                    f"(HTTP 429): {e}"
+                )
+            raise

--- a/vespa/models.py
+++ b/vespa/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import hashlib
 import json
+import os
 import re
 import warnings
 from difflib import get_close_matches
@@ -272,12 +273,21 @@ class ModelConfig:
     )
     def _validate_single_url(self, url_name: str, url: str) -> None:
         """Validate a single URL with retry logic."""
+        # Authenticate Hugging Face requests when a token is available.
+        # Authenticated requests get a much higher rate limit, which avoids
+        # spurious HTTP 429 (Too Many Requests) responses in CI.
+        headers = {}
+        token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+        if token and "huggingface.co" in url:
+            headers["Authorization"] = f"Bearer {token}"
         try:
-            response = requests.head(url, timeout=10, allow_redirects=True)
+            response = requests.head(
+                url, timeout=10, allow_redirects=True, headers=headers
+            )
             if response.status_code != 200:
                 # Some servers don't support HEAD, try GET with stream
                 response = requests.get(
-                    url, timeout=10, stream=True, allow_redirects=True
+                    url, timeout=10, stream=True, allow_redirects=True, headers=headers
                 )
                 response.close()
             if response.status_code != 200:


### PR DESCRIPTION
## Problem

`TestHFModelsURLValidation::test_hf_model_urls_are_valid` fails in CI with errors like:

```
ValueError: model_url returned HTTP 429: https://huggingface.co/nomic-ai/modernbert-embed-base/resolve/main/onnx/model.onnx
```

This is a **unit test** that makes live network requests to huggingface.co to validate model URLs. The unit-test workflow runs a **16-job matrix** (4 OS × 4 Python versions), so many jobs hit HF concurrently and unauthenticated — triggering **HTTP 429 (Too Many Requests)** rate limiting. The existing `@retry` already retries (tenacity retries on any exception), but the concurrent stampede outlasts the backoff. A 429 means *rate-limited*, not *broken URL*, so it shouldn't fail the build.

## Changes

- **Skip on 429** — the test now skips (rather than fails) when validation hits HTTP 429, while still failing on genuinely broken URLs (404, etc.).
- **Authenticate validation requests** — `ModelConfig._validate_single_url` now sends an `Authorization: Bearer <HF_TOKEN>` header for `huggingface.co` URLs when `HF_TOKEN` (or `HUGGING_FACE_HUB_TOKEN`) is set in the environment. Authenticated requests get a much higher rate limit, reducing 429s.
- **Wire `HF_TOKEN` into the unit-test workflow** so the auth path is effective in CI (consistent with the other workflows that already pass `HF_TOKEN`).

Fork PRs without the secret are still covered by the skip-on-429 safety net.

## Testing

```
uv run pytest tests/unit/test_models.py::TestHFModelsURLValidation -q
# 14 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)