### PR TITLE
Correct validation for tenant, app-name and instance as cloud

### DIFF
--- a/docs/sphinx/source/api/summary.md
+++ b/docs/sphinx/source/api/summary.md
@@ -10,3 +10,4 @@
             * [builder](vespa/querybuilder/builder/builder.md)
         * [grouping](vespa/querybuilder/grouping/index.md)
             * [grouping](vespa/querybuilder/grouping/grouping.md)
+    * [validation](vespa/validation.md)

--- a/docs/sphinx/source/api/vespa/validation.md
+++ b/docs/sphinx/source/api/vespa/validation.md
@@ -1,0 +1,1 @@
+::: vespa.validation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
           - Builder: api/vespa/querybuilder/builder/builder.md
           - Grouping: api/vespa/querybuilder/grouping/grouping.md
       - Throttling: api/vespa/throttling.md
+      - Validation: api/vespa/validation.md
 plugins:
     - search
     - autorefs
@@ -155,3 +156,4 @@ plugins:
                 - api/vespa/querybuilder/builder/builder.md: QueryBuilder DSL
                 - api/vespa/querybuilder/grouping/grouping.md: Grouping queries
                 - api/vespa/throttling.md: Adaptive feed throttling
+                - api/vespa/validation.md: Validation of Vespa Cloud tenant, application and instance names

--- a/tests/unit/test_deployment.py
+++ b/tests/unit/test_deployment.py
@@ -3,22 +3,14 @@ from tempfile import TemporaryDirectory
 import os
 from unittest.mock import patch, MagicMock
 
-from urllib3.exceptions import HTTPError
-
-from vespa.deployment import VespaCloud, DataplaneToken
-from vespa.package import (
-    ApplicationPackage,
-    AuthClient,
-    ContainerCluster,
-    Nodes,
-    Parameter,
-)
+from vespa.deployment import VespaCloud
+from vespa.package import ApplicationPackage, AuthClient, Parameter
 
 
 class TestVespaCloud(unittest.TestCase):
     def setUp(self):
-        self.tenant = "test_tenant"
-        self.application = "test_app"
+        self.tenant = "test-tenant"
+        self.application = "test-app"
         self.application_package = MagicMock()
         # Mock ._try_get_access_token to avoid requests
         VespaCloud._try_get_access_token = MagicMock(return_value="fake_access_token")
@@ -88,7 +80,7 @@ class TestVespaCloud(unittest.TestCase):
         self.assertEqual(result, mock_response)
         mock_request.assert_called_once_with(
             "GET",
-            "/application/v4/tenant/test_tenant/application/test_app/instance/default/environment/dev/region/aws-us-east-1c/private-services",
+            "/application/v4/tenant/test-tenant/application/test-app/instance/default/environment/dev/region/aws-us-east-1c/private-services",
         )
 
     @patch("vespa.deployment.VespaCloud._request")
@@ -168,7 +160,7 @@ class TestVespaCloud(unittest.TestCase):
         self.assertEqual(status, {"deployed": True, "status": "done"})
         mock_request.assert_called_once_with(
             "GET",
-            "/application/v4/tenant/test_tenant/application/test_app/build-status/456",
+            "/application/v4/tenant/test-tenant/application/test-app/build-status/456",
         )
 
     @patch("vespa.deployment.VespaCloud._request")
@@ -309,8 +301,8 @@ class TestVespaCloud(unittest.TestCase):
 
 class TestVaultAccessRules(unittest.TestCase):
     def setUp(self):
-        self.tenant = "test_tenant"
-        self.application = "test_app"
+        self.tenant = "test-tenant"
+        self.application = "test-app"
         self.application_package = MagicMock()
         VespaCloud._try_get_access_token = MagicMock(return_value="fake_access_token")
         self.vespa_cloud = VespaCloud(
@@ -378,7 +370,7 @@ class TestVaultAccessRules(unittest.TestCase):
             "rules": [
                 {
                     "id": 0,
-                    "application": "test_app",
+                    "application": "test-app",
                     "contexts": [VespaCloud.secret_store_dev_alias],
                 },
             ]
@@ -387,7 +379,7 @@ class TestVaultAccessRules(unittest.TestCase):
         # Should only GET, no PUT (no CSRF fetch either)
         mock_request.assert_called_once_with(
             "GET",
-            "/tenant-secret/v1/tenant/test_tenant/vault/my-vault",
+            "/tenant-secret/v1/tenant/test-tenant/vault/my-vault",
         )
 
     @patch("vespa.deployment.VespaCloud._request")
@@ -406,7 +398,7 @@ class TestVaultAccessRules(unittest.TestCase):
             # GET CSRF token
             {"token": "fake-csrf-token"},
             # PUT response: MessageResponse JSON
-            {"message": "Set access rules for tenant test_tenant, vault my-vault"},
+            {"message": "Set access rules for tenant test-tenant, vault my-vault"},
         ]
         self.vespa_cloud._ensure_vault_access_rule("my-vault")
         self.assertEqual(mock_request.call_count, 3)
@@ -425,7 +417,7 @@ class TestVaultAccessRules(unittest.TestCase):
                 },
                 {
                     "id": 1,
-                    "application": "test_app",
+                    "application": "test-app",
                     "contexts": [VespaCloud.secret_store_dev_alias],
                 },
             ],
