### PR TITLE
Fix error responses for data operations in VespaAsync

### DIFF
--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -946,13 +946,13 @@ class TestVespaAsync:
             _vespa_async = VespaAsync(app, limits=limits)
 
 
-# feed_data_point, delete_data, get_data and update_data all route through
-# VespaAsync._make_request, so that is what's mocked below.
 @pytest.mark.asyncio
 class TestVespaAsyncDataMethods:
-    async def test_feed_data_point_async_calls_make_request(self):
+    @pytest.mark.parametrize("use_semaphore", [False, True])
+    async def test_feed_data_point_async_calls_make_request(self, use_semaphore):
         app = Vespa(url="http://localhost", port=8080)
         vespa_async = VespaAsync(app)
+        semaphore = asyncio.Semaphore(2) if use_semaphore else None
 
         mock_response = create_mock_httpr_response(
             status_code=200,
@@ -962,7 +962,10 @@ class TestVespaAsyncDataMethods:
         vespa_async._make_request = AsyncMock(return_value=mock_response)
 
         r = await vespa_async.feed_data_point(
-            schema="foo", data_id="0", fields={"body": "this is a test"}
+            schema="foo",
+            data_id="0",
+            fields={"body": "this is a test"},
+            semaphore=semaphore,
         )
 
         assert isinstance(r, VespaResponse)
@@ -975,21 +978,6 @@ class TestVespaAsyncDataMethods:
         assert args[0] == "POST"
         assert args[1] == "http://localhost:8080/document/v1/foo/foo/docid/0"
         assert kwargs["json_data"] == {"fields": {"body": "this is a test"}}
-        assert kwargs["semaphore"] is None
-
-    async def test_feed_data_point_async_passes_semaphore(self):
-        app = Vespa(url="http://localhost", port=8080)
-        vespa_async = VespaAsync(app)
-        semaphore = asyncio.Semaphore(2)
-
-        mock_response = create_mock_httpr_response(status_code=200, json_data={})
-        vespa_async._make_request = AsyncMock(return_value=mock_response)
-
-        await vespa_async.feed_data_point(
-            schema="foo", data_id="0", fields={"body": "x"}, semaphore=semaphore
-        )
-
-        _, kwargs = vespa_async._make_request.call_args
         assert kwargs["semaphore"] is semaphore
 
     async def test_feed_data_point_async_falls_back_when_json_parsing_fails(self):
@@ -1015,9 +1003,11 @@ class TestVespaAsyncDataMethods:
         assert r.json == {"message": "Internal Server Error"}
         assert r.status_code == 500
 
-    async def test_delete_data_async_calls_make_request(self):
+    @pytest.mark.parametrize("use_semaphore", [False, True])
+    async def test_delete_data_async_calls_make_request(self, use_semaphore):
         app = Vespa(url="http://localhost", port=8080)
         vespa_async = VespaAsync(app)
+        semaphore = asyncio.Semaphore(2) if use_semaphore else None
 
         mock_response = create_mock_httpr_response(
             status_code=200,
@@ -1026,7 +1016,9 @@ class TestVespaAsyncDataMethods:
         )
         vespa_async._make_request = AsyncMock(return_value=mock_response)
 
-        r = await vespa_async.delete_data(schema="foo", data_id="0")
+        r = await vespa_async.delete_data(
+            schema="foo", data_id="0", semaphore=semaphore
+        )
 
         assert isinstance(r, VespaResponse)
         assert r.status_code == 200
@@ -1038,19 +1030,6 @@ class TestVespaAsyncDataMethods:
         assert args[0] == "DELETE"
         assert args[1] == "http://localhost:8080/document/v1/foo/foo/docid/0"
         assert "json_data" not in kwargs
-        assert kwargs["semaphore"] is None
-
-    async def test_delete_data_async_passes_semaphore(self):
-        app = Vespa(url="http://localhost", port=8080)
-        vespa_async = VespaAsync(app)
-        semaphore = asyncio.Semaphore(2)
-
-        mock_response = create_mock_httpr_response(status_code=200, json_data={})
-        vespa_async._make_request = AsyncMock(return_value=mock_response)
-
-        await vespa_async.delete_data(schema="foo", data_id="0", semaphore=semaphore)
-
-        _, kwargs = vespa_async._make_request.call_args
         assert kwargs["semaphore"] is semaphore
 
     async def test_delete_data_async_falls_back_when_json_parsing_fails(self):
@@ -1073,9 +1052,11 @@ class TestVespaAsyncDataMethods:
         assert r.json == {"message": "Internal Server Error"}
         assert r.status_code == 500
 
-    async def test_get_data_async_calls_make_request(self):
+    @pytest.mark.parametrize("use_semaphore", [False, True])
+    async def test_get_data_async_calls_make_request(self, use_semaphore):
         app = Vespa(url="http://localhost", port=8080)
         vespa_async = VespaAsync(app)
+        semaphore = asyncio.Semaphore(2) if use_semaphore else None
 
         mock_response = create_mock_httpr_response(
             status_code=200,
@@ -1084,7 +1065,7 @@ class TestVespaAsyncDataMethods:
         )
         vespa_async._make_request = AsyncMock(return_value=mock_response)
 
-        r = await vespa_async.get_data(schema="foo", data_id="0")
+        r = await vespa_async.get_data(schema="foo", data_id="0", semaphore=semaphore)
 
         assert isinstance(r, VespaResponse)
         assert r.status_code == 200
@@ -1096,19 +1077,6 @@ class TestVespaAsyncDataMethods:
         assert args[0] == "GET"
         assert args[1] == "http://localhost:8080/document/v1/foo/foo/docid/0"
         assert "json_data" not in kwargs
-        assert kwargs["semaphore"] is None
-
-    async def test_get_data_async_passes_semaphore(self):
-        app = Vespa(url="http://localhost", port=8080)
-        vespa_async = VespaAsync(app)
-        semaphore = asyncio.Semaphore(2)
-
-        mock_response = create_mock_httpr_response(status_code=200, json_data={})
-        vespa_async._make_request = AsyncMock(return_value=mock_response)
-
-        await vespa_async.get_data(schema="foo", data_id="0", semaphore=semaphore)
-
-        _, kwargs = vespa_async._make_request.call_args
         assert kwargs["semaphore"] is semaphore
 
     async def test_get_data_async_falls_back_when_json_parsing_fails(self):
@@ -1131,9 +1099,11 @@ class TestVespaAsyncDataMethods:
         assert r.json == {"message": "Not Found"}
         assert r.status_code == 404
 
-    async def test_update_data_async_default_auto_assign(self):
+    @pytest.mark.parametrize("use_semaphore", [False, True])
+    async def test_update_data_async_default_auto_assign(self, use_semaphore):
         app = Vespa(url="http://localhost", port=8080)
         vespa_async = VespaAsync(app)
+        semaphore = asyncio.Semaphore(2) if use_semaphore else None
 
         mock_response = create_mock_httpr_response(
             status_code=200,
@@ -1143,7 +1113,10 @@ class TestVespaAsyncDataMethods:
         vespa_async._make_request = AsyncMock(return_value=mock_response)
 
         r = await vespa_async.update_data(
-            schema="foo", data_id="0", fields={"body": "updated"}
+            schema="foo",
+            data_id="0",
+            fields={"body": "updated"},
+            semaphore=semaphore,
         )
 
         assert isinstance(r, VespaResponse)
@@ -1154,7 +1127,7 @@ class TestVespaAsyncDataMethods:
         args, kwargs = vespa_async._make_request.call_args
         assert args[0] == "PUT"
         assert kwargs["json_data"] == {"fields": {"body": {"assign": "updated"}}}
-        assert kwargs["semaphore"] is None
+        assert kwargs["semaphore"] is semaphore
 
     async def test_update_data_async_no_auto_assign_excludes_id(self):
         app = Vespa(url="http://localhost", port=8080)
@@ -1186,21 +1159,6 @@ class TestVespaAsyncDataMethods:
 
         _, kwargs = vespa_async._make_request.call_args
         assert kwargs["params"]["create"] == "true"
-
-    async def test_update_data_async_passes_semaphore(self):
-        app = Vespa(url="http://localhost", port=8080)
-        vespa_async = VespaAsync(app)
-        semaphore = asyncio.Semaphore(2)
-
-        mock_response = create_mock_httpr_response(status_code=200, json_data={})
-        vespa_async._make_request = AsyncMock(return_value=mock_response)
-
-        await vespa_async.update_data(
-            schema="foo", data_id="0", fields={"body": "x"}, semaphore=semaphore
-        )
-
-        _, kwargs = vespa_async._make_request.call_args
-        assert kwargs["semaphore"] is semaphore
 
     async def test_update_data_async_falls_back_when_json_parsing_fails(self):
         """If response.json() raises, update_data should fall back to a message dict."""

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -946,6 +946,286 @@ class TestVespaAsync:
             _vespa_async = VespaAsync(app, limits=limits)
 
 
+# feed_data_point, delete_data, get_data and update_data all route through
+# VespaAsync._make_request, so that is what's mocked below.
+@pytest.mark.asyncio
+class TestVespaAsyncDataMethods:
+    async def test_feed_data_point_async_calls_make_request(self):
+        app = Vespa(url="http://localhost", port=8080)
+        vespa_async = VespaAsync(app)
+
+        mock_response = create_mock_httpr_response(
+            status_code=200,
+            json_data={"id": "id:foo:foo::0"},
+            url="http://localhost:8080/document/v1/foo/foo/docid/0",
+        )
+        vespa_async._make_request = AsyncMock(return_value=mock_response)
+
+        r = await vespa_async.feed_data_point(
+            schema="foo", data_id="0", fields={"body": "this is a test"}
+        )
+
+        assert isinstance(r, VespaResponse)
+        assert r.status_code == 200
+        assert r.json == {"id": "id:foo:foo::0"}
+        assert r.operation_type == "feed"
+
+        vespa_async._make_request.assert_awaited_once()
+        args, kwargs = vespa_async._make_request.call_args
+        assert args[0] == "POST"
+        assert args[1] == "http://localhost:8080/document/v1/foo/foo/docid/0"
+        assert kwargs["json_data"] == {"fields": {"body": "this is a test"}}
+        assert kwargs["semaphore"] is None
+
+    async def test_feed_data_point_async_passes_semaphore(self):
+        app = Vespa(url="http://localhost", port=8080)
+        vespa_async = VespaAsync(app)
+        semaphore = asyncio.Semaphore(2)
+
+        mock_response = create_mock_httpr_response(status_code=200, json_data={})
+        vespa_async._make_request = AsyncMock(return_value=mock_response)
+
+        await vespa_async.feed_data_point(
+            schema="foo", data_id="0", fields={"body": "x"}, semaphore=semaphore
+        )
+
+        _, kwargs = vespa_async._make_request.call_args
+        assert kwargs["semaphore"] is semaphore
+
+    async def test_feed_data_point_async_falls_back_when_json_parsing_fails(self):
+        """If response.json() raises, feed_data_point should fall back to a message dict."""
+        app = Vespa(url="http://localhost", port=8080)
+        vespa_async = VespaAsync(app)
+
+        mock_response = Mock()
+        mock_response.status_code = 500
+        type(mock_response).url = PropertyMock(
+            return_value="http://localhost:8080/document/v1/foo/foo/docid/0"
+        )
+        mock_response.text = "Internal Server Error"
+        mock_response.json.side_effect = RuntimeError(
+            "expected ident at line 1 column 2"
+        )
+        vespa_async._make_request = AsyncMock(return_value=mock_response)
+
+        r = await vespa_async.feed_data_point(
+            schema="foo", data_id="0", fields={"body": "x"}
+        )
+
+        assert r.json == {"message": "Internal Server Error"}
+        assert r.status_code == 500
+
+    async def test_delete_data_async_calls_make_request(self):
+        app = Vespa(url="http://localhost", port=8080)
+        vespa_async = VespaAsync(app)
+
+        mock_response = create_mock_httpr_response(
+            status_code=200,
+            json_data={"id": "id:foo:foo::0"},
+            url="http://localhost:8080/document/v1/foo/foo/docid/0",
+        )
+        vespa_async._make_request = AsyncMock(return_value=mock_response)
+
+        r = await vespa_async.delete_data(schema="foo", data_id="0")
+
+        assert isinstance(r, VespaResponse)
+        assert r.status_code == 200
+        assert r.json == {"id": "id:foo:foo::0"}
+        assert r.operation_type == "delete"
+
+        vespa_async._make_request.assert_awaited_once()
+        args, kwargs = vespa_async._make_request.call_args
+        assert args[0] == "DELETE"
+        assert args[1] == "http://localhost:8080/document/v1/foo/foo/docid/0"
+        assert "json_data" not in kwargs
+        assert kwargs["semaphore"] is None
+
+    async def test_delete_data_async_passes_semaphore(self):
+        app = Vespa(url="http://localhost", port=8080)
+        vespa_async = VespaAsync(app)
+        semaphore = asyncio.Semaphore(2)
+
+        mock_response = create_mock_httpr_response(status_code=200, json_data={})
+        vespa_async._make_request = AsyncMock(return_value=mock_response)
+
+        await vespa_async.delete_data(schema="foo", data_id="0", semaphore=semaphore)
+
+        _, kwargs = vespa_async._make_request.call_args
+        assert kwargs["semaphore"] is semaphore
+
+    async def test_delete_data_async_falls_back_when_json_parsing_fails(self):
+        app = Vespa(url="http://localhost", port=8080)
+        vespa_async = VespaAsync(app)
+
+        mock_response = Mock()
+        mock_response.status_code = 500
+        type(mock_response).url = PropertyMock(
+            return_value="http://localhost:8080/document/v1/foo/foo/docid/0"
+        )
+        mock_response.text = "Internal Server Error"
+        mock_response.json.side_effect = RuntimeError(
+            "expected ident at line 1 column 2"
+        )
+        vespa_async._make_request = AsyncMock(return_value=mock_response)
+
+        r = await vespa_async.delete_data(schema="foo", data_id="0")
+
+        assert r.json == {"message": "Internal Server Error"}
+        assert r.status_code == 500
+
+    async def test_get_data_async_calls_make_request(self):
+        app = Vespa(url="http://localhost", port=8080)
+        vespa_async = VespaAsync(app)
+
+        mock_response = create_mock_httpr_response(
+            status_code=200,
+            json_data={"id": "id:foo:foo::0", "fields": {"body": "x"}},
+            url="http://localhost:8080/document/v1/foo/foo/docid/0",
+        )
+        vespa_async._make_request = AsyncMock(return_value=mock_response)
+
+        r = await vespa_async.get_data(schema="foo", data_id="0")
+
+        assert isinstance(r, VespaResponse)
+        assert r.status_code == 200
+        assert r.json == {"id": "id:foo:foo::0", "fields": {"body": "x"}}
+        assert r.operation_type == "get"
+
+        vespa_async._make_request.assert_awaited_once()
+        args, kwargs = vespa_async._make_request.call_args
+        assert args[0] == "GET"
+        assert args[1] == "http://localhost:8080/document/v1/foo/foo/docid/0"
+        assert "json_data" not in kwargs
+        assert kwargs["semaphore"] is None
+
+    async def test_get_data_async_passes_semaphore(self):
+        app = Vespa(url="http://localhost", port=8080)
+        vespa_async = VespaAsync(app)
+        semaphore = asyncio.Semaphore(2)
+
+        mock_response = create_mock_httpr_response(status_code=200, json_data={})
+        vespa_async._make_request = AsyncMock(return_value=mock_response)
+
+        await vespa_async.get_data(schema="foo", data_id="0", semaphore=semaphore)
+
+        _, kwargs = vespa_async._make_request.call_args
+        assert kwargs["semaphore"] is semaphore
+
+    async def test_get_data_async_falls_back_when_json_parsing_fails(self):
+        app = Vespa(url="http://localhost", port=8080)
+        vespa_async = VespaAsync(app)
+
+        mock_response = Mock()
+        mock_response.status_code = 404
+        type(mock_response).url = PropertyMock(
+            return_value="http://localhost:8080/document/v1/foo/foo/docid/0"
+        )
+        mock_response.text = "Not Found"
+        mock_response.json.side_effect = RuntimeError(
+            "expected ident at line 1 column 2"
+        )
+        vespa_async._make_request = AsyncMock(return_value=mock_response)
+
+        r = await vespa_async.get_data(schema="foo", data_id="0")
+
+        assert r.json == {"message": "Not Found"}
+        assert r.status_code == 404
+
+    async def test_update_data_async_default_auto_assign(self):
+        app = Vespa(url="http://localhost", port=8080)
+        vespa_async = VespaAsync(app)
+
+        mock_response = create_mock_httpr_response(
+            status_code=200,
+            json_data={"id": "id:foo:foo::0"},
+            url="http://localhost:8080/document/v1/foo/foo/docid/0",
+        )
+        vespa_async._make_request = AsyncMock(return_value=mock_response)
+
+        r = await vespa_async.update_data(
+            schema="foo", data_id="0", fields={"body": "updated"}
+        )
+
+        assert isinstance(r, VespaResponse)
+        assert r.status_code == 200
+        assert r.json == {"id": "id:foo:foo::0"}
+        assert r.operation_type == "update"
+
+        args, kwargs = vespa_async._make_request.call_args
+        assert args[0] == "PUT"
+        assert kwargs["json_data"] == {"fields": {"body": {"assign": "updated"}}}
+        assert kwargs["semaphore"] is None
+
+    async def test_update_data_async_no_auto_assign_excludes_id(self):
+        app = Vespa(url="http://localhost", port=8080)
+        vespa_async = VespaAsync(app)
+
+        mock_response = create_mock_httpr_response(status_code=200, json_data={})
+        vespa_async._make_request = AsyncMock(return_value=mock_response)
+
+        await vespa_async.update_data(
+            schema="foo",
+            data_id="0",
+            fields={"id": "0", "body": "updated"},
+            auto_assign=False,
+        )
+
+        _, kwargs = vespa_async._make_request.call_args
+        assert kwargs["json_data"] == {"fields": {"body": "updated"}}
+
+    async def test_update_data_async_create_flag_sets_query_param(self):
+        app = Vespa(url="http://localhost", port=8080)
+        vespa_async = VespaAsync(app)
+
+        mock_response = create_mock_httpr_response(status_code=200, json_data={})
+        vespa_async._make_request = AsyncMock(return_value=mock_response)
+
+        await vespa_async.update_data(
+            schema="foo", data_id="0", fields={"body": "x"}, create=True
+        )
+
+        _, kwargs = vespa_async._make_request.call_args
+        assert kwargs["params"]["create"] == "true"
+
+    async def test_update_data_async_passes_semaphore(self):
+        app = Vespa(url="http://localhost", port=8080)
+        vespa_async = VespaAsync(app)
+        semaphore = asyncio.Semaphore(2)
+
+        mock_response = create_mock_httpr_response(status_code=200, json_data={})
+        vespa_async._make_request = AsyncMock(return_value=mock_response)
+
+        await vespa_async.update_data(
+            schema="foo", data_id="0", fields={"body": "x"}, semaphore=semaphore
+        )
+
+        _, kwargs = vespa_async._make_request.call_args
+        assert kwargs["semaphore"] is semaphore
+
+    async def test_update_data_async_falls_back_when_json_parsing_fails(self):
+        """If response.json() raises, update_data should fall back to a message dict."""
+        app = Vespa(url="http://localhost", port=8080)
+        vespa_async = VespaAsync(app)
+
+        mock_response = Mock()
+        mock_response.status_code = 500
+        type(mock_response).url = PropertyMock(
+            return_value="http://localhost:8080/document/v1/foo/foo/docid/0"
+        )
+        mock_response.text = "Internal Server Error"
+        mock_response.json.side_effect = RuntimeError(
+            "expected ident at line 1 column 2"
+        )
+        vespa_async._make_request = AsyncMock(return_value=mock_response)
+
+        r = await vespa_async.update_data(
+            schema="foo", data_id="0", fields={"body": "x"}
+        )
+
+        assert r.json == {"message": "Internal Server Error"}
+        assert r.status_code == 500
+
+
 class TestVespaSyncStreaming(unittest.TestCase):
     @patch("vespa.application.httpr.Client")
     def test_query_streaming(self, MockClient):

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -2303,16 +2303,22 @@ class VespaAsync(object):
         if profile:
             kwargs.update(get_profiling_params())
 
-        r = await self._make_request(
+        response = await self._make_request(
             "POST",
             self.app.search_end_point,
             json_data=body,
             params=kwargs,
             headers={"Accept": "application/cbor"},
         )
+        try:
+            json = response.json()
+        except RuntimeError:
+            json = {"message": response.text}
 
         return VespaQueryResponse(
-            json=r.json(), status_code=r.status_code, url=str(r.url)
+            json=json,
+            status_code=response.status_code,
+            url=str(response.url)
         )
 
     @retry(
@@ -2351,9 +2357,13 @@ class VespaAsync(object):
             semaphore=semaphore,
             params=kwargs,
         )
+        try:
+            json = response.json()
+        except RuntimeError:
+            json = {"message": response.text}
 
         return VespaResponse(
-            json=response.json(),
+            json=json,
             status_code=response.status_code,
             url=str(response.url),
             operation_type="feed",
@@ -2385,13 +2395,20 @@ class VespaAsync(object):
             id=data_id, schema=schema, namespace=namespace, group=groupname
         )
         end_point = "{}{}".format(self.app.end_point, path)
-        if semaphore:
-            async with semaphore:
-                response = await self.httpr_client.delete(end_point, params=kwargs)
-        else:
-            response = await self.httpr_client.delete(end_point, params=kwargs)
+
+        response = await self._make_request(
+            "DELETE",
+            end_point,
+            semaphore=semaphore,
+            params=kwargs,
+        )
+        try:
+            json = response.json()
+        except RuntimeError:
+            json = {"message": response.text}
+
         return VespaResponse(
-            json=response.json(),
+            json=json,
             status_code=response.status_code,
             url=str(response.url),
             operation_type="delete",
@@ -2423,13 +2440,20 @@ class VespaAsync(object):
             id=data_id, schema=schema, namespace=namespace, group=groupname
         )
         end_point = "{}{}".format(self.app.end_point, path)
-        if semaphore:
-            async with semaphore:
-                response = await self.httpr_client.get(end_point, params=kwargs)
-        else:
-            response = await self.httpr_client.get(end_point, params=kwargs)
+
+        response = await self._make_request(
+            "GET",
+            end_point,
+            semaphore=semaphore,
+            params=kwargs,
+        )
+        try:
+            json = response.json()
+        except RuntimeError:
+            json = {"message": response.text}
+
         return VespaResponse(
-            json=response.json(),
+            json=json,
             status_code=response.status_code,
             url=str(response.url),
             operation_type="get",
@@ -2479,8 +2503,13 @@ class VespaAsync(object):
             semaphore=semaphore,
             params=kwargs,
         )
+        try:
+            json = response.json()
+        except RuntimeError:
+            json = {"message": response.text}
+
         return VespaResponse(
-            json=response.json(),
+            json=json,
             status_code=response.status_code,
             url=str(response.url),
             operation_type="update",

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -252,12 +252,14 @@ def raise_for_status(
 
         raise http_error
 
+
 def _response_json(response: Response) -> Dict:
     """Return the parsed JSON body, falling back to the raw text on a non-JSON body."""
     try:
         return response.json()
     except (JSONDecodeError, ValueError, RuntimeError):
         return {"message": response.text}
+
 
 class Vespa(object):
     def __init__(
@@ -2320,7 +2322,7 @@ class VespaAsync(object):
         return VespaQueryResponse(
             json=_response_json(response),
             status_code=response.status_code,
-            url=str(response.url)
+            url=str(response.url),
         )
 
     @retry(

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -252,6 +252,12 @@ def raise_for_status(
 
         raise http_error
 
+def _response_json(response: Response) -> Dict:
+    """Return the parsed JSON body, falling back to the raw text on a non-JSON body."""
+    try:
+        return response.json()
+    except (JSONDecodeError, ValueError, RuntimeError):
+        return {"message": response.text}
 
 class Vespa(object):
     def __init__(
@@ -2310,13 +2316,9 @@ class VespaAsync(object):
             params=kwargs,
             headers={"Accept": "application/cbor"},
         )
-        try:
-            json = response.json()
-        except RuntimeError:
-            json = {"message": response.text}
 
         return VespaQueryResponse(
-            json=json,
+            json=_response_json(response),
             status_code=response.status_code,
             url=str(response.url)
         )
@@ -2357,13 +2359,9 @@ class VespaAsync(object):
             semaphore=semaphore,
             params=kwargs,
         )
-        try:
-            json = response.json()
-        except RuntimeError:
-            json = {"message": response.text}
 
         return VespaResponse(
-            json=json,
+            json=_response_json(response),
             status_code=response.status_code,
             url=str(response.url),
             operation_type="feed",
@@ -2402,13 +2400,9 @@ class VespaAsync(object):
             semaphore=semaphore,
             params=kwargs,
         )
-        try:
-            json = response.json()
-        except RuntimeError:
-            json = {"message": response.text}
 
         return VespaResponse(
-            json=json,
+            json=_response_json(response),
             status_code=response.status_code,
             url=str(response.url),
             operation_type="delete",
@@ -2447,13 +2441,9 @@ class VespaAsync(object):
             semaphore=semaphore,
             params=kwargs,
         )
-        try:
-            json = response.json()
-        except RuntimeError:
-            json = {"message": response.text}
 
         return VespaResponse(
-            json=json,
+            json=_response_json(response),
             status_code=response.status_code,
             url=str(response.url),
             operation_type="get",
@@ -2503,13 +2493,9 @@ class VespaAsync(object):
             semaphore=semaphore,
             params=kwargs,
         )
-        try:
-            json = response.json()
-        except RuntimeError:
-            json = {"message": response.text}
 
         return VespaResponse(
-            json=json,
+            json=_response_json(response),
             status_code=response.status_code,
             url=str(response.url),
             operation_type="update",


### PR DESCRIPTION
Error responses from the vespa api might not be json. This would previously give a json decode error. Now the functions instead return {"message": response.text} with the correct error code.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.