### PR TITLE
feat: accept retry policies in async query

### DIFF
--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -25,6 +25,7 @@ from tenacity import (
     RetryError,
     wait_none,
     stop_after_attempt,
+    retry_if_result,
 )
 
 
@@ -1226,6 +1227,52 @@ class TestVespaAsyncQuery:
                 await vespa_async.query(body={"yql": "x"}, retry_policy=policy)
 
         assert vespa_async._make_request.await_count == attempts
+
+    async def test_query_retries_if_result_uses_vespa_response(self):
+        app = Vespa(url="http://localhost", port=8080)
+        vespa_async = VespaAsync(app)
+        vespa_async._make_request = AsyncMock(
+            side_effect=[
+                create_mock_httpr_response(
+                    status_code=200,
+                    json_data={"root": {}},
+                    url="http://localhost:8080/search/",
+                ),
+                create_mock_httpr_response(
+                    status_code=200,
+                    json_data={"root": {"children": ["one"]}},
+                    url="http://localhost:8080/search/",
+                ),
+            ]
+        )
+
+        policy = AsyncRetrying(
+            wait=wait_none(),
+            stop=stop_after_attempt(2),
+            retry=retry_if_result(lambda r: not r.hits),
+        )
+
+        result = await vespa_async.query(body={"yql": "x"}, retry_policy=policy)
+
+        assert vespa_async._make_request.await_count == 2
+        assert len(result.hits) == 1
+
+    async def test_query_honours_retry_error_callback(self):
+        """A policy with retry_error_callback should return the callback's value."""
+        app = Vespa(url="http://localhost", port=8080)
+        vespa_async = VespaAsync(app)
+        vespa_async._make_request = AsyncMock(side_effect=RuntimeError("fail"))
+
+        policy = AsyncRetrying(
+            wait=wait_none(),
+            stop=stop_after_attempt(2),
+            retry_error_callback=lambda _: "fallback",
+        )
+
+        result = await vespa_async.query(body={"yql": "x"}, retry_policy=policy)
+
+        assert result == "fallback"
+        assert vespa_async._make_request.await_count == 2
 
 
 class TestVespaSyncStreaming(unittest.TestCase):

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -1205,7 +1205,7 @@ class TestVespaAsyncQuery:
 
         r = await vespa_async.query(
             body={"yql": "select * from sources * where true"},
-            retry=AsyncRetrying(wait=wait_none(), stop=stop_after_attempt(3)),
+            retry_policy=AsyncRetrying(wait=wait_none(), stop=stop_after_attempt(3)),
         )
 
         assert isinstance(r, VespaQueryResponse)
@@ -1223,7 +1223,7 @@ class TestVespaAsyncQuery:
 
         with patch("tenacity.asyncio._portable_async_sleep", new=AsyncMock()):
             with pytest.raises(RetryError):
-                await vespa_async.query(body={"yql": "x"}, retry=policy)
+                await vespa_async.query(body={"yql": "x"}, retry_policy=policy)
 
         assert vespa_async._make_request.await_count == attempts
 

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -1211,7 +1211,7 @@ class TestVespaAsyncQuery:
 
         assert isinstance(r, VespaQueryResponse)
         assert r.status_code == 200
-        vespa_async._make_request.await_count == 2
+        assert vespa_async._make_request.await_count == 2
 
     @pytest.mark.parametrize(
         "policy,attempts",

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -20,6 +20,12 @@ from vespa.application import (
 )
 import httpx
 from typing import List
+from tenacity import (
+    AsyncRetrying,
+    RetryError,
+    wait_none,
+    stop_after_attempt,
+)
 
 
 def create_mock_httpr_response(status_code=200, json_data=None, text="{}", url=""):
@@ -1182,6 +1188,44 @@ class TestVespaAsyncDataMethods:
 
         assert r.json == {"message": "Internal Server Error"}
         assert r.status_code == 500
+
+
+@pytest.mark.asyncio
+class TestVespaAsyncQuery:
+    async def test_query_retries(self):
+        app = Vespa(url="http://localhost", port=8080)
+        vespa_async = VespaAsync(app)
+
+        success = create_mock_httpr_response(
+            status_code=200, json_data={"root": {}}, url="http://localhost:8080/search/"
+        )
+        vespa_async._make_request = AsyncMock(
+            side_effect=[RuntimeError("fail"), success]
+        )
+
+        r = await vespa_async.query(
+            body={"yql": "select * from sources * where true"},
+            retry=AsyncRetrying(wait=wait_none(), stop=stop_after_attempt(3)),
+        )
+
+        assert isinstance(r, VespaQueryResponse)
+        assert r.status_code == 200
+        vespa_async._make_request.await_count == 2
+
+    @pytest.mark.parametrize(
+        "policy,attempts",
+        [(AsyncRetrying(wait=wait_none(), stop=stop_after_attempt(2)), 2), (None, 5)],
+    )
+    async def test_query_exhausts_retries(self, policy, attempts):
+        app = Vespa(url="http://localhost", port=8080)
+        vespa_async = VespaAsync(app)
+        vespa_async._make_request = AsyncMock(side_effect=RuntimeError("fail"))
+
+        with patch("tenacity.asyncio._portable_async_sleep", new=AsyncMock()):
+            with pytest.raises(RetryError):
+                await vespa_async.query(body={"yql": "x"}, retry=policy)
+
+        assert vespa_async._make_request.await_count == attempts
 
 
 class TestVespaSyncStreaming(unittest.TestCase):

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -2323,26 +2323,21 @@ class VespaAsync(object):
             )
         )
 
