### PR TITLE
Feed to vespacloud-docsearch.cloud-enclave in prod.aws-us-east-1

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -83,6 +83,10 @@ search:
     - url: https://b4f1a714.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - pyvespa_index.json
+    # vespacloud-docsearch.cloud-enclave | prod.aws-us-east-1
+    - url: https://ab1642f7.b68a8c0d.z.vespa-app.cloud/
+      indexes:
+        - pyvespa_index.json
 
 defaults:
   - scope:

--- a/_paragraphs_config.yml
+++ b/_paragraphs_config.yml
@@ -38,3 +38,7 @@ search:
     - url: https://b4f1a714.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - paragraph_index.json
+    # vespacloud-docsearch.cloud-enclave | prod.aws-us-east-1
+    - url: https://ab1642f7.b68a8c0d.z.vespa-app.cloud/
+      indexes:
+        - paragraph_index.json

--- a/_suggestions_config.yml
+++ b/_suggestions_config.yml
@@ -39,3 +39,7 @@ search:
     - url: https://b4f1a714.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - suggestions_index.json
+    # vespacloud-docsearch.cloud-enclave | prod.aws-us-east-1
+    - url: https://ab1642f7.b68a8c0d.z.vespa-app.cloud/
+      indexes:
+        - suggestions_index.json


### PR DESCRIPTION
Extend feed endpoints so docsearch data is also fed to `vespacloud-docsearch.cloud-enclave` in zone `prod.aws-us-east-1` (cluster `ab1642f7`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)