### PR TITLE
Fix worker limiting in feed_async_iterable

### DIFF
--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -2,6 +2,7 @@
 
 import json
 import unittest
+import asyncio
 
 import pytest
 from unittest.mock import PropertyMock, patch
@@ -702,7 +703,7 @@ class TestFeedAsyncIterable(unittest.TestCase):
                     groupname=None,
                     data_id="doc2",
                     fields={"title": "Document 2"},
-                    semaphore=unittest.mock.ANY
+                    semaphore=unittest.mock.ANY,
                 ),
             ],
             any_order=True,
@@ -760,6 +761,39 @@ class TestFeedAsyncIterable(unittest.TestCase):
         self.assertEqual(
             callback.call_args[0][0].json["message"], "Missing fields in input dict"
         )
+
+    def test_feed_async_iterable_respects_max_workers(self):
+        max_workers = 5
+        num_docs = 30
+        current = 0
+        max_seen = 0
+
+        async def fake_feed_data_point(*args, semaphore=None, **kwargs):
+            nonlocal current, max_seen
+            async with semaphore:
+                current += 1
+                max_seen = max(max_seen, current)
+                await asyncio.sleep(0.01)
+                current -= 1
+            return VespaResponse(
+                json={}, status_code=200, url="", operation_type="feed"
+            )
+
+        self.mock_session.feed_data_point.side_effect = fake_feed_data_point
+
+        docs = [
+            {"id": f"doc{i}", "fields": {"title": f"Document {i}"}}
+            for i in range(num_docs)
+        ]
+
+        self.vespa.feed_async_iterable(
+            iter=docs,
+            schema="test_schema",
+            namespace="test_namespace",
+            max_workers=max_workers,
+        )
+
+        self.assertLessEqual(max_seen, max_workers)
 
 
 class TestQueryMany(unittest.TestCase):

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -770,6 +770,7 @@ class TestFeedAsyncIterable(unittest.TestCase):
 
         async def fake_feed_data_point(*args, semaphore=None, **kwargs):
             nonlocal current, max_seen
+            assert isinstance(semaphore, asyncio.Semaphore)
             async with semaphore:
                 current += 1
                 max_seen = max(max_seen, current)

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -694,6 +694,7 @@ class TestFeedAsyncIterable(unittest.TestCase):
                     groupname=None,
                     data_id="doc1",
                     fields={"title": "Document 1"},
+                    semaphore=unittest.mock.ANY,
                 ),
                 unittest.mock.call(
                     schema="test_schema",
@@ -701,6 +702,7 @@ class TestFeedAsyncIterable(unittest.TestCase):
                     groupname=None,
                     data_id="doc2",
                     fields={"title": "Document 2"},
+                    semaphore=unittest.mock.ANY
                 ),
             ],
             any_order=True,

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -984,40 +984,42 @@ class Vespa(object):
                             callback(response, id)
                         continue
 
-                    async with semaphore:
-                        if operation_type == "feed":
-                            task = async_session.feed_data_point(
-                                schema=schema,
-                                namespace=namespace,
-                                groupname=groupname,
-                                data_id=id,
-                                fields=fields,
-                                **kwargs,
-                            )
-                        elif operation_type == "update":
-                            task = async_session.update_data(
-                                schema=schema,
-                                namespace=namespace,
-                                groupname=groupname,
-                                data_id=id,
-                                fields=fields,
-                                **kwargs,
-                            )
-                        elif operation_type == "delete":
-                            task = async_session.delete_data(
-                                schema=schema,
-                                namespace=namespace,
-                                data_id=id,
-                                groupname=groupname,
-                                **kwargs,
-                            )
+                    if operation_type == "feed":
+                        task = async_session.feed_data_point(
+                            schema=schema,
+                            namespace=namespace,
+                            groupname=groupname,
+                            data_id=id,
+                            fields=fields,
+                            semaphore=semaphore,
+                            **kwargs,
+                        )
+                    elif operation_type == "update":
+                        task = async_session.update_data(
+                            schema=schema,
+                            namespace=namespace,
+                            groupname=groupname,
+                            data_id=id,
+                            fields=fields,
+                            semaphore=semaphore,
+                            **kwargs,
+                        )
+                    elif operation_type == "delete":
+                        task = async_session.delete_data(
+                            schema=schema,
+                            namespace=namespace,
+                            data_id=id,
+                            groupname=groupname,
+                            semaphore=semaphore,
+                            **kwargs,
+                        )
 
-                        tasks.append(handle_result(asyncio.create_task(task), id))
+                    tasks.append(handle_result(asyncio.create_task(task), id))
 
-                        # Control the number of in-flight tasks
-                        if len(tasks) >= max_queue_size:
-                            await asyncio.gather(*tasks)
-                            tasks = []
+                    # Control the number of in-flight tasks
+                    if len(tasks) >= max_queue_size:
+                        await asyncio.gather(*tasks)
+                        tasks = []
 
                 if tasks:
                     await asyncio.gather(*tasks)


### PR DESCRIPTION
The semaphore which was supposed to limit the number of concurrent connections was only held during task creation. This has been changed so that the semaphore is instead held while the task is running. The test for `feed_async_iterable` has also been updated to check that the semaphore is passed to `feed_data_point`/`update_data`/`delete_data`.

I have done some manual benchmarks to see if the change limits the number of concurrent connections, but I don't know if this should be added as a unit test.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