-        async for attempt in retry_policy:
-            with attempt:
-                response = await self._make_request(
-                    "POST",
-                    self.app.search_end_point,
-                    json_data=body,
-                    params=kwargs,
-                    headers={"Accept": "application/cbor"},
-                )
+        async def _do_query() -> VespaQueryResponse:
+            response = await self._make_request(
+                "POST",
+                self.app.search_end_point,
+                json_data=body,
+                params=kwargs,
+                headers={"Accept": "application/cbor"},
+            )
+            return VespaQueryResponse(
+                json=_response_json(response),
+                status_code=response.status_code,
+                url=str(response.url),
+            )
 
-                query_response = VespaQueryResponse(
-                    json=_response_json(response),
-                    status_code=response.status_code,
-                    url=str(response.url),
-                )
-
-            if not attempt.retry_state.outcome.failed:
-                attempt.retry_state.set_result(query_response)
-
-        return query_response
+        return await retry_policy(_do_query)
 
     @retry(
         wait=wait_exponential(multiplier=1),

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -15,6 +15,7 @@ from requests import Session
 from requests.models import Response
 from requests.exceptions import ConnectionError, HTTPError, JSONDecodeError
 from tenacity import (
+    AsyncRetrying,
     retry,
     wait_exponential,
     wait_random_exponential,
@@ -2284,14 +2285,12 @@ class VespaAsync(object):
             raise state.outcome.exception()
         return state.outcome.result()
 
-    @retry(
-        wait=wait_random_exponential(multiplier=1.5, max=60), stop=stop_after_attempt(5)
-    )
     async def query(
         self,
         body: Optional[Dict] = None,
         groupname: Optional[str] = None,
         profile: bool = False,
+        retry: Optional[AsyncRetrying] = None,
         **kwargs,
     ) -> VespaQueryResponse:
         """
@@ -2301,29 +2300,49 @@ class VespaAsync(object):
             body (dict): Dict containing all the request parameters.
             groupname (str, optional): The groupname used in streaming search.
             profile (bool, optional): Add profiling parameters to the query (response may be large). Defaults to False.
+            retry (AsyncRetrying, optional): Custom tenacity retry policy. Defaults to five attempts with random exponential wait time.
             **kwargs (dict, optional): Additional valid Vespa HTTP Query API parameters.
 
         Returns:
             VespaQueryResponse: The response from the query.
+
+        Raises:
+            RetryError: When all retries have failed, unless a custom policy with reraise is passed.
         """
         if groupname:
             kwargs["streaming.groupname"] = groupname
         if profile:
             kwargs.update(get_profiling_params())
 
-        response = await self._make_request(
-            "POST",
-            self.app.search_end_point,
-            json_data=body,
-            params=kwargs,
-            headers={"Accept": "application/cbor"},
+        retry = (
+            retry.copy()
+            if retry
+            else AsyncRetrying(
+                wait=wait_random_exponential(multiplier=1.5, max=60),
+                stop=stop_after_attempt(5),
+            )
         )
 
-        return VespaQueryResponse(
-            json=_response_json(response),
-            status_code=response.status_code,
-            url=str(response.url),
-        )
+        async for attempt in retry:
+            with attempt:
+                response = await self._make_request(
+                    "POST",
+                    self.app.search_end_point,
+                    json_data=body,
+                    params=kwargs,
+                    headers={"Accept": "application/cbor"},
+                )
+
+                query_response = VespaQueryResponse(
+                    json=_response_json(response),
+                    status_code=response.status_code,
+                    url=str(response.url),
+                )
+
+            if not attempt.retry_state.outcome.failed:
+                attempt.retry_state.set_result(query_response)
+
+        return query_response
 
     @retry(
         wait=wait_exponential(multiplier=1),

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -2290,7 +2290,7 @@ class VespaAsync(object):
         body: Optional[Dict] = None,
         groupname: Optional[str] = None,
         profile: bool = False,
-        retry: Optional[AsyncRetrying] = None,
+        retry_policy: Optional[AsyncRetrying] = None,
         **kwargs,
     ) -> VespaQueryResponse:
         """
@@ -2300,7 +2300,7 @@ class VespaAsync(object):
             body (dict): Dict containing all the request parameters.
             groupname (str, optional): The groupname used in streaming search.
             profile (bool, optional): Add profiling parameters to the query (response may be large). Defaults to False.
-            retry (AsyncRetrying, optional): Custom tenacity retry policy. Defaults to five attempts with random exponential wait time.
+            retry_policy (AsyncRetrying, optional): Custom tenacity retry policy. Defaults to five attempts with random exponential wait time.
             **kwargs (dict, optional): Additional valid Vespa HTTP Query API parameters.
 
         Returns:
@@ -2314,16 +2314,16 @@ class VespaAsync(object):
         if profile:
             kwargs.update(get_profiling_params())
 
-        retry = (
-            retry.copy()
-            if retry
+        retry_policy = (
+            retry_policy.copy()
+            if retry_policy
             else AsyncRetrying(
                 wait=wait_random_exponential(multiplier=1.5, max=60),
                 stop=stop_after_attempt(5),
             )
         )
 
-        async for attempt in retry:
+        async for attempt in retry_policy:
             with attempt:
                 response = await self._make_request(
                     "POST",


### PR DESCRIPTION
As we discussed in Friday's catch-up @thomasht86 .

Here's the little PR to support configurable retries in `AsyncVespa.query` using [tenacity's retrying blocks](https://tenacity.readthedocs.io/en/latest/#retrying-code-block). The same approach could be followed for the rest of methods with the `@retry` decorator (and for the sync request with retry), but for now I kept the PR contained only on this one for faster delivery and discussion. I could help to complete the migration to this style for the rest of methods in the future.

This new version works exactly the same as the old one, with the additional overriding capabilities. Same default retry and all.

---

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
