### PR TITLE
chore: accept httpr client in asyncio context

### DIFF
--- a/vespa/application.py
+++ b/vespa/application.py
@@ -332,7 +332,7 @@ class Vespa(object):
         connections: Optional[int] = 1,
         total_timeout: Optional[int] = None,
         timeout: Union[httpx.Timeout, int, float] = 30.0,
-        client: Optional[httpx.AsyncClient] = None,
+        client: Optional[Union[httpx.AsyncClient, httpr.AsyncClient]] = None,
         **kwargs,
     ) -> "VespaAsync":
         """
@@ -356,7 +356,7 @@ class Vespa(object):
             total_timeout (int, optional): Deprecated. Will be ignored. Use timeout instead.
             timeout (float | int | httpx.Timeout, optional): Timeout in seconds. Defaults to 30.0.
                 httpx.Timeout is deprecated but still supported for backward compatibility.
-            client (httpx.AsyncClient, optional): Reusable httpx.AsyncClient to use instead of creating a new
+            client (httpx.AsyncClient | httpr.AsyncClient, optional): Reusable httpx.AsyncClient to use instead of creating a new
                 one. When provided, the caller is responsible for closing the client.
             **kwargs (dict, optional): Additional arguments to be passed to the httpx.AsyncClient.
 


### PR DESCRIPTION
Extremely simple change to fix the typings of the `asyncio` context builder to accept a `httpr` client too. That is what the underline `VespaAsync` init accepts so it is perfectly compatible without additional changes.


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