@@ -439,7 +431,7 @@ class TestVaultAccessRules(unittest.TestCase):
             # GET CSRF token
             {"token": "fake-csrf-token"},
             # PUT response: MessageResponse JSON
-            {"message": "Set access rules for tenant test_tenant, vault my-vault"},
+            {"message": "Set access rules for tenant test-tenant, vault my-vault"},
         ]
         self.vespa_cloud._ensure_vault_access_rule("my-vault")
         self.assertEqual(mock_request.call_count, 3)
@@ -448,7 +440,7 @@ class TestVaultAccessRules(unittest.TestCase):
             [
                 {
                     "id": 0,
-                    "application": "test_app",
+                    "application": "test-app",
                     "contexts": [VespaCloud.secret_store_dev_alias],
                 }
             ],

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -481,14 +481,14 @@ class TestRankProfile(unittest.TestCase):
         schema = Schema(name="test", document=doc, rank_profiles=[rank_profile])
 
         schema_text = schema.schema_to_text
-        
+
         # Check that numeric values are NOT quoted
         self.assertIn("approximate-threshold: 0.05", schema_text)
         self.assertIn("filter-first-threshold: 0.0", schema_text)
         self.assertIn("filter-first-exploration: 0.3", schema_text)
         self.assertIn("exploration-slack: 0.0", schema_text)
         self.assertIn("num-threads-per-search: 1", schema_text)
-        
+
         # Check that numeric values are not wrapped with quotes
         self.assertNotIn('"0.05"', schema_text)
         self.assertNotIn('"0.0"', schema_text)
@@ -509,9 +509,11 @@ class TestRankProfile(unittest.TestCase):
         schema = Schema(name="test", document=doc, rank_profiles=[rank_profile])
 
         schema_text = schema.schema_to_text
-        
+
         # Check that string values ARE quoted
-        self.assertIn('fieldMatch(title).maxAlternativeSegmentations: "10"', schema_text)
+        self.assertIn(
+            'fieldMatch(title).maxAlternativeSegmentations: "10"', schema_text
+        )
         self.assertIn('some-string-property: "value"', schema_text)
 
     def test_rank_profile_properties_mixed_types(self):
@@ -530,14 +532,16 @@ class TestRankProfile(unittest.TestCase):
         schema = Schema(name="test", document=doc, rank_profiles=[rank_profile])
 
         schema_text = schema.schema_to_text
-        
+
         # Check numeric values are NOT quoted
         self.assertIn("bm25(text).k1: 0.9", schema_text)
         self.assertIn("bm25(text).b: 0.4", schema_text)
         self.assertIn("num-threads-per-search: 1", schema_text)
-        
+
         # Check string values ARE quoted
-        self.assertIn('fieldMatch(title).maxAlternativeSegmentations: "10"', schema_text)
+        self.assertIn(
+            'fieldMatch(title).maxAlternativeSegmentations: "10"', schema_text
+        )
 
 
 class TestSchema(unittest.TestCase):
@@ -1810,16 +1814,44 @@ class TestClientsWithCluster(unittest.TestCase):
 
 class TestValidAppName(unittest.TestCase):
     def test_invalid_name(self):
-        with pytest.raises(ValueError):
-            ApplicationPackage(name="test_app")
-        with pytest.raises(ValueError):
-            ApplicationPackage(name="test-app")
-        with pytest.raises(ValueError):
-            ApplicationPackage(name="42testapp")
-        with pytest.raises(ValueError):
-            ApplicationPackage(name="testApp")
-        with pytest.raises(ValueError):
-            ApplicationPackage(name="testapp" + "x" * 20)
+        for name in [
+            "",
+            "42testapp",  # does not start with a letter
+            "testApp",  # uppercase
+            "test.app",  # dot
+            "-testapp",  # leading dash
+            "_testapp",  # leading underscore
+            "test app",  # space
+            "a" * 41,  # too long
+        ]:
+            with self.subTest(name=name):
+                with pytest.raises(ValueError):
+                    ApplicationPackage(name=name)
+
+    def test_valid_name(self):
+        for name in [
+            "testapp",
+            "test-app",
+            "test_app",  # underscores are fine for a self-hosted application
+            "search2",
+            "my-search-app",
+            "a" * 40,
+        ]:
+            with self.subTest(name=name):
+                self.assertEqual(ApplicationPackage(name=name).name, name)
+
+    def test_cloud_reserved_names_are_allowed(self):
+        # 'api' and 'default' are reserved as Vespa Cloud names, which an application
+        # package name is not.
+        for name in ["api", "default"]:
+            with self.subTest(name=name):
+                self.assertEqual(ApplicationPackage(name=name).name, name)
+
+    def test_default_schema_name_has_no_dashes(self):
+        # Schema names are Vespa identifiers, which cannot contain dashes.
+        app_package = ApplicationPackage(name="my-test-app")
+        self.assertEqual(app_package.name, "my-test-app")
+        self.assertEqual(app_package.schema.name, "my_test_app")
 
 
 class TestFieldAlias(unittest.TestCase):
@@ -3094,7 +3126,9 @@ class TestIncludeFiles(unittest.TestCase):
                 include_files=[(src, "models/embedder.onnx")],
             )
             app.to_files(out)
