### PR TITLE
Thomasht86/auto-dependency-updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Python version bumps are handled by update-deps.yml (weekly uv re-lock), so no
+# pip ecosystem here. Security alerts stay on via repo settings, independent of
+# this file. Actions are kept current here, grouped into one PR.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/integration-cloud.yml
+++ b/.github/workflows/integration-cloud.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - master
   pull_request:
-    paths: [".github/workflows/integration-cloud.yml"]
+    paths: [".github/workflows/integration-cloud.yml", "uv.lock"]
   schedule:
     - cron: "0 11 * * 0"
 

--- a/.github/workflows/notebooks-cloud.yml
+++ b/.github/workflows/notebooks-cloud.yml
@@ -3,7 +3,8 @@ name: Notebooks - cloud
 on:
   workflow_dispatch:
   pull_request:
-    paths: ["docs/sphinx/source/**/*cloud.ipynb", "vespa/deployment.py"]
+    paths:
+      ["docs/sphinx/source/**/*cloud.ipynb", "vespa/deployment.py", "uv.lock"]
   push:
     branches:
       - master

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -1,0 +1,84 @@
+name: Update dependencies
+
+# Weekly: re-resolve uv.lock to latest allowed versions, gate on unit tests,
+# open one PR. The uv.lock change triggers the full CI matrix (the cloud
+# workflows include uv.lock in their path filters). Replaces per-dependency
+# Dependabot PRs. See TEST_STRATEGY.md.
+
+on:
+  schedule:
+    - cron: "0 5 * * 1" # Mondays 05:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  upgrade:
+    runs-on: ubuntu-latest
+    steps:
+      # App token, not GITHUB_TOKEN: PRs made with GITHUB_TOKEN don't trigger
+      # other workflows, which would skip CI on the dependency PR.
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.DEPS_BOT_APP_ID }}
+          private-key: ${{ secrets.DEPS_BOT_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: master # always bump master's deps, even on dispatch from a branch
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6
+
+      - name: Upgrade lockfile to latest allowed versions
+        run: uv lock --upgrade
+
+      - name: Stop if nothing changed
+        id: diff
+        run: |
+          if git diff --quiet -- uv.lock; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No dependency updates available."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run unit tests (fast gate)
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: uv run --extra dev pytest tests/unit -s -v
+
+      - name: Create or update pull request
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          BRANCH="deps/weekly-uv-upgrade"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add uv.lock
+          git commit -m "chore(deps): weekly uv lock --upgrade"
+          # Bot-only branch, so a plain force push is fine (no lease ref is
+          # fetched on the shallow checkout).
+          git push --force origin "$BRANCH"
+
+          BODY=$'Automated `uv lock --upgrade`: bumps dependencies to the latest versions allowed by `pyproject.toml`. Unit tests passed in the upgrade job; the full CI matrix (including cloud suites, via their `uv.lock` path filter) runs on this PR. Merge once green. See `TEST_STRATEGY.md`.'
+
+          # `gh pr list --state open` so a previously merged PR on this branch
+          # doesn't suppress opening the new one.
+          if [ -n "$(gh pr list --head "$BRANCH" --base master --state open --json number -q '.[0].number')" ]; then
+            echo "Open PR already exists; branch updated."
+          else
+            gh pr create \
+              --base master \
+              --head "$BRANCH" \
+              --title "chore(deps): weekly dependency upgrade" \
+              --body "$BODY"
+          fi

--- a/TEST_STRATEGY.md
+++ b/TEST_STRATEGY.md
@@ -1,0 +1,78 @@
+# Testing & Dependency Strategy
+
+How and why we test pyvespa and keep dependencies current. Update when the
+strategy changes, not just the code.
+
+## Guiding principle
+
+> If the full test suite passes against the latest allowed dependency versions,
+> the risk of taking those updates is low enough to merge.
+
+We don't review dependency diffs by hand; the test suite is the gate. It is only
+as good as our coverage, so invest in coverage.
+
+## What we test
+
+| Suite | Location | CI workflow | Python | Needs |
+|-------|----------|-------------|--------|-------|
+| Unit | `tests/unit/` | `pyvespa-unit-tests.yml` | 3.10-3.13 x {ubuntu, windows, macos} | none (mocked) |
+| Integration (local) | `tests/integration/` (docker, grouping, queries, evaluation) | `integration-except-cloud.yml` | 3.10 | Docker + Vespa |
+| Integration (cloud) | `tests/integration/` (vespa_cloud*, mteb) | `integration-cloud.yml` | 3.10 | Vespa Cloud secrets |
+| Doctests | `tests/mktestdocs/` | `mktestdocs.yml` | 3.10 | none |
+| Notebooks (local) | `docs/` notebooks | `notebooks-except-cloud.yml` | 3.11 | none |
+| Notebooks (cloud) | `docs/` notebooks | `notebooks-cloud.yml` | 3.11 | Vespa Cloud + model API keys |
+
+Unit, local integration, doctests, and local notebooks run on every
+`pull_request` to `master`. The two **cloud** suites are path-filtered: they
+trigger only on PRs touching their own workflow, a few specific files, or
+`uv.lock` (added so dependency PRs run them); otherwise they run on a weekly cron.
+A dependency PR changes `uv.lock`, so it runs the full matrix. "Full test suite"
+means all of the above green on a PR.
+
+## Lockfile and install styles
+
+pyvespa is a published library: consumers resolve from our `pyproject.toml`
+ranges and never see `uv.lock`. The lockfile governs only our dev/CI.
+
+CI uses two install styles on purpose:
+
+- **`pip install -e .[extra]`** (unit matrix, integration-except-cloud): latest
+  versions allowed by `pyproject.toml`. Our real-world canary for what users get.
+- **`uv sync`** (mktestdocs, notebooks-cloud, integration-cloud, copilot-setup):
+  locked versions from `uv.lock`, for reproducibility.
+
+We keep `uv.lock` committed: it gives reproducible dev/CI and is the single
+artifact we bump (one re-lock updates every transitive dep in one PR). The
+trade-off is that pinned CI can hide breakage users on floating ranges hit, which
+is why the unit matrix stays floating on `pip install`.
+
+## Keeping dependencies up to date
+
+Goal: few, batched, test-gated updates, not a stream of per-dependency PRs.
+
+- **Python** (`update-deps.yml`): weekly `uv lock --upgrade`, unit-test gate, one
+  PR on `deps/weekly-uv-upgrade`. The `uv.lock` change triggers the full matrix
+  (cloud suites included, via their `uv.lock` path filter); merge once green. Uses
+  a short-lived GitHub App token (`DEPS_BOT_APP_ID` / `DEPS_BOT_APP_PRIVATE_KEY`),
+  since PRs made with `GITHUB_TOKEN` don't trigger CI.
+- **GitHub Actions** (`dependabot.yml`): SHA-pinned in workflows; Dependabot keeps
+  them current, grouped into one weekly PR.
+- **Security**: enable Dependabot security *updates* (not just alerts) in repo
+  settings. These open targeted CVE PRs independent of `dependabot.yml`, so a
+  vulnerable Python dep is still bumped immediately even though we don't run a
+  `pip` ecosystem for routine version updates (that noise is what the weekly
+  re-lock replaces).
+
+## Pinning policy in `pyproject.toml`
+
+- Prefer floating lower bounds (`>=`) so the floating CI stays meaningful.
+- Exact pins (`==`) only where reproducibility matters (build toolchain:
+  `setuptools`, `build`, `twine`) or to dodge a known-bad release.
+- `requests` / `httpx` are transitional (see CLAUDE.md, `httpr` migration); remove
+  when done.
+
+## Open items
+
+- Consider moving remaining `pip install` workflows to `uv`, keeping the unit
+  matrix floating.
+- Consider auto-merge on the weekly deps PR once we trust the gate.


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

**Why**

The uv.lock file isn't used by our users (they resolve from the loose bounds in pyproject.toml), but it's worth committing for reproducible, faster CI.

Dependabot opens lockfile-based version PRs several times a week. Each needs manual approval and usually a full CI run to confirm nothing breaks. That's a recurring hassle and a lot of redundant, slow, costly CI runs.

**What**

Replace the stream of Dependabot version PRs with a single scheduled job:

- update-deps.yml — weekly (Mondays) uv lock --upgrade to the latest versions allowed by pyproject.toml, gated on unit tests, opening one PR on deps/weekly-uv-upgrade. The uv.lock change triggers the full CI matrix; merge once green. No manual oversight unless something fails.
- integration-cloud.yml / notebooks-cloud.yml — added uv.lock to their pull_request path filters so the cloud suites also run on the deps PR.
- dependabot.yml — drops the pip ecosystem (now redundant); keeps GitHub Actions updates, grouped into one weekly PR. CVE coverage stays via Dependabot security updates in repo settings.
- TEST_STRATEGY.md — documents the testing + dependency strategy and the lockfile rationale.

Have added necessary secret and variable to repo.

FYI @odosk 