### PR TITLE
Thomasht86/support mteb single app

### DIFF
--- a/tests/integration/test_integration_mtebevaluation.py
+++ b/tests/integration/test_integration_mtebevaluation.py
@@ -126,5 +126,125 @@ class TestVespaMTEBEvaluatorIntegration(unittest.TestCase):
             evaluator.cleanup()
 
 
+class TestVespaMTEBEvaluatorSingleApp(unittest.TestCase):
+    """
+    Integration test for VespaMTEBEvaluator single-application mode (Docker).
+
+    Purpose:
+        Verify that several MTEB tasks can be evaluated against a single
+        deployed Vespa application (one schema per task) instead of
+        deploying/feeding/tearing down per task, and that the resulting
+        retrieval quality matches expectations.
+
+    Test Coverage:
+        - single_app=True with a list of tasks builds one multi-schema package
+        - One deployment serves all tasks; each task feeds/queries its own schema
+        - NDCG@10 per task and per query function matches expected values
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.results_dir = tempfile.mkdtemp(prefix="mteb_single_app_test_")
+        # URL-based model so the embedder runs locally on Docker (no model hub).
+        # Small e5-small-v2 (int8 ONNX) keeps the test fast.
+        cls.model_config = ModelConfig(
+            model_id="e5-small-v2",
+            embedding_dim=384,
+            embedding_field_type="float",
+            distance_metric="angular",
+            model_url="https://huggingface.co/Xenova/e5-small-v2/resolve/main/onnx/model_int8.onnx",
+            tokenizer_url="https://huggingface.co/Xenova/e5-small-v2/resolve/main/tokenizer.json",
+            max_tokens=512,
+            query_prepend="query: ",
+            document_prepend="passage: ",
+        )
+        # Two small Nano tasks evaluated against one application.
+        cls.tasks = ["NanoSciFactRetrieval", "NanoNFCorpusRetrieval"]
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "results_dir") and Path(cls.results_dir).exists():
+            shutil.rmtree(cls.results_dir)
+
+    def test_mteb_evaluator_single_app(self):
+        """
+        Evaluate two MTEB tasks against a single deployed application.
+
+        Verifies that one deployment serves both tasks (each in its own
+        schema) and that NDCG@10 matches expected values per query function.
+        """
+        evaluator = VespaMTEBEvaluator(
+            model_configs=self.model_config,
+            task_name=self.tasks,
+            results_dir=self.results_dir,
+            overwrite=True,
+            deployment_target="docker",
+            single_app=True,
+        )
+
+        # One package with one schema per task, served by a single application.
+        self.assertEqual(
+            sorted(s.name for s in evaluator.package.schemas),
+            sorted(evaluator._task_schema_map.values()),
+        )
+        self.assertEqual(len(evaluator.package.schemas), len(self.tasks))
+
+        # Expected NDCG@10 scores per task and query function. The container is
+        # recreated per run and HNSW is approximate, so a few queries near the
+        # top-k cliff can shift NDCG@10 slightly between runs; compare with a
+        # small tolerance rather than exact equality.
+        ndcg_tol = 0.03
+        expected_scores = {
+            "NanoSciFactRetrieval": {
+                "semantic": 0.71351,
+                "bm25": 0.74974,
+                "fusion": 0.73637,
+                "atan_norm": 0.79992,
+                "norm_linear": 0.79641,
+            },
+            "NanoNFCorpusRetrieval": {
+                "semantic": 0.3075,
+                "bm25": 0.32867,
+                "fusion": 0.32884,
+                "atan_norm": 0.35409,
+                "norm_linear": 0.36318,
+            },
+        }
+
+        try:
+            results = evaluator.evaluate()
+
+            # Verify overall structure
+            self.assertIn("metadata", results)
+            self.assertIn("results", results)
+            self.assertIsNotNone(results["metadata"]["benchmark_finished_at"])
+
+            # both task evaluated against single vespa application
+            for task_name, task_expected in expected_scores.items():
+                self.assertIn(task_name, results["results"])
+                task_data = results["results"][task_name]
+                for query_fn_name, expected_ndcg in task_expected.items():
+                    self.assertIn(
+                        query_fn_name,
+                        task_data,
+                        f"Missing query function '{query_fn_name}' for '{task_name}'",
+                    )
+                    fn_scores = task_data[query_fn_name]["scores"]
+                    self.assertIn("train", fn_scores)
+                    train_scores = fn_scores["train"][0]
+                    self.assertIn("ndcg_at_10", train_scores)
+                    self.assertAlmostEqual(
+                        train_scores["ndcg_at_10"],
+                        expected_ndcg,
+                        delta=ndcg_tol,
+                        msg=(
+                            f"NDCG@10 mismatch for '{task_name}'/'{query_fn_name}': "
+                            f"expected {expected_ndcg}, got {train_scores['ndcg_at_10']}"
+                        ),
+                    )
+        finally:
+            evaluator.cleanup()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/vespa/evaluation/_mteb.py
+++ b/vespa/evaluation/_mteb.py
@@ -29,7 +29,13 @@ except ImportError as e:
     ) from e
 
 from vespa.models import ApplicationPackageWithQueryFunctions
-from vespa.models import create_hybrid_package, ModelConfig, get_model_config
+from vespa.models import (
+    create_hybrid_package,
+    create_single_app_hybrid_package,
+    sanitize_component_id,
+    ModelConfig,
+    get_model_config,
+)
 from vespa.deployment import VespaDocker, VespaCloud
 from vespa.application import Vespa as VespaApp
 from vespa.io import VespaResponse
@@ -41,6 +47,25 @@ logging.basicConfig(
     handlers=[logging.StreamHandler()],
 )
 logger = logging.getLogger(__name__)
+
+# Vespa Cloud tenant/application/instance names allow lowercase letters, digits
+# and hyphens, up to 20 characters.
+_MAX_APPLICATION_NAME_LENGTH = 20
+
+
+def _derive_application_name(eval_name: str) -> str:
+    """Derive a valid Vespa Cloud application name from an evaluation name.
+
+    Lowercases and hyphenates the name. When combining several task names yields
+    a name longer than Vespa Cloud allows, it is truncated and a short
+    deterministic hash suffix is appended to keep it unique.
+    """
+    name = eval_name.lower().replace("_", "-")
+    if len(name) <= _MAX_APPLICATION_NAME_LENGTH:
+        return name
+    digest = hashlib.md5(eval_name.encode()).hexdigest()[:6]
+    keep = _MAX_APPLICATION_NAME_LENGTH - len(digest) - 1  # -1 for the hyphen
+    return f"{name[:keep].rstrip('-')}-{digest}"
 
 
 class VespaMTEBApp(SearchProtocol):
@@ -83,6 +108,12 @@ class VespaMTEBApp(SearchProtocol):
 
         self.port = port
         self._current_task_name: Optional[str] = None
+
+        # When True, all tasks are deployed with separate schemas to one Vespa
+        # application (may require a lot of memory for large tasks / embedding
+        # dimensions / many models).
+        self.single_app: bool = kwargs.pop("single_app", False)
+        self.task_schema_map: dict[str, str] = kwargs.pop("task_schema_map", None) or {}
 
         # Deployment target configuration
         self.deployment_target: Literal["docker", "cloud"] = kwargs.pop(
@@ -237,6 +268,9 @@ class VespaMTEBApp(SearchProtocol):
         )
 
     def get_query_functions(self) -> dict[str, Callable]:
+        if self.single_app:
+            schema_name = self.task_schema_map[self._current_task_name]
+            return self.package.get_query_functions_for_schema(schema_name)
         return self.package.get_query_functions()
 
     def get_timeout(self) -> float:
@@ -297,11 +331,22 @@ class VespaMTEBApp(SearchProtocol):
             f"Starting indexing for model(s) '{model_ids}' and task '{task_name}'"
         )
 
-        # Ensure clean state before deploying new container
-        self.ensure_clean_state()
+        if self.single_app:
+            schema_name = self.task_schema_map[task_name]
+            if self.app is None:
+                logger.info("Deploying single Vespa application for all tasks...")
+                self.app: Vespa = self._deploy()
+            else:
+                logger.info(
+                    f"Reusing deployed application; feeding schema '{schema_name}'."
+                )
+        else:
+            schema_name = "doc"
+            # Ensure clean state before deploying new container
+            self.ensure_clean_state()
 
-        logger.info("Deploying Vespa application...")
-        self.app: Vespa = self._deploy()
+            logger.info("Deploying Vespa application...")
+            self.app: Vespa = self._deploy()
 
         logger.info("Starting to index corpus...")
 
@@ -334,7 +379,9 @@ class VespaMTEBApp(SearchProtocol):
                 logger.error(f"Error feeding doc {doc_id}: {response.json}")
 
         vespa_feed = corpus_to_vespa_feed(corpus)
-        self.app.feed_iterable(vespa_feed, schema="doc", callback=feed_callback)
+        self.app.feed_async_iterable(
+            vespa_feed, schema=schema_name, callback=feed_callback
+        )
 
         logger.info(
             f"Successfully indexed {fed_count} documents to Vespa (errors: {error_count})"
@@ -460,12 +507,15 @@ class VespaMTEBEvaluator:
 
     Args:
         model_configs: One or more ModelConfig instances or model name strings.
-        task_name: Name of a single MTEB task to evaluate (mutually exclusive with benchmark_name).
+        task_name: Name of a single MTEB task, or a list of task names, to evaluate
+            (mutually exclusive with benchmark_name)
         benchmark_name: Name of an MTEB benchmark to evaluate (mutually exclusive with task_name).
         results_dir: Directory to save results. Defaults to "results".
         overwrite: If False, skip evaluations where results already exist. Defaults to False.
         deployment_target: Where to deploy Vespa. Either "docker" or "cloud". Defaults to "cloud".
         port: Vespa application port (Docker only). Defaults to 8080.
+        single_app: If True, deploy a single application with one schema per task and
+            evaluate all tasks against it. May require a lot of memory for large tasks / embedding dimensions / many models.
         tenant: Vespa Cloud tenant name. Required when deployment_target="cloud".
         application: Vespa Cloud application name. Defaults to benchmark/task name if not specified.
         instance: Vespa Cloud instance name. Defaults to "default".
@@ -490,17 +540,27 @@ class VespaMTEBEvaluator:
         ...     key_content=os.getenv("VESPA_API_KEY"),
         ... )
         >>> evaluator.evaluate()
+
+    Example (single application for several tasks):
+        >>> evaluator = VespaMTEBEvaluator(
+        ...     model_configs="e5-small-v2",
+        ...     task_name=["NanoSciFactRetrieval", "NanoNFCorpusRetrieval"],
+        ...     deployment_target="docker",
+        ...     single_app=True,
+        ... )
+        >>> evaluator.evaluate()
     """
 
     def __init__(
         self,
         model_configs: ModelConfig | str | List[ModelConfig | str],
-        task_name: str | None = None,
+        task_name: str | List[str] | None = None,
         benchmark_name: str | None = None,
         results_dir: str | Path = "results",
         overwrite: bool = False,
         deployment_target: Literal["docker", "cloud"] = "cloud",
         port: int = 8080,
+        single_app: bool = False,
         # Cloud-specific parameters
         tenant: str | None = None,
         application: str | None = None,
@@ -518,6 +578,8 @@ class VespaMTEBEvaluator:
             raise ValueError(
                 "Either 'task_name' or 'benchmark_name' must be specified."
             )
+        if isinstance(task_name, list) and not task_name:
+            raise ValueError("'task_name' must not be an empty list.")
 
         # Normalize model_configs to list of ModelConfig instances
         self.model_configs = self._normalize_model_configs(model_configs)
@@ -527,6 +589,7 @@ class VespaMTEBEvaluator:
         self.results_dir = Path(results_dir)
         self.overwrite = overwrite
         self.port = port
+        self.single_app = single_app
 
         # Deployment configuration
         self.deployment_target = deployment_target
@@ -538,9 +601,7 @@ class VespaMTEBEvaluator:
 
         # Derive application name from benchmark/task name if not specified
         if application is None:
-            eval_name = benchmark_name or task_name
-            # Sanitize the name for Vespa Cloud (lowercase, alphanumeric and hyphens)
-            self.application = eval_name.lower().replace("_", "-")
+            self.application = _derive_application_name(self._get_eval_name())
         else:
             self.application = application
 
@@ -550,14 +611,52 @@ class VespaMTEBEvaluator:
                 raise ValueError("'tenant' is required when deployment_target='cloud'")
 
         # Create the application package
-        self.package = create_hybrid_package(self.model_configs)
-        self.query_function_names = list(self.package.get_query_functions().keys())
+        if self.single_app:
+            # One schema per task, served by a single deployed application.
+            self._task_schema_map = self._build_task_schema_map()
+            self.package = create_single_app_hybrid_package(
+                self.model_configs,
+                schema_names=list(self._task_schema_map.values()),
+            )
+            # Query function names are the logical names shared by every schema.
+            self.query_function_names = list(
+                next(iter(self.package.schema_query_functions.values())).keys()
+            )
+        else:
+            self._task_schema_map = {}
+            self.package = create_hybrid_package(self.model_configs)
+            self.query_function_names = list(self.package.get_query_functions().keys())
 
         # Compute model suffix for file naming
         self.model_suffix = self._get_model_suffix()
 
         # Track the VespaMTEBApp instance for lifecycle management
         self._vespa_app: Optional[VespaMTEBApp] = None
+
+    def _resolve_task_names(self) -> List[str]:
+        """Resolve the canonical MTEB task names to evaluate.
+
+        Derived from :meth:`_get_tasks` so the task->schema map is keyed by the
+        same ``task_metadata.name`` that ``index()``/``search()`` look up at
+        runtime (a user-supplied name may differ from MTEB's canonical name).
+        """
+        return [task.metadata.name for task in self._get_tasks()]
+
+    def _build_task_schema_map(self) -> dict:
+        """Map each task name to a unique, valid Vespa schema name."""
+        task_schema_map: dict[str, str] = {}
+        used: set[str] = set()
+        for task_name in self._resolve_task_names():
+            schema_name = sanitize_component_id(task_name).lower()
+            # preemptively disambiguate if two task names sanitize to the same schema name.
+            if schema_name in used:
+                suffix = 2
+                while f"{schema_name}{suffix}" in used:
+                    suffix += 1
+                schema_name = f"{schema_name}{suffix}"
+            used.add(schema_name)
+            task_schema_map[task_name] = schema_name
+        return task_schema_map
 
     def _normalize_model_configs(
         self, model_input: ModelConfig | str | List[ModelConfig | str]
@@ -685,6 +784,8 @@ class VespaMTEBEvaluator:
                 "key_location": self.key_location,
                 "auto_cleanup": self.auto_cleanup,
                 "disk_folder": disk_folder,
+                "single_app": self.single_app,
+                "task_schema_map": self._task_schema_map,
             },
             name=f"vespa/{self.model_suffix}_hybrid_vespa",
             languages=["eng-Latn"],
@@ -716,13 +817,19 @@ class VespaMTEBEvaluator:
         if self.benchmark_name is not None:
             benchmark = mteb.get_benchmark(self.benchmark_name)
             return list(benchmark.tasks)
+        if isinstance(self.task_name, list):
+            return [mteb.get_task(name) for name in self.task_name]
         # task_name is guaranteed to be set by __init__ validation
         return [mteb.get_task(self.task_name)]  # type: ignore[arg-type]
 
     def _get_eval_name(self) -> str:
         """Get the evaluation name (benchmark or task name)."""
-        # One of these is guaranteed to be set by __init__ validation
-        return self.benchmark_name or self.task_name  # type: ignore[return-value]
+        if self.benchmark_name is not None:
+            return self.benchmark_name
+        if isinstance(self.task_name, list):
+            # Combine task names into a single evaluation name.
+            return "-".join(self.task_name)
+        return self.task_name
 
     def evaluate(self) -> dict:
         """

--- a/vespa/models.py
+++ b/vespa/models.py
@@ -1132,7 +1132,7 @@ def _create_query_functions(
 
     def bm25_query_fn(query_text: str, top_k: int) -> dict:
         return {
-            "yql": "select * from sources * where userQuery();",  # provide the yql directly as a string
+            "yql": str(qb.select("*").from_(schema_name).where(qb.userQuery())),
             "query": query_text,
             "ranking": f"bm25{profile_suffix}",
             "hits": top_k,
@@ -1219,10 +1219,15 @@ class ApplicationPackageWithQueryFunctions(ApplicationPackage):
     def __init__(
         self,
         query_functions: Optional[Dict[str, Callable[[str, int], dict]]] = None,
+        schema_query_functions: Optional[
+            Dict[str, Dict[str, Callable[[str, int], dict]]]
+        ] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.query_functions = query_functions or {}
+        # Only used for single vespa application, multi-schema packages
+        self.schema_query_functions = schema_query_functions or {}
 
     def get_query_functions(self) -> Dict[str, Callable[[str, int], dict]]:
         """
@@ -1232,6 +1237,173 @@ class ApplicationPackageWithQueryFunctions(ApplicationPackage):
             Dict of query functions
         """
         return self.query_functions
+
+    def get_query_functions_for_schema(
+        self, schema_name: str
+    ) -> Dict[str, Callable[[str, int], dict]]:
+        """
+        Get the query functions scoped to a single schema.
+
+        Only meaningful for packages created with
+        :func:`create_single_app_hybrid_package`, where each schema has its
+        own set of query functions targeting that schema.
+
+        Args:
+            schema_name: Name of the schema to retrieve query functions for.
+
+        Returns:
+            Dict of query functions for the given schema.
+
+        Raises:
+            KeyError: If the schema is unknown.
+        """
+        if schema_name not in self.schema_query_functions:
+            raise KeyError(
+                f"No query functions for schema '{schema_name}'. "
+                f"Available schemas: {list(self.schema_query_functions.keys())}"
+            )
+        return self.schema_query_functions[schema_name]
+
+
+def _resolve_model_configs(
+    models: Union[str, ModelConfig, List[Union[str, ModelConfig]], List[ModelConfig]],
+) -> List[ModelConfig]:
+    """Normalize the ``models`` argument to a non-empty list of ModelConfig."""
+    if isinstance(models, (str, ModelConfig)):
+        model_configs = [models]
+    else:
+        model_configs = list(models)
+
+    if not model_configs:
+        raise ValueError("At least one model must be provided")
+
+    resolved_configs = []
+    for model in model_configs:
+        if isinstance(model, str):
+            resolved_configs.append(get_model_config(model))
+        else:
+            resolved_configs.append(model)
+    return resolved_configs
+
+
+def _build_schema_artifacts(
+    resolved_configs: List[ModelConfig],
+    schema_name: str,
+    global_rerank_count: int = 1000,
+) -> tuple[Schema, List[Component], Dict[str, Callable[[str, int], dict]]]:
+    """
+    Build the schema, embedder components, and query functions for one schema.
+
+    Used by both :func:`create_hybrid_package` (single schema) and
+    :func:`create_single_app_hybrid_package` (one schema per task). Components
+    are de-duplicated within this schema by component_id; callers building
+    multiple schemas should de-duplicate components across schemas.
+
+    Args:
+        resolved_configs: List of ModelConfig instances (already resolved).
+        schema_name: Name of the schema to build.
+        global_rerank_count: Number of hits to rerank in global phase.
+
+    Returns:
+        A tuple of (schema, components, query_functions) for this schema.
+    """
+    # Determine if we have multiple models (affects naming)
+    is_multi_model = len(resolved_configs) > 1
+
+    # Check for component_id collisions (same model_id but different dim/type)
+    # If collisions exist, we need to use full unique identifiers for all configs
+    component_ids = [c.component_id for c in resolved_configs]
+    has_component_id_collisions = len(component_ids) != len(set(component_ids))
+
+    components = []
+    seen_component_ids = set()  # Track which component_ids we've already added
+    all_embedding_fields = []
+    all_rank_profiles = []
+    match_only_inputs = []
+    query_functions = {}
+
+    for config in resolved_configs:
+        # Create unique identifiers for multi-model setup
+        # Use full unique identifier (with dim/type) if there are component_id collisions
+        if has_component_id_collisions:
+            unique_id = _get_model_string(config)
+        else:
+            unique_id = config.component_id
+
+        profile_suffix = f"_{unique_id}" if is_multi_model else ""
+        embedding_field_name = (
+            f"embedding_{unique_id}" if is_multi_model else "embedding"
+        )
+        query_tensor = f"q{profile_suffix}"
+
+        # Create and collect component - only if we haven't seen this component_id yet
+        # Multiple ModelConfigs with the same model_id share the same embedder
+        if config.component_id not in seen_component_ids:
+            components.append(create_embedder_component(config))
+            seen_component_ids.add(config.component_id)
+
+        # Create and collect embedding field
+        embedding_field = create_embedding_field(
+            config, field_name=embedding_field_name, embedder_id=config.component_id
+        )
+        all_embedding_fields.append(embedding_field)
+
+        # Track query inputs for match-only profile
+        match_only_inputs.append((f"query({query_tensor})", embedding_field.type))
+
+        # Create and collect all rank profiles for this model
+        all_rank_profiles.extend(
+            _create_model_profiles(
+                config,
+                embedding_field_name,
+                profile_suffix,
+                query_tensor,
+                global_rerank_count,
+            )
+        )
+        # Create and collect query functions for this model
+        query_functions.update(
+            _create_query_functions(
+                config,
+                embedding_field_name,
+                schema_name,
+                query_tensor,
+                profile_suffix,
+            )
+        )
+
+    # Create match-only profile with inputs for all models
+    match_only_profile = RankProfile(
+        name="match-only",
+        inputs=match_only_inputs,
+        first_phase="random",
+    )
+
+    # Build the schema with all fields
+    schema = Schema(
+        name=schema_name,
+        document=Document(
+            fields=[
+                Field(
+                    name="id",
+                    type="string",
+                    indexing=["summary", "attribute"],
+                ),
+                Field(
+                    name="text",
+                    type="string",
+                    indexing=["index", "summary"],
+                    index="enable-bm25",
+                    bolding=True,
+                ),
+            ]
+            + all_embedding_fields
+        ),
+        fieldsets=[FieldSet(name="default", fields=["text"])],
+        rank_profiles=[match_only_profile] + all_rank_profiles,
+    )
+
+    return schema, components, query_functions
 
 
 def create_hybrid_package(
@@ -1299,116 +1471,10 @@ def create_hybrid_package(
         2
     """
     # Normalize input to a list of ModelConfig objects
-    if isinstance(models, (str, ModelConfig)):
-        model_configs = [models]
-    else:
-        model_configs = list(models)
+    resolved_configs = _resolve_model_configs(models)
 
-    if not model_configs:
-        raise ValueError("At least one model must be provided")
-
-    # Convert string model names to ModelConfig objects
-    resolved_configs = []
-    for model in model_configs:
-        if isinstance(model, str):
-            resolved_configs.append(get_model_config(model))
-        else:
-            resolved_configs.append(model)
-
-    # Determine if we have multiple models (affects naming)
-    is_multi_model = len(resolved_configs) > 1
-
-    # Check for component_id collisions (same model_id but different dim/type)
-    # If collisions exist, we need to use full unique identifiers for all configs
-    component_ids = [c.component_id for c in resolved_configs]
-    has_component_id_collisions = len(component_ids) != len(set(component_ids))
-
-    # Build components, fields, and profiles for each model
-    all_components = []
-    seen_component_ids = set()  # Track which component_ids we've already added
-    all_embedding_fields = []
-    all_rank_profiles = []
-    match_only_inputs = []
-    query_functions = {}
-
-    for config in resolved_configs:
-        # Create unique identifiers for multi-model setup
-        # Use full unique identifier (with dim/type) if there are component_id collisions
-        if has_component_id_collisions:
-            unique_id = _get_model_string(config)
-        else:
-            unique_id = config.component_id
-
-        profile_suffix = f"_{unique_id}" if is_multi_model else ""
-        embedding_field_name = (
-            f"embedding_{unique_id}" if is_multi_model else "embedding"
-        )
-        query_tensor = f"q{profile_suffix}"
-
-        # Create and collect component - only if we haven't seen this component_id yet
-        # Multiple ModelConfigs with the same model_id share the same embedder
-        if config.component_id not in seen_component_ids:
-            all_components.append(create_embedder_component(config))
-            seen_component_ids.add(config.component_id)
-
-        # Create and collect embedding field
-        embedding_field = create_embedding_field(
-            config, field_name=embedding_field_name, embedder_id=config.component_id
-        )
-        all_embedding_fields.append(embedding_field)
-
-        # Track query inputs for match-only profile
-        match_only_inputs.append((f"query({query_tensor})", embedding_field.type))
-
-        # Create and collect all rank profiles for this model
-        all_rank_profiles.extend(
-            _create_model_profiles(
-                config,
-                embedding_field_name,
-                profile_suffix,
-                query_tensor,
-                global_rerank_count,
-            )
-        )
-        # Create and collect query functions for this model
-        model_query_functions = _create_query_functions(
-            config,
-            embedding_field_name,
-            schema_name,
-            query_tensor,
-            profile_suffix,
-        )
-        query_functions.update(model_query_functions)
-
-    # Create match-only profile with inputs for all models
-    match_only_profile = RankProfile(
-        name="match-only",
-        inputs=match_only_inputs,
-        first_phase="random",
-    )
-
-    # Build the schema with all fields
-    schema = Schema(
-        name=schema_name,
-        document=Document(
-            fields=[
-                Field(
-                    name="id",
-                    type="string",
-                    indexing=["summary", "attribute"],
-                ),
-                Field(
-                    name="text",
-                    type="string",
-                    indexing=["index", "summary"],
-                    index="enable-bm25",
-                    bolding=True,
-                ),
-            ]
-            + all_embedding_fields
-        ),
-        fieldsets=[FieldSet(name="default", fields=["text"])],
-        rank_profiles=[match_only_profile] + all_rank_profiles,
+    schema, all_components, query_functions = _build_schema_artifacts(
+        resolved_configs, schema_name, global_rerank_count
     )
 
     # Raise the maxHits limit via the default query profile.
@@ -1420,5 +1486,86 @@ def create_hybrid_package(
         schema=[schema],
         components=all_components,
         query_functions=query_functions,
+        query_profile=query_profile,
+    )
+
+
+def create_single_app_hybrid_package(
+    models: Union[str, ModelConfig, List[Union[str, ModelConfig]], List[ModelConfig]],
+    schema_names: List[str],
+    app_name: str = "hybridapp",
+    global_rerank_count: int = 1000,
+) -> ApplicationPackageWithQueryFunctions:
+    """
+    Create a single Vespa application package with one schema per task.
+
+    Unlike :func:`create_hybrid_package`, which builds a single ``doc`` schema,
+    this builds one schema per entry in ``schema_names``, all served by the same
+    application. This lets several MTEB tasks be evaluated against one deployed
+    application (avoiding deploy/feed/teardown per task): each task feeds and
+    queries only its own schema.
+
+    Every schema is configured identically (same fields, rank profiles and query
+    functions as :func:`create_hybrid_package`), and the embedder components are
+    shared across all schemas. The returned package exposes per-schema query
+    functions via :meth:`ApplicationPackageWithQueryFunctions.get_query_functions_for_schema`.
+
+    Args:
+        models: Single model or list of models to configure. Each can be a string
+            model name (e.g. "e5-small-v2") or a ModelConfig instance.
+        schema_names: Names of the schemas to create (one per task). Must be valid,
+            unique Vespa identifiers.
+        app_name: Name of the application (default: "hybridapp").
+        global_rerank_count: Number of hits to rerank in global phase (default: 1000).
+
+    Returns:
+        ApplicationPackageWithQueryFunctions with one schema per name, shared
+        embedder components, and per-schema query functions in
+        ``schema_query_functions``.
+
+    Raises:
+        ValueError: If no schemas are provided or schema names are not unique.
+
+    Example:
+        >>> package = create_single_app_hybrid_package(
+        ...     "e5-small-v2", schema_names=["taska", "taskb"]
+        ... )
+        >>> sorted(s.name for s in package.schemas)
+        ['taska', 'taskb']
+        >>> sorted(package.get_query_functions_for_schema("taska").keys())
+        ['atan_norm', 'bm25', 'fusion', 'norm_linear', 'semantic']
+    """
+    if not schema_names:
+        raise ValueError("At least one schema name must be provided")
+    if len(schema_names) != len(set(schema_names)):
+        raise ValueError(f"Schema names must be unique, got: {schema_names}")
+
+    resolved_configs = _resolve_model_configs(models)
+
+    schemas = []
+    all_components: List[Component] = []
+    seen_component_ids: set = set()  # De-duplicate embedders across all schemas
+    schema_query_functions: Dict[str, Dict[str, Callable[[str, int], dict]]] = {}
+
+    for schema_name in schema_names:
+        schema, components, query_functions = _build_schema_artifacts(
+            resolved_configs, schema_name, global_rerank_count
+        )
+        schemas.append(schema)
+        schema_query_functions[schema_name] = query_functions
+        # Embedder components are application-wide; add each only once.
+        for component in components:
+            if component.id not in seen_component_ids:
+                all_components.append(component)
+                seen_component_ids.add(component.id)
+
+    # Raise the maxHits limit via the default query profile.
+    query_profile = QueryProfile(fields=[QueryField(name="maxHits", value=10000)])
+
+    return ApplicationPackageWithQueryFunctions(
+        name=app_name,
+        schema=schemas,
+        components=all_components,
+        schema_query_functions=schema_query_functions,
         query_profile=query_profile,
     )


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Context: for some text ranking evals, we want to deploy many MTEB-tasks to a single vespa application to make it run faster (each task gets a separate schema). Next step is to also extend the interface to easily add more fusion methods (rank profile), in particular normalized bm25.
Note that this mode may require a lot more memory eg. if we configure many embedding fields and/or models. 

Manually tested by me.  