-            self.assertTrue(os.path.isfile(os.path.join(out, "models", "embedder.onnx")))
+            self.assertTrue(
+                os.path.isfile(os.path.join(out, "models", "embedder.onnx"))
+            )
 
     def test_include_files_dest_subdir_in_zip(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -3143,7 +3177,7 @@ class TestIncludeFiles(unittest.TestCase):
                     name="testinclude",
                     include_files=[(src, "../escaped.json")],
                 )
-    
+
     def test_abs_windows_path(self):
         with tempfile.TemporaryDirectory() as tempdir:
             src = self._make_src_file(tempdir)

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -1,0 +1,245 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+"""Unit tests for vespa.validation.
+
+The expectations mirror the Vespa Cloud controller's
+``com.yahoo.vespa.hosted.controller.api.identifiers.IdentifierTest``.
+"""
+
+import re
+import unittest
+
+from vespa.validation import (
+    MAX_NAME_LENGTH,
+    MAX_NAME_LENGTH_LEGACY,
+    to_vespa_identifier,
+    validate_application_name,
+    validate_application_package_name,
+    validate_cloud_names,
+    validate_instance_name,
+    validate_tenant_name,
+)
+
+# The pattern as written in the controller, used to assert that our (linear time)
+# formulation accepts and rejects exactly the same names.
+CONTROLLER_PATTERN = re.compile(r"^(?=.{1,40}$)[a-z](-?[a-z0-9]+)*$")
+
+VALID_NAMES = [
+    "a",
+    "myapp",
+    "my-app",
+    "search2",
+    "my-search-app",
+    "a1-2b-3c",
+    "msbe",
+    "a" * MAX_NAME_LENGTH,
+]
+
+INVALID_NAMES = [
+    "",
+    "2fast",  # does not start with a letter
+    "-app",  # leading dash
+    "app-",  # trailing dash
+    "my--app",  # double-dash
+    "My_App",  # uppercase and underscore
+    "MixedCaseApplication",
+    "underscore_application",
+    "application.with.dots",
+    "`",
+    "app name",  # space
+    "app\n",  # trailing newline
+    "a" * (MAX_NAME_LENGTH + 1),  # too long
+]
+
+
+class TestNamePattern(unittest.TestCase):
+    def test_equivalent_to_controller_pattern(self):
+        for name in VALID_NAMES + INVALID_NAMES:
+            with self.subTest(name=name):
+                # Java's Matcher.matches() requires the whole input to be consumed,
+                # which fullmatch replicates.
+                expected = CONTROLLER_PATTERN.fullmatch(name) is not None
+                actual = True
+                try:
+                    validate_tenant_name(name)
+                except ValueError:
+                    actual = False
+                self.assertEqual(expected, actual)
+
+
+class TestValidateTenantName(unittest.TestCase):
+    def test_valid(self):
+        for name in VALID_NAMES:
+            with self.subTest(name=name):
+                self.assertEqual(validate_tenant_name(name), name)
+
+    def test_invalid(self):
+        for name in INVALID_NAMES:
+            with self.subTest(name=name):
+                with self.assertRaises(ValueError):
+                    validate_tenant_name(name)
+
+    def test_reserved(self):
+        for name in ["api", "default"]:
+            with self.subTest(name=name):
+                with self.assertRaises(ValueError) as ctx:
+                    validate_tenant_name(name)
+                self.assertIn("reserved", str(ctx.exception))
+
+    def test_not_a_string(self):
+        with self.assertRaises(TypeError):
+            validate_tenant_name(None)
+
+
+class TestValidateApplicationName(unittest.TestCase):
+    def test_valid(self):
+        for name in VALID_NAMES:
+            with self.subTest(name=name):
+                self.assertEqual(validate_application_name(name), name)
+
+    def test_invalid(self):
+        for name in INVALID_NAMES:
+            with self.subTest(name=name):
+                with self.assertRaises(ValueError):
+                    validate_application_name(name)
+
+    def test_reserved(self):
+        for name in ["api", "default"]:
+            with self.subTest(name=name):
+                with self.assertRaises(ValueError):
+                    validate_application_name(name)
+
+    def test_cannot_be_longer_than_40_characters(self):
+        with self.assertRaises(ValueError):
+            validate_application_name("application-name-longer-than-40-characters")
+
+    def test_legacy_endpoints_limits_length_to_20_characters(self):
+        name = "a" * MAX_NAME_LENGTH_LEGACY
+        self.assertEqual(validate_application_name(name, legacy_endpoints=True), name)
+        with self.assertRaises(ValueError):
+            validate_application_name(
+                "longer-than-20-characters", legacy_endpoints=True
+            )
+        # Without legacy endpoints, the same name is fine.
+        self.assertEqual(
+            validate_application_name("longer-than-20-characters"),
+            "longer-than-20-characters",
+        )
+
+    def test_error_message_states_the_limit(self):
+        with self.assertRaises(ValueError) as ctx:
+            validate_application_name(
+                "longer-than-20-characters", legacy_endpoints=True
+            )
+        self.assertIn("no more than 20 characters", str(ctx.exception))
+        with self.assertRaises(ValueError) as ctx:
+            validate_application_name("a" * 41)
+        self.assertIn("no more than 40 characters", str(ctx.exception))
+
+
+class TestValidateInstanceName(unittest.TestCase):
+    def test_valid(self):
+        for name in VALID_NAMES:
+            with self.subTest(name=name):
+                self.assertEqual(validate_instance_name(name), name)
+
+    def test_invalid(self):
+        for name in INVALID_NAMES:
+            with self.subTest(name=name):
+                with self.assertRaises(ValueError):
+                    validate_instance_name(name)
+
+    def test_default_is_allowed(self):
+        # InstanceId extends SerializedIdentifier, not NonDefaultIdentifier, and
+        # 'default' is the default instance name in Vespa Cloud.
+        self.assertEqual(validate_instance_name("default"), "default")
+
+    def test_api_is_reserved(self):
+        with self.assertRaises(ValueError):
+            validate_instance_name("api")
+
+    def test_tester_suffix_is_reserved(self):
+        with self.assertRaises(ValueError) as ctx:
+            validate_instance_name("myinstance-t")
+        self.assertIn("tester", str(ctx.exception))
+        # A name merely containing '-t' is fine.
+        self.assertEqual(validate_instance_name("my-test"), "my-test")
+
+
+class TestValidateApplicationPackageName(unittest.TestCase):
+    def test_valid(self):
+        for name in VALID_NAMES + ["my_app", "my_app-2", "a_b_c"]:
+            with self.subTest(name=name):
+                self.assertEqual(validate_application_package_name(name), name)
+
+    def test_invalid(self):
+        for name in [
+            "",
+            "2fast",  # does not start with a letter
+            "-app",  # leading dash
+            "_app",  # leading underscore
+            "My_App",  # uppercase
+            "app.with.dots",
+            "app name",  # space
+            "app\n",  # trailing newline
+            "a" * (MAX_NAME_LENGTH + 1),  # too long
+        ]:
+            with self.subTest(name=name):
+                with self.assertRaises(ValueError):
+                    validate_application_package_name(name)
+
+    def test_cloud_rules_do_not_apply(self):
+        # An application package name is not a Vespa Cloud name, so the reserved names
+        # and the no-double-dash and no-trailing-dash rules do not apply.
+        for name in ["api", "default", "my--app", "my-app-"]:
+            with self.subTest(name=name):
+                self.assertEqual(validate_application_package_name(name), name)
+
+    def test_derived_names_are_valid(self):
+        # Whatever is accepted must yield a valid schema name and cluster ids.
+        vespa_identifier = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*")
+        ncname = re.compile(r"[a-zA-Z_][a-zA-Z0-9_.\-]*")
+        for name in VALID_NAMES + ["my_app", "my--app", "my-app-", "api"]:
+            with self.subTest(name=name):
+                self.assertTrue(vespa_identifier.fullmatch(to_vespa_identifier(name)))
+                for cluster_id in (f"{name}_container", f"{name}_content"):
+                    self.assertTrue(ncname.fullmatch(cluster_id))
+
+
+class TestValidateCloudNames(unittest.TestCase):
+    def test_all_valid(self):
+        validate_cloud_names(
+            tenant="my-tenant", application="my-app", instance="default"
+        )
+
+    def test_none_is_not_validated(self):
+        validate_cloud_names()
+        validate_cloud_names(tenant="my-tenant")
+
+    def test_reports_which_name_is_invalid(self):
+        with self.assertRaises(ValueError) as ctx:
+            validate_cloud_names(tenant="my-tenant", application="my--app")
+        self.assertIn("application", str(ctx.exception))
+        with self.assertRaises(ValueError) as ctx:
+            validate_cloud_names(tenant="My-Tenant")
+        self.assertIn("tenant", str(ctx.exception))
+
+    def test_legacy_endpoints_applies_to_application_only(self):
+        long_name = "longer-than-20-characters"
+        with self.assertRaises(ValueError):
+            validate_cloud_names(application=long_name, legacy_endpoints=True)
+        # Tenant and instance names are never restricted to 20 characters.
+        validate_cloud_names(
+            tenant=long_name, instance=long_name, legacy_endpoints=True
+        )
+
+
+class TestToVespaIdentifier(unittest.TestCase):
+    def test_dashes_become_underscores(self):
+        self.assertEqual(to_vespa_identifier("my-app"), "my_app")
+        self.assertEqual(to_vespa_identifier("myapp"), "myapp")
+        self.assertEqual(to_vespa_identifier("my-search-app"), "my_search_app")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vespa/deployment.py
+++ b/vespa/deployment.py
@@ -34,6 +34,7 @@ from cryptography.hazmat.primitives.asymmetric import ec
 
 from vespa.application import Vespa
 from vespa.package import ApplicationPackage, AuthClient, Parameter
