### PR TITLE
fix(mteb): set maxHits in query profile to fix HTTP 500 on retrieval queries

### DIFF
--- a/vespa/evaluation/_mteb.py
+++ b/vespa/evaluation/_mteb.py
@@ -217,9 +217,12 @@ class VespaMTEBApp(SearchProtocol):
         return hashlib.md5(combined.encode()).hexdigest()
 
     def common_query_params(self, top_k: int) -> dict[str, Any]:
+        # NOTE: maxHits must not be passed as a runtime query parameter - Vespa
+        # rejects it ("maxHits must be specified in a query profile"). It is set
+        # in the application's default query profile (see create_hybrid_package),
+        # which raises the limit so that hits=top_k requests are accepted.
         return {
             "hits": top_k,
-            "maxHits": top_k,
             "timeout": "20s",
         }
 
@@ -403,7 +406,9 @@ class VespaMTEBApp(SearchProtocol):
         empty_results = 0
         for qi, (qid, response) in enumerate(zip(query_ids, responses)):
             if not response.is_successful():
-                logger.error(f"Query {qid} failed: {response.status_code}")
+                logger.error(
+                    f"Query {qid} failed: {response.status_code} - {response.json}"
+                )
                 # Add a dummy result with score 0.0 to prevent evaluation pipeline errors
                 results[qid] = {"__dummy__": 0.0}
                 empty_results += 1

--- a/vespa/models.py
+++ b/vespa/models.py
@@ -21,6 +21,8 @@ from vespa.package import (
     Schema,
     Document,
     FieldSet,
+    QueryProfile,
+    QueryField,
 )
 import vespa.querybuilder as qb
 
@@ -1399,10 +1401,18 @@ def create_hybrid_package(
         rank_profiles=[match_only_profile] + all_rank_profiles,
     )
 
+    # Raise the maxHits limit via the default query profile. Retrieval queries
+    # request `hits=top_k` (top_k can be up to ~1000), which exceeds Vespa's
+    # default maxHits of 400. maxHits is not overridable as a runtime query
+    # parameter ("maxHits must be specified in a query profile"), so it must be
+    # configured here.
+    query_profile = QueryProfile(fields=[QueryField(name="maxHits", value=10000)])
+
     # Create the application package
     return ApplicationPackageWithQueryFunctions(
         name=app_name,
         schema=[schema],
         components=all_components,
         query_functions=query_functions,
+        query_profile=query_profile,
     )


### PR DESCRIPTION
## Problem

`test_integration_vespa_cloud_mteb.py::...::test_evaluate_nanomsarco_retrieval_cloud` fails in CI: every profile reports `NDCG@10 = 0.0`, e.g.

```
AssertionError: 0.0 != 0.62092 within 0.05 delta
```

The deploy log made it look like a readiness race (search nodes "not started" right before "Deployment complete!"), but capturing the Vespa **error body** showed every query failing deterministically:

```
500 - {'root': {'errors': [{'code': 5,
  'message': 'Failed: maxHits must be specified in a query profile.', ...}]}}
```

## Root cause

MTEB retrieval queries request `hits=top_k` (top_k is ~1000) and `common_query_params` also passed `maxHits=top_k` as a **runtime** query parameter. Vespa's default `maxHits` limit is 400, and `maxHits` is **not** overridable per-request — it must be declared in a query profile. So all queries (including BM25, which uses no embeddings) returned HTTP 500, and `search()` substitutes `0.0` for failed queries → every profile collapsed to `NDCG@10 = 0.0`.

A warm-up/readiness probe was ruled out: a trivial match-all query succeeded on the **first** attempt, confirming the backend was ready.

## Why it started failing now

The `maxHits=400` limit and the guard that rejects it as a request parameter (`DefaultProperties.requireNotPresentIn`) have existed since Vespa's initial open-source release. What changed is **where** the guard runs: pyvespa's `query_many` sends queries as HTTP POST with a JSON body, and POST-body parameters were not previously validated against this guard.

Vespa [PR #37213 — "Fix validation of queries sent via HTTP POST"](https://github.com/vespa-engine/vespa/pull/37213) (commit [`ee47f38f`](https://github.com/vespa-engine/vespa/commit/ee47f38fade3fbbba07ca272ba8bf02487a77865), 2026-06-16) made POST queries validate their request map the same way GET queries already did. That surfaced the latent `maxHits` bug, which is why this broke now on platform `8.709.19`. The fix below is correct regardless of platform version.

## Fix

- `create_hybrid_package` now attaches a default query profile with `maxHits=10000`, so `hits=top_k` requests are accepted.
- Removed `maxHits` from `common_query_params` (cannot be set per-request).
- `search()` now logs the Vespa error body, not just the status code — this is what made the bug diagnosable and will help future failures.

## Verification

Ran the cloud integration test end-to-end — **passes**, with scores matching the expected values exactly:

| Profile | NDCG@10 |
|---|---|
| semantic | 0.62092 |
| bm25 | 0.52063 |
| fusion | 0.60338 |
| atan_norm | 0.62851 |
| norm_linear | 0.64687 |

Unit tests (`tests/unit/test_models.py`) also pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)