### PR TITLE
Fix raise_for_status with httpr >= 0.6.0

### DIFF
--- a/vespa/application.py
+++ b/vespa/application.py
@@ -204,21 +204,13 @@ def raise_for_status(
         VespaError: If the response JSON contains an error message.
     """
 
-    # Check if response has raise_for_status method (requests/httpx)
-    # or if we need to check manually (httpr)
     has_error = False
     http_error = None
 
-    if hasattr(response, "raise_for_status"):
-        # requests/httpx Response - use built-in method
-        try:
-            response.raise_for_status()
-            return  # No error, return early
-        except HTTPError as e:
-            has_error = True
-            http_error = e
-    else:
-        # httpr Response - check status code manually
+    if isinstance(response, httpr.Response):
+        # httpr Response - check status code manually. httpr >= 0.6.0 does provide a
+        # raise_for_status(), but it raises httpr.HTTPStatusError, which is not a
+        # requests HTTPError, so it must not be used to detect the error here.
         if 400 <= response.status_code < 600:
             has_error = True
             # Try to format error message with JSON if available
@@ -230,6 +222,14 @@ def raise_for_status(
             except Exception:
                 # Fall back to text if JSON parsing fails
                 http_error = HTTPError(f"HTTP {response.status_code}: {response.text}")
+    else:
+        # requests/httpx Response - use built-in method
+        try:
+            response.raise_for_status()
+            return  # No error, return early
+        except HTTPError as e:
+            has_error = True
+            http_error = e
 
     if has_error:
         # Handle 404 special case
@@ -245,8 +245,9 @@ def raise_for_status(
                 raise VespaError(errors) from http_error
             if error_message:
                 raise VespaError(error_message) from http_error
-        except JSONDecodeError:
-            # If we can't parse JSON, just raise the HTTP error
+        except (JSONDecodeError, ValueError, RuntimeError):
+            # If we can't parse JSON, just raise the HTTP error.
+            # httpr raises RuntimeError, not JSONDecodeError, on a non-JSON body.
             pass
 
         raise http_error


### PR DESCRIPTION
Fixes the 5 `test_integration_docker.py` failures currently red on every master-based branch (e.g. [run 29969545390](https://github.com/vespa-engine/pyvespa/actions/runs/29969545390) on `dependabot/uv/jupyterlab-4.5.10`, and on #1329, which does not cause them).

## Cause

httpr **0.6.0** added `Response.raise_for_status()` (0.4.6 has none). `raise_for_status()` dispatched on the presence of that method:

```python
if hasattr(response, "raise_for_status"):
    try:
        response.raise_for_status()
        return
    except HTTPError as e:          # requests.exceptions.HTTPError
        ...
else:
    # httpr Response - check status code manually
```

So httpr responses started taking the requests/httpx branch, and the `httpr.HTTPStatusError` raised there is `httpr.HTTPError -> Exception` — not a subclass of requests' `HTTPError`, so it escaped uncaught. That skipped both things below it:

- `if response.status_code == 404 and not raise_on_not_found: return` — so `get_data()` on an absent document raised instead of returning a 404 response object (4 of the 5 failures)
- the `root.errors` -> `VespaError` conversion — so `redeploy_with_application_package_changes`, which does `with pytest.raises(VespaError)` on an undefined rank profile, got `httpr.HTTPStatusError` (the 5th)

CI installs unlocked (`Collecting httpr>=0.4.0` -> `httpr-0.6.0`), which is why it fails there but not with the 0.4.6 pinned in `uv.lock`.

## Change

Dispatch on `isinstance(response, httpr.Response)` instead, so which branch runs no longer depends on the installed httpr version. The two branch bodies are unchanged.

Also widens the JSON decode guard from `except JSONDecodeError` to `except (JSONDecodeError, ValueError, RuntimeError)`: httpr's `.json()` raises a plain `RuntimeError` on a non-JSON body, so a 4xx/5xx with a non-JSON body leaked a `RuntimeError` in place of the `HTTPError`.

## Verification

Checked with both httpr versions:

| | 0.4.6 (uv.lock) | 0.6.0 (as CI resolves) |
|---|---|---|
| `tests/unit/` | 620 passed | 620 passed |
| `get_data()` on absent doc, live Vespa | returns 404 response | returns 404 response |
| bad rank profile, live Vespa | raises `VespaError` | raises `VespaError` |

Before the fix, both live-Vespa rows raise `httpr.HTTPStatusError` on 0.6.0.

The real test for this is the docker integration suite that was failing, so no unit tests are added here.

Worth considering separately: CI installing unlocked means httpr releases land in CI without a lockfile change, which is how this went unnoticed from ~Jul 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)