+from vespa.validation import validate_cloud_names, validate_instance_name
 import vespa
 
 # Get the Vespa home directory
@@ -584,8 +585,10 @@ class VespaCloud(VespaDeployment):
             ```
 
         Args:
-            tenant (str): Tenant name registered in the Vespa Cloud.
-            application (str): Application name in the Vespa Cloud.
+            tenant (str): Tenant name registered in the Vespa Cloud. Must start with a lowercase letter,
+                may only contain lowercase letters, digits and dashes, may not contain double-dashes, may
+                not end with a dash, and may contain no more than 40 characters.
+            application (str): Application name in the Vespa Cloud. Same naming rules as for the tenant.
             application_package (ApplicationPackage): Application package to be deployed. Either this or application_root must be set.
             key_location (str, optional): Location of the control plane key used for signing HTTP requests to the Vespa Cloud.
             key_content (str, optional): Content of the control plane key used for signing HTTP requests to the Vespa Cloud. Use only when the key file is not available.
@@ -593,14 +596,18 @@ class VespaCloud(VespaDeployment):
             output_file (str, optional): Output file to write output messages. Default is sys.stdout.
             application_root (str, optional): Directory for the application root (location of services.xml, models/, schemas/, etc.). If the application is packaged with Maven, use the generated `<myapp>/target/application` directory.
             cluster (str, optional): Name of the cluster to target when retrieving endpoints. This affects which endpoints are used for initializing the :class:`Vespa` instance in `VespaCloud.get_application` and `VespaCloud.deploy`.
-            instance (str, optional): Name of the application instance. Default is "default".
+            instance (str, optional): Name of the application instance. Same naming rules as for the tenant,
+                except that "default" is allowed, while names ending in "-t" are reserved for tester
+                instances. Default is "default".
 
         Raises:
             RuntimeError: If deployment fails.
+            ValueError: If the tenant, application or instance name is invalid.
 
         Returns:
             Vespa: A Vespa connection instance for interacting with the deployed application.
         """
+        validate_cloud_names(tenant=tenant, application=application, instance=instance)
         self.tenant = tenant
         self.application = application
         self.application_package = application_package
@@ -728,6 +735,7 @@ class VespaCloud(VespaDeployment):
             raise ValueError(
                 f"Invalid environment: {environment}. Must be 'dev' or 'perf'."
             )
+        validate_instance_name(instance or self.instance)
         if environment == "dev":
             self._ensure_vault_access_for_dev()
         if self.application_package is not None:
@@ -789,6 +797,7 @@ class VespaCloud(VespaDeployment):
             RuntimeError: If deployment fails or if there are issues with the deployment process.
 
         """
+        validate_instance_name(instance or self.instance)
         if application_root is None:
             if self.application_root is None:
                 application_root = os.path.join(os.getcwd(), self.application)
@@ -1118,6 +1127,7 @@ class VespaCloud(VespaDeployment):
             Vespa: A Vespa connection instance. This connects to the mtls endpoint. To connect to the token endpoint, use `VespaCloud.get_application(endpoint_type="token")`.
         """
 
+        validate_instance_name(instance or self.instance)
         if environment == "dev":
             self._ensure_vault_access_for_dev(application_root=str(application_root))
 

--- a/vespa/package.py
+++ b/vespa/package.py
@@ -28,6 +28,7 @@ from vespa.configuration.services import services
 from vespa.configuration.services import *
 from vespa.configuration.deployment import DeploymentItem
 from vespa.configuration.query_profiles import QueryProfileItem
+from vespa.validation import to_vespa_identifier, validate_application_package_name
 
 if sys.version_info >= (3, 11):
     from typing import Unpack
@@ -3113,7 +3114,11 @@ class ApplicationPackage(object):
         p = Path(dest)
         # On Windows, Path("/foo").is_absolute() is False (drive-relative), so also
         # check for a leading "/" to catch POSIX-style absolute paths on all platforms.
-        if PurePosixPath(p).is_absolute() or PureWindowsPath(p).is_absolute() or str(dest).startswith("/"):
+        if (
+            PurePosixPath(p).is_absolute()
+            or PureWindowsPath(p).is_absolute()
+            or str(dest).startswith("/")
+        ):
             raise ValueError(
                 f"include_files: destination path '{dest}' must be relative, not absolute"
             )
@@ -3123,9 +3128,7 @@ class ApplicationPackage(object):
             )
         posix = p.as_posix()
         if not posix or posix == ".":
-            raise ValueError(
-                f"include_files: destination path '{dest}' is empty"
-            )
+            raise ValueError(f"include_files: destination path '{dest}' is empty")
         return posix
 
     def __init__(
@@ -3145,16 +3148,18 @@ class ApplicationPackage(object):
         deployment_config: Optional[Union[DeploymentConfiguration, VT]] = None,
         services_config: Optional[ServicesConfiguration] = None,
         query_profile_config: Optional[Union[VT, List[VT]]] = None,
-        include_files: Optional[
-            List[Tuple[Union[str, Path], Union[str, Path]]]
-        ] = None,
+        include_files: Optional[List[Tuple[Union[str, Path], Union[str, Path]]]] = None,
     ) -> None:
         """Create an application package.
 
         Args:
-            name (str): Application name. Cannot contain '-' or '_'.
+            name (str): Application name. Must start with a lowercase letter, may only contain lowercase
+                letters, digits, underscores and dashes, and may contain no more than 40 characters. Note
+                that this is not the Vespa Cloud application name, which is given to `VespaCloud` and is
+                subject to stricter rules (no underscores).
             schema (list, optional): List of Schema objects for the application. If None, a default Schema
-                with the same name as the application will be created. Defaults to None.
+                with the same name as the application will be created, with any dashes replaced by
+                underscores, as schema names cannot contain dashes. Defaults to None.
             query_profile (QueryProfile, optional): QueryProfile of the application. If None, a default
                 QueryProfile with QueryProfileType 'root' will be created. Defaults to None.
             query_profile_type (QueryProfileType, optional): QueryProfileType of the application. If None,
@@ -3190,18 +3195,12 @@ class ApplicationPackage(object):
             ```
         This creates a default Schema, QueryProfile, and QueryProfileType, which can be populated with your application's specifics.
         """
-        if not (
-            name[0].isalpha() and name.islower() and len(name) <= 20 and name.isalnum()
-        ):
-            raise ValueError(
-                "Application package name must start with a letter, must be lowercase, can only contain [a-z0-9], and may contain no more than 20 characters, was '{}'".format(
-                    name
-                )
-            )
+        validate_application_package_name(name)
         self.name = name
         if not schema:
             schema = (
-                [Schema(name=self.name, document=Document())]
+                # Schema names are Vespa identifiers, which cannot contain dashes.
+                [Schema(name=to_vespa_identifier(self.name), document=Document())]
                 if create_schema_by_default
                 else []
             )

--- a/vespa/validation.py
+++ b/vespa/validation.py
@@ -1,0 +1,287 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+"""Validation of Vespa Cloud names for tenant, application and instance, and of the
+name of an application package.
+
+The Vespa Cloud rules implemented here mirror the ones enforced by the controller in
+``com.yahoo.vespa.hosted.controller.api.identifiers`` (``Identifier``, ``TenantId``,
+``ApplicationId`` and ``InstanceId``):
+
+* Must start with a lowercase letter.
+* May only contain lowercase letters, digits and dashes.
+* No double-dashes, and may not end with a dash.
+* At most 40 characters (20 if the tenant still supports legacy endpoints).
+* ``api`` is reserved for all three, and ``default`` is reserved for tenant and
+  application names (but is the default instance name, hence allowed for instances).
+* Instance names ending in ``-t`` are reserved for tester instances.
+
+The controller expresses the character rules as ``^(?=.{1,40}$)[a-z](-?[a-z0-9]+)*$``.
+:data:`NAME_PATTERN` is an equivalent, but unambiguous, formulation of the same
+language, with the length check done separately to avoid the exponential backtracking
+that the nested quantifiers of the original would allow.
+
+These rules apply to names that are given to Vespa Cloud. The name of an application
+package is a separate, more permissive thing — see
+:func:`validate_application_package_name`.
+"""
+
+import re
+from typing import Iterable, Optional
+
+# Note: The legacy limit of 20 characters is due to level 7 routing endpoint hostnames
+# being 'cluster--application--tenant', which can be at most 63 characters. It is only
+# relevant for tenants and applications listed in the endpoint-config feature flag.
+MAX_NAME_LENGTH: int = 40
+MAX_NAME_LENGTH_LEGACY: int = 20
+
+#: Equivalent to the controller's ``[a-z](-?[a-z0-9]+)*``, without the length check.
+NAME_PATTERN = re.compile(r"[a-z][a-z0-9]*(-[a-z0-9]+)*")
+
+#: Application package names, which are not subject to the Vespa Cloud rules. See
+#: :func:`validate_application_package_name`.
+PACKAGE_NAME_PATTERN = re.compile(r"[a-z][a-z0-9_-]*")
+
+#: Reserved for the Vespa Cloud API, and therefore not a valid name of anything.
+RESERVED_API = "api"
+#: Reserved name for tenants and applications. Allowed (and default) for instances.
+RESERVED_DEFAULT = "default"
+#: Suffix reserved for tester instances.
+TESTER_INSTANCE_SUFFIX = "-t"
+
+_CLOUD_RULES = (
+    "must start with a lowercase letter, may only contain lowercase letters, digits "
+    "and dashes, may not contain double-dashes, may not end with a dash, and may "
+    "contain no more than {max_length} characters"
+)
+
+_PACKAGE_RULES = (
+    "must start with a lowercase letter, may only contain lowercase letters, digits, "
+    "underscores and dashes, and may contain no more than {max_length} characters"
+)
+
+
+def _validate_name(
+    name: str,
+    kind: str,
+    pattern: "re.Pattern" = NAME_PATTERN,
+    rules: str = _CLOUD_RULES,
+    max_length: int = MAX_NAME_LENGTH,
+    reserved: Iterable[str] = (RESERVED_API,),
+) -> str:
+    """Validate ``name`` as a name of the given kind.
+
+    Args:
+        name (str): The name to validate.
+        kind (str): What the name names, e.g. ``"tenant"``. Used in error messages.
+        pattern (re.Pattern, optional): Pattern the name must match in full.
+        rules (str, optional): Description of the rules, for error messages.
+        max_length (int, optional): Maximum length of the name. Defaults to 40.
+        reserved (Iterable[str], optional): Names that are not allowed for this kind.
+
+    Returns:
+        str: The validated name, unchanged.
+
+    Raises:
+        TypeError: If ``name`` is not a string.
+        ValueError: If ``name`` is not a valid name of the given kind.
+    """
+    if not isinstance(name, str):
+        raise TypeError(
+            "Invalid {} name: expected a string, got {}.".format(
+                kind, type(name).__name__
+            )
+        )
+    if name in reserved:
+        raise ValueError(
+            "Invalid {kind} name '{name}': '{name}' is reserved.".format(
+                kind=kind, name=name
+            )
+        )
+    if len(name) > max_length or not pattern.fullmatch(name):
+        raise ValueError(
+            "Invalid {kind} name '{name}': {kind} names {rules}.".format(
+                kind=kind, name=name, rules=rules.format(max_length=max_length)
+            )
+        )
+    return name
+
+
+def validate_tenant_name(name: str) -> str:
+    """Validate a Vespa Cloud tenant name.
+
+    Args:
+        name (str): The tenant name to validate.
+
+    Returns:
+        str: The validated tenant name, unchanged.
+
+    Raises:
+        ValueError: If the name is not a valid tenant name.
+
+    Example:
+        ```python
+        from vespa.validation import validate_tenant_name
+
+        validate_tenant_name("my-tenant")
+        'my-tenant'
+        ```
+    """
+    return _validate_name(name, "tenant", reserved=(RESERVED_API, RESERVED_DEFAULT))
+
+
+def validate_application_name(name: str, legacy_endpoints: bool = False) -> str:
+    """Validate a Vespa Cloud application name.
+
+    Args:
+        name (str): The application name to validate.
+        legacy_endpoints (bool, optional): Set to True if the tenant still supports
+            legacy (level 7 routing) endpoints, in which case the name may contain no
+            more than 20 characters. Defaults to False.
+
+    Returns:
+        str: The validated application name, unchanged.
+
+    Raises:
+        ValueError: If the name is not a valid application name.
+
+    Example:
+        ```python
+        from vespa.validation import validate_application_name
+
+        validate_application_name("my-app")
+        'my-app'
+        ```
+    """
+    return _validate_name(
+        name,
+        "application",
+        max_length=MAX_NAME_LENGTH_LEGACY if legacy_endpoints else MAX_NAME_LENGTH,
+        reserved=(RESERVED_API, RESERVED_DEFAULT),
+    )
+
+
+def validate_instance_name(name: str) -> str:
+    """Validate a Vespa Cloud application instance name.
+
+    Note that ``default`` is a valid instance name, and that instance names ending in
+    ``-t`` are reserved for tester instances.
+
+    Args:
+        name (str): The instance name to validate.
+
+    Returns:
+        str: The validated instance name, unchanged.
+
+    Raises:
+        ValueError: If the name is not a valid instance name.
+
+    Example:
+        ```python
+        from vespa.validation import validate_instance_name
+
+        validate_instance_name("default")
+        'default'
+        ```
+    """
+    _validate_name(name, "instance")
+    if name.endswith(TESTER_INSTANCE_SUFFIX):
+        raise ValueError(
+            "Invalid instance name '{}': instance names ending in '{}' are reserved "
+            "for tester instances.".format(name, TESTER_INSTANCE_SUFFIX)
+        )
+    return name
+
+
+def validate_application_package_name(name: str) -> str:
+    """Validate the name of an :class:`vespa.package.ApplicationPackage`.
+
+    An application package name is not a Vespa Cloud application name — the Vespa Cloud
+    tenant, application and instance names are given to :class:`vespa.deployment.VespaCloud`
+    separately, and validated there — so the Vespa Cloud rules deliberately do not apply
+    here, and self-hosted applications are free to use underscores. The name must,
+    however, be usable for what pyvespa derives from it:
+
+    * The default schema name, which is a Vespa identifier (``[a-zA-Z_][a-zA-Z0-9_]*``)
+      once dashes are replaced by underscores, hence the leading letter.
+    * The ``<name>_container`` and ``<name>_content`` cluster ids, which are ``xsd:NCName``
+      in services.xml, and which end up verbatim in Vespa Cloud endpoint names (where
+      only underscores are translated, to dashes), hence lowercase only and the length
+      limit.
+    * The Docker container name used by :class:`vespa.deployment.VespaDocker`.
+
+    Args:
+        name (str): The application package name to validate.
+
+    Returns:
+        str: The validated name, unchanged.
+
+    Raises:
+        ValueError: If the name is not a valid application package name.
+
+    Example:
+        ```python
+        from vespa.validation import validate_application_package_name
+
+        validate_application_package_name("my_app")
+        'my_app'
+        ```
+    """
+    return _validate_name(
+        name,
+        "application package",
+        pattern=PACKAGE_NAME_PATTERN,
+        rules=_PACKAGE_RULES,
+        reserved=(),
+    )
+
+
+def to_vespa_identifier(name: str) -> str:
+    """Convert a name to a Vespa identifier.
+
+    Vespa identifiers, such as schema and document type names, may contain underscores
+    but not dashes, so dashes are replaced by underscores. This is the inverse of the
+    controller's ``Identifier.toDns()``.
+
+    Args:
+        name (str): The name to convert.
+
+    Returns:
+        str: The name with dashes replaced by underscores.
+
+    Example:
+        ```python
+        from vespa.validation import to_vespa_identifier
+
+        to_vespa_identifier("my-app")
+        'my_app'
+        ```
+    """
+    return name.replace("-", "_")
+
+
+def validate_cloud_names(
+    tenant: Optional[str] = None,
+    application: Optional[str] = None,
+    instance: Optional[str] = None,
+    legacy_endpoints: bool = False,
+) -> None:
+    """Validate any combination of Vespa Cloud tenant, application and instance names.
+
+    Arguments that are None are not validated.
+
+    Args:
+        tenant (str, optional): Tenant name. Defaults to None.
+        application (str, optional): Application name. Defaults to None.
+        instance (str, optional): Instance name. Defaults to None.
+        legacy_endpoints (bool, optional): Whether the tenant supports legacy endpoints,
+            which limits the application name to 20 characters. Defaults to False.
+
+    Raises:
+        ValueError: If any of the given names is invalid.
+    """
+    if tenant is not None:
+        validate_tenant_name(tenant)
+    if application is not None:
+        validate_application_name(application, legacy_endpoints=legacy_endpoints)
+    if instance is not None:
+        validate_instance_name(instance)


### PR DESCRIPTION
> [!WARNING]
> This code was written by Claude Opus 5, but has been tested and verified by me (@thomasht86).

Correct validation for tenant, app-name and instance as cloud.

The application package name was validated with an ad-hoc rule (`name[0].isalpha() and name.islower() and len(name) <= 20 and name.isalnum()`), and the Vespa Cloud tenant, application and instance names were not validated at all.

The rules were retrieved and verified against `controller-server/src/main/java/com/yahoo/vespa/hosted/controller/api/identifiers/` in the `cloud` repo.

## Vespa Cloud names

New module `vespa/validation.py` implements the controller rules, applied in `VespaCloud` on construction and on `deploy` / `deploy_to_prod` / `deploy_from_disk`:

- Must start with a lowercase letter, may only contain lowercase letters, digits and dashes, no double-dashes, may not end with a dash, 1-40 characters.
- `api` is reserved for all three; `default` for tenant and application only; instance names ending in `-t` are reserved for testers.
- `validate_application_name(..., legacy_endpoints=True)` applies the stricter 20 character limit.

Two details differ from the issue description, both confirmed in the source:

| | pattern | `api` | `default` | other |
|---|---|---|---|---|
| `TenantId` | 40 | rejected | rejected | — |
| `ApplicationId` | 40, or 20 if `legacyEndpointsSupported` | rejected | rejected | — |
| `InstanceId` | 40 (no legacy variant) | rejected | **allowed** | `-t` suffix reserved |

1. **`default` is valid for instances.** `InstanceId extends SerializedIdentifier`, not `NonDefaultIdentifier` (only `TenantId` and `ApplicationId` do), and `default` is the standard instance name in Vespa Cloud.
2. **The legacy 20-char limit is application-only.** `TenantId.validate` and `InstanceId.validate` always use `strictPattern`; only `ApplicationId.validate` takes the `legacyEndpointsSupported` flag. `ApplicationController.withNewInstance` separately rejects instance names ending in `-t`.

The character rules are written as `[a-z][a-z0-9]*(-[a-z0-9]+)*` rather than transcribing the controller's `[a-z](-?[a-z0-9]+)*`. Same language, but the original's nested quantifiers backtrack exponentially in Python on a failing 40-character input. A unit test asserts both patterns accept and reject exactly the same names.

## Application package names

The cloud rules deliberately **do not** apply to `ApplicationPackage(name=...)`, which is not a Vespa Cloud application name — the tenant/application/instance names are passed to `VespaCloud` separately and validated there. Applying them would needlessly force self-hosted users onto cloud naming by rejecting the underscores that are idiomatic in Vespa schema names.

Package names are instead validated against what pyvespa actually derives from them (`[a-z][a-z0-9_-]*`, max 40), which allows underscores and the cloud-reserved `api` / `default`:

- The **default schema name**, a Vespa identifier `[a-zA-Z_][a-zA-Z0-9_]*` per `SchemaParser.jj`, once dashes are replaced by underscores — hence the required leading letter.
- The **`<name>_container` / `<name>_content` cluster ids**, which are `xsd:NCName` in services.xml and end up verbatim in Vespa Cloud endpoint names, where `Endpoint.sanitize` only translates `_` to `-` and does not lowercase — hence lowercase only and the length limit.
- The **Docker container name** used by `VespaDocker`.

Uppercase is not allowed, even though Vespa itself permits it in schema names and NCName cluster ids, because of that non-lowercasing `Endpoint.sanitize`. A test asserts the closure property: everything the package validator accepts yields a valid schema name and valid cluster ids.

| | validated against | underscores | `api` / `default` |
|---|---|---|---|
| `ApplicationPackage(name=...)` | `[a-z][a-z0-9_-]*`, ≤40 | yes | allowed |
| `VespaCloud(tenant=, application=, instance=)` | cloud rules | no | reserved |
| `VespaDocker` | nothing beyond the package name | yes | allowed |

## Behaviour changes

- `ApplicationPackage(name="my-app")` and `name="my_app"` are now accepted (both were rejected before). A dashed package name gets a default schema named with underscores (`my-app` -> schema `my_app`), since schema names cannot contain dashes.
- Application package names may now be up to 40 characters, was 20.
- A pre-existing Vespa Cloud tenant or application whose name contains underscores now raises in `VespaCloud`. The controller enforces `strictPattern` only at creation time, so such names can exist — but deploying to them would have failed anyway.
- `tests/unit/test_deployment.py` fixtures renamed from `test_tenant` / `test_app` to `test-tenant` / `test-app`, which the new rules require.

## Testing

- New `tests/unit/test_validation.py`, plus extended `TestValidAppName`.
- 709 unit + mktestdocs tests pass; `ruff check` clean.
- Integration tests not run (need Docker/Cloud credentials), but every tenant/application/instance literal in `tests/integration/` was checked against the new rules and is valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
