### PR TITLE
refactor: define all retry strategies once in vespa.retries (#1344)

### DIFF
--- a/docs/sphinx/source/api/summary.md
+++ b/docs/sphinx/source/api/summary.md
@@ -10,4 +10,5 @@
             * [builder](vespa/querybuilder/builder/builder.md)
         * [grouping](vespa/querybuilder/grouping/index.md)
             * [grouping](vespa/querybuilder/grouping/grouping.md)
+    * [retries](vespa/retries.md)
     * [validation](vespa/validation.md)

--- a/docs/sphinx/source/api/vespa/retries.md
+++ b/docs/sphinx/source/api/vespa/retries.md
@@ -1,0 +1,1 @@
+::: vespa.retries

--- a/docs/sphinx/source/query.ipynb
+++ b/docs/sphinx/source/query.ipynb
@@ -1096,8 +1096,9 @@
             "source": [
                 "## Error handling\n",
                 "\n",
-                "Vespa's default query timeout is 500ms; Pyvespa will by default retry up to 3 times for queries\n",
-                "that return response codes like 429, 500,503 and 504. A `VespaError` is raised if retries did not end up with success. In the following\n",
+                "Vespa's default query timeout is 500ms. Pyvespa retries a query that gets a 429 (too many requests)\n",
+                "response or a connection error up to 10 times with exponential backoff; other error responses are not retried. The retry policies\n",
+                "are defined in `vespa.retries`. A `VespaError` is raised if the final response is an error. In the following\n",
                 "example, we set a very low [timeout](https://docs.vespa.ai/en/reference/query-api-reference.html#timeout) of `1ms` which will cause\n",
                 "Vespa to time out the request, and it returns a 504 http error code. The underlying error is wrapped in a `VespaError` with\n",
                 "the payload error message returned from Vespa:\n"

--- a/docs/sphinx/source/reference-api.rst
+++ b/docs/sphinx/source/reference-api.rst
@@ -79,6 +79,15 @@ vespa.querybuilder
    :special-members: __init__
    :show-inheritance:
 
+#############
+vespa.retries
+#############
+
+.. automodule:: vespa.retries
+   :members:
+   :undoc-members:
+
+
 ################
 vespa.exceptions
 ################

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -27,6 +27,7 @@ from tenacity import (
     stop_after_attempt,
     retry_if_result,
 )
+from vespa.retries import QUERY_RETRY
 
 
 def create_mock_httpr_response(status_code=200, json_data=None, text="{}", url=""):
@@ -1222,7 +1223,10 @@ class TestVespaAsyncQuery:
         vespa_async = VespaAsync(app)
         vespa_async._make_request = AsyncMock(side_effect=RuntimeError("fail"))
 
-        with patch("tenacity.asyncio._portable_async_sleep", new=AsyncMock()):
+        # Neutralise the default policy's waits by patching the module-level
+        # constant at its point of use; the policy is copied per call.
+        no_wait_default = QUERY_RETRY.copy(wait=wait_none())
+        with patch("vespa.application.QUERY_RETRY", no_wait_default):
             with pytest.raises(RetryError):
                 await vespa_async.query(body={"yql": "x"}, retry_policy=policy)
 

--- a/tests/unit/test_retries.py
+++ b/tests/unit/test_retries.py
@@ -19,6 +19,7 @@ from tenacity import (
     stop_after_attempt,
     stop_never,
     wait_none,
+    wait_random_exponential,
 )
 from tenacity.stop import stop_after_attempt as _stop_after_attempt_cls
 
@@ -82,10 +83,12 @@ class TestPolicyDefinitions:
         # Explicit decision, see the THROTTLE_RETRY docstring in vespa.retries.
         assert THROTTLE_RETRY.stop is stop_never
 
-    def test_all_docv1_methods_share_one_throttle_wait(self):
-        # feed_data_point used to have a different 429 wait than its siblings.
-        # There is now a single THROTTLE_RETRY, so this is a structural guarantee;
-        # assert its parameters so a silent change is noticed.
+    def test_throttle_retry_uses_jittered_backoff(self):
+        # All four docv1 methods share THROTTLE_RETRY. The wait must stay
+        # randomised so concurrent tasks that hit 429 together do not retry in
+        # lockstep (see review on #1346); assert type and cap so a silent
+        # change is noticed.
+        assert isinstance(THROTTLE_RETRY.wait, wait_random_exponential)
         assert THROTTLE_RETRY.wait.multiplier == 1
         assert THROTTLE_RETRY.wait.max == 10
 

--- a/tests/unit/test_retries.py
+++ b/tests/unit/test_retries.py
@@ -1,0 +1,275 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+"""
+Tests for vespa.retries and the call sites that use it.
+
+Waits are neutralised by patching the module-level policy constants at their
+point of use with ``POLICY.copy(wait=wait_none())``. Because every call site
+copies the policy before invoking it, this is safe and needs no tenacity internals.
+"""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpr
+import pytest
+from requests.exceptions import HTTPError
+from tenacity import (
+    AsyncRetrying,
+    Retrying,
+    stop_after_attempt,
+    stop_never,
+    wait_none,
+)
+from tenacity.stop import stop_after_attempt as _stop_after_attempt_cls
+
+from vespa import retries
+from vespa.application import Vespa, VespaAsync, VespaSync
+from vespa.io import VespaResponse
+from vespa.retries import (
+    CONTROL_PLANE_RETRY,
+    DOCV1_RETRY,
+    QUERY_RETRY,
+    SYNC_REQUEST_RETRY,
+    THROTTLE_RETRY,
+    URL_VALIDATION_RETRY,
+    VISIT_RETRY,
+    is_connection_error,
+    retry_if_status,
+    wait_golden_jitter,
+)
+
+
+def _httpr_response(status_code: int, json_data=None) -> Mock:
+    response = Mock(spec=httpr.Response)
+    response.status_code = status_code
+    response.json.return_value = json_data if json_data is not None else {}
+    response.text = "{}"
+    response.url = "http://localhost:8080/"
+    response.headers = {}
+    return response
+
+
+class TestPolicyDefinitions:
+    """The documented shape of each policy, so drift is caught by a test."""
+
+    def test_async_policies_are_async(self):
+        for policy in (QUERY_RETRY, DOCV1_RETRY, THROTTLE_RETRY):
+            assert isinstance(policy, AsyncRetrying)
+
+    def test_sync_policies_are_sync(self):
+        for policy in (
+            SYNC_REQUEST_RETRY,
+            VISIT_RETRY,
+            CONTROL_PLANE_RETRY,
+            URL_VALIDATION_RETRY,
+        ):
+            assert isinstance(policy, Retrying)
+
+    def test_bounded_policies_stop_after_attempt(self):
+        expected = {
+            QUERY_RETRY: 5,
+            DOCV1_RETRY: 3,
+            SYNC_REQUEST_RETRY: 11,
+            VISIT_RETRY: 3,
+            CONTROL_PLANE_RETRY: 3,
+            URL_VALIDATION_RETRY: 3,
+        }
+        for policy, attempts in expected.items():
+            assert isinstance(policy.stop, _stop_after_attempt_cls)
+            assert policy.stop.max_attempt_number == attempts
+
+    def test_throttle_retry_is_deliberately_unbounded(self):
+        # Explicit decision, see the THROTTLE_RETRY docstring in vespa.retries.
+        assert THROTTLE_RETRY.stop is stop_never
+
+    def test_all_docv1_methods_share_one_throttle_wait(self):
+        # feed_data_point used to have a different 429 wait than its siblings.
+        # There is now a single THROTTLE_RETRY, so this is a structural guarantee;
+        # assert its parameters so a silent change is noticed.
+        assert THROTTLE_RETRY.wait.multiplier == 1
+        assert THROTTLE_RETRY.wait.max == 10
+
+    def test_public_constants_are_exported(self):
+        for name in retries.__all__:
+            assert hasattr(retries, name)
+
+
+class TestHelpers:
+    def test_retry_if_status_on_vespa_response(self):
+        predicate = retry_if_status(429, 503).predicate
+        assert predicate(
+            VespaResponse(json={}, status_code=429, url="", operation_type="get")
+        )
+        assert predicate(
+            VespaResponse(json={}, status_code=503, url="", operation_type="get")
+        )
+        assert not predicate(
+            VespaResponse(json={}, status_code=200, url="", operation_type="get")
+        )
+
+    def test_retry_if_status_on_httpr_response(self):
+        predicate = retry_if_status(429).predicate
+        assert predicate(_httpr_response(429))
+        assert not predicate(_httpr_response(200))
+
+    def test_wait_golden_jitter_matches_legacy_formula(self):
+        state = Mock()
+        with patch("vespa.retries.random.uniform", return_value=0.0):
+            state.attempt_number = 1
+            assert wait_golden_jitter()(state) == pytest.approx(0.1)
+            state.attempt_number = 4
+            assert wait_golden_jitter()(state) == pytest.approx(0.1 * 1.618**3)
+
+    def test_is_connection_error(self):
+        assert is_connection_error(ConnectionResetError())
+        assert is_connection_error(RuntimeError("error sending request"))
+        assert not is_connection_error(ValueError("bad value"))
+
+
+class TestSyncRequestRetry:
+    """VespaSync._request_with_retry keeps its pre-tenacity behaviour."""
+
+    @pytest.fixture
+    def sync_client(self):
+        app = Vespa(url="http://localhost", port=8080)
+        client = VespaSync(app)
+        client.http_client = Mock()
+        return client
+
+    @pytest.fixture(autouse=True)
+    def no_wait(self):
+        with patch(
+            "vespa.application.SYNC_REQUEST_RETRY",
+            SYNC_REQUEST_RETRY.copy(wait=wait_none()),
+        ):
+            yield
+
+    def test_retries_429_then_returns_success(self, sync_client):
+        sync_client.http_client.get.side_effect = [
+            _httpr_response(429),
+            _httpr_response(429),
+            _httpr_response(200),
+        ]
+        response = sync_client._request_with_retry("GET", "http://x")
+        assert response.status_code == 200
+        assert sync_client.http_client.get.call_count == 3
+
+    def test_returns_last_429_after_num_retries(self, sync_client):
+        sync_client.num_retries_429 = 2
+        sync_client.http_client.get.return_value = _httpr_response(429)
+        response = sync_client._request_with_retry("GET", "http://x")
+        assert response.status_code == 429
+        assert sync_client.http_client.get.call_count == 3  # 1 + num_retries_429
+
+    def test_retries_connection_error_then_reraises(self, sync_client):
+        sync_client.num_retries_429 = 1
+        sync_client.http_client.post.side_effect = ConnectionResetError("reset")
+        with pytest.raises(ConnectionResetError):
+            sync_client._request_with_retry("POST", "http://x", json_data={"a": 1})
+        assert sync_client.http_client.post.call_count == 2
+
+    def test_non_connection_error_raises_immediately(self, sync_client):
+        sync_client.http_client.get.side_effect = ValueError("boom")
+        with pytest.raises(ValueError):
+            sync_client._request_with_retry("GET", "http://x")
+        assert sync_client.http_client.get.call_count == 1
+
+    def test_does_not_retry_5xx(self, sync_client):
+        sync_client.http_client.get.return_value = _httpr_response(503)
+        response = sync_client._request_with_retry("GET", "http://x")
+        assert response.status_code == 503
+        assert sync_client.http_client.get.call_count == 1
+
+
+class TestVisitRetry:
+    def test_visit_policy_retries_http_error_three_times(self):
+        calls = {"n": 0}
+
+        @VISIT_RETRY.wraps
+        def flaky():
+            calls["n"] += 1
+            raise HTTPError("HTTP 500")
+
+        with pytest.raises(Exception):
+            flaky()
+        assert calls["n"] == 3
+
+
+@pytest.mark.asyncio
+class TestAsyncDocv1Retry:
+    """The two-layer docv1 policy behaves like the former stacked decorators."""
+
+    @pytest.fixture
+    def async_client(self):
+        app = Vespa(url="http://localhost", port=8080)
+        return VespaAsync(app)
+
+    @pytest.fixture(autouse=True)
+    def no_wait(self):
+        with (
+            patch("vespa.application.DOCV1_RETRY", DOCV1_RETRY.copy(wait=wait_none())),
+            patch(
+                "vespa.application.THROTTLE_RETRY",
+                THROTTLE_RETRY.copy(wait=wait_none()),
+            ),
+        ):
+            yield
+
+    @pytest.mark.parametrize(
+        "method,kwargs",
+        [
+            ("feed_data_point", {"fields": {"a": 1}}),
+            ("update_data", {"fields": {"a": 1}}),
+            ("get_data", {}),
+            ("delete_data", {}),
+        ],
+    )
+    async def test_retries_429_until_success(self, async_client, method, kwargs):
+        async_client._make_request = AsyncMock(
+            side_effect=[_httpr_response(429)] * 4 + [_httpr_response(200)]
+        )
+        response = await getattr(async_client, method)(
+            schema="s", data_id="1", **kwargs
+        )
+        assert response.status_code == 200
+        assert async_client._make_request.await_count == 5
+
+    async def test_429_retry_is_unbounded(self, async_client):
+        # Well past any small stop bound: 429 must keep retrying until success.
+        async_client._make_request = AsyncMock(
+            side_effect=[_httpr_response(429)] * 25 + [_httpr_response(200)]
+        )
+        response = await async_client.get_data(schema="s", data_id="1")
+        assert response.status_code == 200
+        assert async_client._make_request.await_count == 26
+
+    async def test_503_retried_three_times_then_returned(self, async_client):
+        async_client._make_request = AsyncMock(return_value=_httpr_response(503))
+        response = await async_client.feed_data_point(
+            schema="s", data_id="1", fields={"a": 1}
+        )
+        assert response.status_code == 503
+        assert async_client._make_request.await_count == 3
+
+    async def test_exception_retried_three_times_then_reraised(self, async_client):
+        async_client._make_request = AsyncMock(side_effect=RuntimeError("boom"))
+        with pytest.raises(RuntimeError):
+            await async_client.delete_data(schema="s", data_id="1")
+        assert async_client._make_request.await_count == 3
+
+    async def test_operation_type_and_payload_preserved(self, async_client):
+        async_client._make_request = AsyncMock(return_value=_httpr_response(200))
+        response = await async_client.update_data(
+            schema="s", data_id="1", fields={"a": 1}, create=True
+        )
+        assert response.operation_type == "update"
+        call = async_client._make_request.await_args
+        assert call.args[0] == "PUT"
+        assert call.kwargs["json_data"] == {"fields": {"a": {"assign": 1}}}
+        assert call.kwargs["params"] == {"create": "true"}
+
+    async def test_custom_stop_via_copy(self):
+        # Users can bound the 429 retry themselves by copying the constant.
+        bounded = THROTTLE_RETRY.copy(stop=stop_after_attempt(2), wait=wait_none())
+        assert bounded.stop.max_attempt_number == 2
+        assert THROTTLE_RETRY.stop is stop_never  # original untouched

--- a/vespa/application.py
+++ b/vespa/application.py
@@ -5,7 +5,18 @@ import asyncio
 import traceback
 import concurrent.futures
 import warnings
-from typing import Optional, Dict, Generator, List, IO, Iterable, Callable, Tuple, Union
+from typing import (
+    Any,
+    Optional,
+    Dict,
+    Generator,
+    List,
+    IO,
+    Iterable,
+    Callable,
+    Tuple,
+    Union,
+)
 from concurrent.futures import ThreadPoolExecutor, Future, as_completed
 from queue import Queue, Empty
 import threading
@@ -13,27 +24,22 @@ import httpr
 
 from requests import Session
 from requests.models import Response
-from requests.exceptions import ConnectionError, HTTPError, JSONDecodeError
-from tenacity import (
-    AsyncRetrying,
-    retry,
-    wait_exponential,
-    wait_random_exponential,
-    stop_after_attempt,
-    retry_if_result,
-    retry_if_exception,
-    retry_if_exception_type,
-    retry_any,
-    RetryCallState,
-)
+from requests.exceptions import HTTPError, JSONDecodeError
+from tenacity import AsyncRetrying, stop_after_attempt
 from time import sleep
 from urllib.parse import quote
-import random
-import time
 
 from vespa.exceptions import VespaError
 from vespa.io import VespaQueryResponse, VespaResponse, VespaVisitResponse
 from vespa.package import ApplicationPackage
+from vespa.retries import (
+    DOCV1_RETRY,
+    QUERY_RETRY,
+    SYNC_REQUEST_RETRY,
+    THROTTLE_RETRY,
+    VISIT_RETRY,
+    is_connection_error as _is_connection_error,
+)
 from vespa.throttling import AdaptiveThrottler
 
 import httpx
@@ -67,31 +73,6 @@ def get_profiling_params() -> Dict[str, str]:
         "trace.timestamps": "true",
         "presentation.timing": "true",
     }
-
-
-def _is_connection_error(e: Exception) -> bool:
-    """
-    Check if an exception is a connection-related error.
-
-    This handles both requests.ConnectionError and httpr exceptions
-    (RequestError, ConnectError) as well as generic network errors.
-
-    Args:
-        e: The exception to check
-
-    Returns:
-        True if this is a connection/network error, False otherwise
-    """
-    error_str = str(e).lower()
-    return (
-        isinstance(e, ConnectionError)
-        or isinstance(e, ConnectionResetError)
-        or (hasattr(httpr, "RequestError") and isinstance(e, httpr.RequestError))
-        or (hasattr(httpr, "ConnectError") and isinstance(e, httpr.ConnectError))
-        or "error sending request" in error_str
-        or "connection" in error_str
-        or type(e).__name__ == "RequestError"
-    )
 
 
 def _prepare_mtls_cert_data(cert: Optional[str], key: Optional[str]) -> Optional[bytes]:
@@ -1506,7 +1487,11 @@ class VespaSync(object):
 
     def _request_with_retry(self, method: str, url: str, json_data=None, **kwargs):
         """
-        Execute HTTP request with 429 retry logic using exponential backoff.
+        Execute HTTP request, retrying on 429 responses and connection errors.
+
+        Uses ``vespa.retries.SYNC_REQUEST_RETRY`` with the stop bound taken from
+        ``self.num_retries_429``. On exhaustion the last response is returned (or
+        the last connection error re-raised); other exceptions propagate at once.
 
         Args:
             method: HTTP method (GET, POST, PUT, DELETE, etc.)
@@ -1528,31 +1513,11 @@ class VespaSync(object):
             else:
                 kwargs["json"] = prepared_body
 
-        for attempt in range(self.num_retries_429 + 1):
-            try:
-                # Make the request using httpr.Client
-                response = getattr(self.http_client, method.lower())(url, **kwargs)
-
-                if response.status_code == 429 and attempt < self.num_retries_429:
-                    # Exponential backoff for 429 (same formula as CustomHTTPAdapter)
-                    wait_time = 0.1 * 1.618**attempt + random.uniform(0, 1)
-                    time.sleep(wait_time)
-                    continue
-
-                return response
-            except (ConnectionResetError, Exception) as e:
-                # Check if it's a connection/network error that should be retried
-                # This includes httpr.RequestError, httpr.ConnectError, ConnectionResetError, and other network errors
-                if _is_connection_error(e) and attempt < self.num_retries_429:
-                    wait_time = 0.1 * 1.618**attempt + random.uniform(0, 1)
-                    time.sleep(wait_time)
-                elif _is_connection_error(e):
-                    raise
-                else:
-                    # Not a connection error, re-raise immediately
-                    raise
-
-        return response
+        send = getattr(self.http_client, method.lower())
+        policy = SYNC_REQUEST_RETRY.copy(
+            stop=stop_after_attempt(self.num_retries_429 + 1)
+        )
+        return policy(send, url, **kwargs)
 
     def __enter__(self):
         self._open_http_client()
@@ -1921,7 +1886,7 @@ class VespaSync(object):
                 f"slice_id must be in range [0, {slices - 1}]. Got {slice_id} instead."
             )
 
-        @retry(retry=retry_if_exception_type(HTTPError), stop=stop_after_attempt(3))
+        @VISIT_RETRY.wraps
         def visit_request(end_point: str, params: Dict[str, str]):
             r = self._request_with_retry("GET", end_point, params=params)
             raise_for_status(r)
@@ -2280,11 +2245,6 @@ class VespaAsync(object):
         await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
         return [result for result in map(lambda task: task.result(), tasks)]
 
-    def callback_docv1(state: RetryCallState) -> VespaResponse:
-        if state.outcome.failed:
-            raise state.outcome.exception()
-        return state.outcome.result()
-
     async def query(
         self,
         body: Optional[Dict] = None,
@@ -2300,7 +2260,7 @@ class VespaAsync(object):
             body (dict): Dict containing all the request parameters.
             groupname (str, optional): The groupname used in streaming search.
             profile (bool, optional): Add profiling parameters to the query (response may be large). Defaults to False.
-            retry_policy (AsyncRetrying, optional): Custom tenacity retry policy. Defaults to five attempts with random exponential wait time.
+            retry_policy (AsyncRetrying, optional): Custom tenacity retry policy. Defaults to ``vespa.retries.QUERY_RETRY`` (five attempts with random exponential wait time).
             **kwargs (dict, optional): Additional valid Vespa HTTP Query API parameters.
 
         Returns:
@@ -2314,14 +2274,7 @@ class VespaAsync(object):
         if profile:
             kwargs.update(get_profiling_params())
 
-        retry_policy = (
-            retry_policy.copy()
-            if retry_policy
-            else AsyncRetrying(
-                wait=wait_random_exponential(multiplier=1.5, max=60),
-                stop=stop_after_attempt(5),
-            )
-        )
+        retry_policy = (retry_policy or QUERY_RETRY).copy()
 
         async def _do_query() -> VespaQueryResponse:
             response = await self._make_request(
@@ -2339,19 +2292,52 @@ class VespaAsync(object):
 
         return await retry_policy(_do_query)
 
-    @retry(
-        wait=wait_exponential(multiplier=1),
-        retry=retry_any(
-            retry_if_exception(lambda x: True),
-            retry_if_result(lambda x: x.get_status_code() == 503),
-        ),
-        stop=stop_after_attempt(3),
-        retry_error_callback=callback_docv1,
-    )
-    @retry(
-        wait=wait_random_exponential(multiplier=1, max=3),
-        retry=retry_if_result(lambda x: x.get_status_code() == 429),
-    )
+    async def _docv1_request(
+        self,
+        method: str,
+        operation_type: str,
+        schema: str,
+        data_id: str,
+        namespace: Optional[str],
+        groupname: Optional[str],
+        json_data: Optional[Dict] = None,
+        semaphore: Optional[asyncio.Semaphore] = None,
+        params: Optional[Dict] = None,
+    ) -> VespaResponse:
+        """
+        Send a document/v1 request with the shared two-layer retry policy.
+
+        Inner layer ``THROTTLE_RETRY`` retries 429 responses (unbounded, see
+        ``vespa.retries``). Outer layer ``DOCV1_RETRY`` retries any exception or
+        a 503 response up to 3 attempts, then re-raises the last exception or
+        returns the last response.
+        """
+        path = self.app.get_document_v1_path(
+            id=data_id, schema=schema, namespace=namespace, group=groupname
+        )
+        end_point = "{}{}".format(self.app.end_point, path)
+
+        request_kwargs: Dict[str, Any] = {
+            "semaphore": semaphore,
+            "params": params or {},
+        }
+        if json_data is not None:
+            request_kwargs["json_data"] = json_data
+
+        async def _send() -> VespaResponse:
+            response = await self._make_request(method, end_point, **request_kwargs)
+            return VespaResponse(
+                json=_response_json(response),
+                status_code=response.status_code,
+                url=str(response.url),
+                operation_type=operation_type,
+            )
+
+        async def _send_with_throttle_retry() -> VespaResponse:
+            return await THROTTLE_RETRY.copy()(_send)
+
+        return await DOCV1_RETRY.copy()(_send_with_throttle_retry)
+
     async def feed_data_point(
         self,
         schema: str,
@@ -2362,40 +2348,18 @@ class VespaAsync(object):
         semaphore: Optional[asyncio.Semaphore] = None,
         **kwargs,
     ) -> VespaResponse:
-        path = self.app.get_document_v1_path(
-            id=data_id, schema=schema, namespace=namespace, group=groupname
-        )
-        end_point = "{}{}".format(self.app.end_point, path)
-        vespa_format = {"fields": fields}
-
-        response = await self._make_request(
+        return await self._docv1_request(
             "POST",
-            end_point,
-            json_data=vespa_format,
+            "feed",
+            schema,
+            data_id,
+            namespace,
+            groupname,
+            json_data={"fields": fields},
             semaphore=semaphore,
             params=kwargs,
         )
 
-        return VespaResponse(
-            json=_response_json(response),
-            status_code=response.status_code,
-            url=str(response.url),
-            operation_type="feed",
-        )
-
-    @retry(
-        wait=wait_exponential(multiplier=1),
-        retry=retry_any(
-            retry_if_exception(lambda x: True),
-            retry_if_result(lambda x: x.get_status_code() == 503),
-        ),
-        stop=stop_after_attempt(3),
-        retry_error_callback=callback_docv1,
-    )
-    @retry(
-        wait=wait_exponential(multiplier=1, max=10),
-        retry=retry_if_result(lambda x: x.get_status_code() == 429),
-    )
     async def delete_data(
         self,
         schema: str,
@@ -2405,38 +2369,17 @@ class VespaAsync(object):
         semaphore: Optional[asyncio.Semaphore] = None,
         **kwargs,
     ) -> VespaResponse:
-        path = self.app.get_document_v1_path(
-            id=data_id, schema=schema, namespace=namespace, group=groupname
-        )
-        end_point = "{}{}".format(self.app.end_point, path)
-
-        response = await self._make_request(
+        return await self._docv1_request(
             "DELETE",
-            end_point,
+            "delete",
+            schema,
+            data_id,
+            namespace,
+            groupname,
             semaphore=semaphore,
             params=kwargs,
         )
 
-        return VespaResponse(
-            json=_response_json(response),
-            status_code=response.status_code,
-            url=str(response.url),
-            operation_type="delete",
-        )
-
-    @retry(
-        wait=wait_exponential(multiplier=1),
-        retry=retry_any(
-            retry_if_exception(lambda x: True),
-            retry_if_result(lambda x: x.get_status_code() == 503),
-        ),
-        stop=stop_after_attempt(3),
-        retry_error_callback=callback_docv1,
-    )
-    @retry(
-        wait=wait_exponential(multiplier=1, max=10),
-        retry=retry_if_result(lambda x: x.get_status_code() == 429),
-    )
     async def get_data(
         self,
         schema: str,
@@ -2446,38 +2389,17 @@ class VespaAsync(object):
         semaphore: Optional[asyncio.Semaphore] = None,
         **kwargs,
     ) -> VespaResponse:
-        path = self.app.get_document_v1_path(
-            id=data_id, schema=schema, namespace=namespace, group=groupname
-        )
-        end_point = "{}{}".format(self.app.end_point, path)
-
-        response = await self._make_request(
+        return await self._docv1_request(
             "GET",
-            end_point,
+            "get",
+            schema,
+            data_id,
+            namespace,
+            groupname,
             semaphore=semaphore,
             params=kwargs,
         )
 
-        return VespaResponse(
-            json=_response_json(response),
-            status_code=response.status_code,
-            url=str(response.url),
-            operation_type="get",
-        )
-
-    @retry(
-        wait=wait_exponential(multiplier=1),
-        retry=retry_any(
-            retry_if_exception(lambda x: True),
-            retry_if_result(lambda x: x.get_status_code() == 503),
-        ),
-        stop=stop_after_attempt(3),
-        retry_error_callback=callback_docv1,
-    )
-    @retry(
-        wait=wait_exponential(multiplier=1, max=10),
-        retry=retry_if_result(lambda x: x.get_status_code() == 429),
-    )
     async def update_data(
         self,
         schema: str,
@@ -2490,10 +2412,6 @@ class VespaAsync(object):
         semaphore: Optional[asyncio.Semaphore] = None,
         **kwargs,
     ) -> VespaResponse:
-        path = self.app.get_document_v1_path(
-            id=data_id, schema=schema, namespace=namespace, group=groupname
-        )
-        end_point = "{}{}".format(self.app.end_point, path)
         if create:
             kwargs["create"] = str(create).lower()
         if auto_assign:
@@ -2502,17 +2420,14 @@ class VespaAsync(object):
             # Can not send 'id' in fields for partial update
             vespa_format = {"fields": {k: v for k, v in fields.items() if k != "id"}}
 
-        response = await self._make_request(
+        return await self._docv1_request(
             "PUT",
-            end_point,
+            "update",
+            schema,
+            data_id,
+            namespace,
+            groupname,
             json_data=vespa_format,
             semaphore=semaphore,
             params=kwargs,
-        )
-
-        return VespaResponse(
-            json=_response_json(response),
-            status_code=response.status_code,
-            url=str(response.url),
-            operation_type="update",
         )

--- a/vespa/deployment.py
+++ b/vespa/deployment.py
@@ -14,7 +14,6 @@ from io import BytesIO
 from pathlib import Path
 from time import sleep, strftime, gmtime
 from typing import Tuple, Union, IO, Optional, List, Dict, Literal, Set
-from tenacity import retry, stop_after_attempt, wait_exponential
 from datetime import timezone
 import platform
 import subprocess
@@ -34,6 +33,7 @@ from cryptography.hazmat.primitives.asymmetric import ec
 
 from vespa.application import Vespa
 from vespa.package import ApplicationPackage, AuthClient, Parameter
+from vespa.retries import CONTROL_PLANE_RETRY
 from vespa.validation import validate_cloud_names, validate_instance_name
 import vespa
 
@@ -1590,11 +1590,7 @@ class VespaCloud(VespaDeployment):
             )
         return regions
 
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, max=3),
-        reraise=True,
-    )
+    @CONTROL_PLANE_RETRY.wraps
     def get_connection_response_with_retry(
         self,
         method,

--- a/vespa/models.py
+++ b/vespa/models.py
@@ -8,7 +8,6 @@ from difflib import get_close_matches
 from typing import Any, Callable, Dict, List, Optional, Union, Literal
 import requests
 from dataclasses import dataclass, fields, field
-from tenacity import retry, stop_after_attempt, wait_exponential
 
 from vespa.package import (
     ApplicationPackage,
@@ -26,6 +25,7 @@ from vespa.package import (
     QueryField,
 )
 import vespa.querybuilder as qb
+from vespa.retries import URL_VALIDATION_RETRY
 
 PoolingStrategy = Literal["mean", "cls", "none"]
 
@@ -268,11 +268,7 @@ class ModelConfig:
         for url_name, url in urls_to_check:
             self._validate_single_url(url_name, url)
 
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        reraise=True,
-    )
+    @URL_VALIDATION_RETRY.wraps
     def _validate_single_url(self, url_name: str, url: str) -> None:
         """Validate a single URL with retry logic."""
         # Authenticate Hugging Face requests when a token is available.

--- a/vespa/retries.py
+++ b/vespa/retries.py
@@ -125,63 +125,70 @@ RETRY_ON_503_OR_EXCEPTION = retry_any(
 
 # --------------------------------------------------------------------------- #
 # Policies
+#
+# Each constant is followed by a string literal so that both Sphinx autodoc and
+# mkdocstrings (griffe) pick it up as the attribute's docstring.
 # --------------------------------------------------------------------------- #
 
-#: Default for ``VespaAsync.query``: retry any exception up to 5 attempts with
-#: random exponential backoff. Does not inspect the status code.
 QUERY_RETRY = AsyncRetrying(
     wait=wait_random_exponential(multiplier=1.5, max=60),
     stop=stop_after_attempt(5),
 )
+"""Default for ``VespaAsync.query``: retry any exception up to 5 attempts with
+random exponential backoff. Does not inspect the status code."""
 
-#: Outer layer for async document/v1 operations (feed/get/update/delete): retry
-#: any exception or a 503 response up to 3 attempts. On exhaustion the last
-#: exception is re-raised or the last response is returned, never ``RetryError``.
 DOCV1_RETRY = AsyncRetrying(
     wait=wait_exponential(multiplier=1),
     retry=RETRY_ON_503_OR_EXCEPTION,
     stop=stop_after_attempt(3),
     retry_error_callback=_return_last_outcome,
 )
+"""Outer layer for async document/v1 operations (feed/get/update/delete): retry
+any exception or a 503 response up to 3 attempts. On exhaustion the last
+exception is re-raised or the last response is returned, never ``RetryError``."""
 
-#: Inner layer for async document/v1 operations: retry a 429 response.
-#: Deliberately unbounded (``stop_never``) so that sustained backpressure from
-#: Vespa slows the feed down instead of failing it. ``feed_async_iterable`` has
-#: no adaptive throttler, so this is the only backpressure mechanism on that path.
 THROTTLE_RETRY = AsyncRetrying(
-    wait=wait_exponential(multiplier=1, max=10),
+    wait=wait_random_exponential(multiplier=1, max=10),
     retry=RETRY_ON_429,
     stop=stop_never,
 )
+"""Inner layer for async document/v1 operations: retry a 429 response.
 
-#: Used by every sync data-plane request (``VespaSync._request_with_retry``):
-#: retry a 429 response or a connection error. The stop is overridden per client
-#: from ``VespaSync.num_retries_429`` (default 10 retries, i.e. 11 attempts).
-#: On exhaustion the last response is returned or the last exception re-raised.
+Deliberately unbounded (``stop_never``) so that sustained backpressure from
+Vespa slows the feed down instead of failing it. ``feed_async_iterable`` has
+no adaptive throttler, so this is the only backpressure mechanism on that path.
+
+The wait is randomised (uniform between 0 and ``min(2**n, 10)`` seconds) so
+that many concurrent tasks hitting 429 together do not retry in lockstep."""
+
 SYNC_REQUEST_RETRY = Retrying(
     retry=retry_any(retry_if_exception(is_connection_error), RETRY_ON_429),
     wait=wait_golden_jitter(),
     stop=stop_after_attempt(11),
     retry_error_callback=_return_last_outcome,
 )
+"""Used by every sync data-plane request (``VespaSync._request_with_retry``):
+retry a 429 response or a connection error. The stop is overridden per client
+from ``VespaSync.num_retries_429`` (default 10 retries, i.e. 11 attempts).
+On exhaustion the last response is returned or the last exception re-raised."""
 
-#: Per-slice retry in ``Vespa.visit`` on top of ``SYNC_REQUEST_RETRY``: retry an
-#: ``HTTPError`` raised by ``raise_for_status`` up to 3 attempts, no wait.
 VISIT_RETRY = Retrying(
     retry=retry_if_exception_type(HTTPError),
     stop=stop_after_attempt(3),
 )
+"""Per-slice retry in ``Vespa.visit`` on top of ``SYNC_REQUEST_RETRY``: retry an
+``HTTPError`` raised by ``raise_for_status`` up to 3 attempts, no wait."""
 
-#: ``VespaCloud`` control-plane requests: 3 attempts, exponential wait capped at 3s.
 CONTROL_PLANE_RETRY = Retrying(
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, max=3),
     reraise=True,
 )
+"""``VespaCloud`` control-plane requests: 3 attempts, exponential wait capped at 3s."""
 
-#: Validation of external model URLs in ``vespa.models``: 3 attempts, 1-10s wait.
 URL_VALIDATION_RETRY = Retrying(
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=1, max=10),
     reraise=True,
 )
+"""Validation of external model URLs in ``vespa.models``: 3 attempts, 1-10s wait."""

--- a/vespa/retries.py
+++ b/vespa/retries.py
@@ -1,0 +1,187 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+"""
+Retry strategies used across pyvespa.
+
+Every retry policy in the library is defined here, once, as a tenacity
+``Retrying``/``AsyncRetrying`` object. Call sites either wrap a function with
+``POLICY.wraps`` (decorator style) or invoke ``POLICY.copy()(fn, ...)`` directly.
+Both create a fresh copy per call, so the module-level objects are never mutated.
+
+Defining them in one place makes the differences between strategies visible and
+deliberate, gives users a documented default they can inspect or adapt via
+``POLICY.copy(stop=..., wait=...)``, and gives tests a stable patch target.
+"""
+
+import random
+from typing import Any, Callable
+
+import httpr
+from requests.exceptions import ConnectionError, HTTPError
+from tenacity import (
+    AsyncRetrying,
+    RetryCallState,
+    Retrying,
+    retry_any,
+    retry_if_exception,
+    retry_if_exception_type,
+    retry_if_result,
+    stop_after_attempt,
+    stop_never,
+    wait_exponential,
+    wait_random_exponential,
+)
+from tenacity.wait import wait_base
+
+__all__ = [
+    "CONTROL_PLANE_RETRY",
+    "DOCV1_RETRY",
+    "QUERY_RETRY",
+    "SYNC_REQUEST_RETRY",
+    "THROTTLE_RETRY",
+    "URL_VALIDATION_RETRY",
+    "VISIT_RETRY",
+    "is_connection_error",
+    "retry_if_status",
+    "wait_golden_jitter",
+]
+
+
+# --------------------------------------------------------------------------- #
+# Predicates and helpers
+# --------------------------------------------------------------------------- #
+
+
+def retry_if_status(*codes: int) -> retry_if_result:
+    """
+    Retry when the returned response has one of the given HTTP status codes.
+
+    Works with any object exposing ``get_status_code()`` (``VespaResponse``) or a
+    ``status_code`` attribute (``httpr.Response``).
+    """
+
+    def _has_status(response: Any) -> bool:
+        get = getattr(response, "get_status_code", None)
+        status = get() if callable(get) else getattr(response, "status_code", None)
+        return status in codes
+
+    return retry_if_result(_has_status)
+
+
+def is_connection_error(e: BaseException) -> bool:
+    """
+    Check if an exception is a connection-related error.
+
+    This handles both requests.ConnectionError and httpr exceptions
+    (RequestError, ConnectError) as well as generic network errors.
+
+    Args:
+        e: The exception to check
+
+    Returns:
+        True if this is a connection/network error, False otherwise
+    """
+    error_str = str(e).lower()
+    return (
+        isinstance(e, ConnectionError)
+        or isinstance(e, ConnectionResetError)
+        or (hasattr(httpr, "RequestError") and isinstance(e, httpr.RequestError))
+        or (hasattr(httpr, "ConnectError") and isinstance(e, httpr.ConnectError))
+        or "error sending request" in error_str
+        or "connection" in error_str
+        or type(e).__name__ == "RequestError"
+    )
+
+
+def _return_last_outcome(state: RetryCallState) -> Any:
+    """
+    ``retry_error_callback`` that surfaces the final attempt instead of ``RetryError``.
+
+    If the last attempt raised, that exception is re-raised. Otherwise the last
+    result (e.g. a 503 response) is returned to the caller.
+    """
+    if state.outcome.failed:
+        raise state.outcome.exception()
+    return state.outcome.result()
+
+
+class wait_golden_jitter(wait_base):
+    """
+    Wait ``0.1 * 1.618**n + uniform(0, 1)`` seconds, where ``n`` is the zero-based
+    attempt index. Used by the sync client for 429 and connection-error retries.
+    """
+
+    def __call__(self, retry_state: RetryCallState) -> float:
+        return 0.1 * 1.618 ** (retry_state.attempt_number - 1) + random.uniform(0, 1)
+
+
+_retry_on_any_exception: Callable[[BaseException], bool] = lambda _: True  # noqa: E731
+
+RETRY_ON_429 = retry_if_status(429)
+RETRY_ON_503_OR_EXCEPTION = retry_any(
+    retry_if_exception(_retry_on_any_exception), retry_if_status(503)
+)
+
+
+# --------------------------------------------------------------------------- #
+# Policies
+# --------------------------------------------------------------------------- #
+
+#: Default for ``VespaAsync.query``: retry any exception up to 5 attempts with
+#: random exponential backoff. Does not inspect the status code.
+QUERY_RETRY = AsyncRetrying(
+    wait=wait_random_exponential(multiplier=1.5, max=60),
+    stop=stop_after_attempt(5),
+)
+
+#: Outer layer for async document/v1 operations (feed/get/update/delete): retry
+#: any exception or a 503 response up to 3 attempts. On exhaustion the last
+#: exception is re-raised or the last response is returned, never ``RetryError``.
+DOCV1_RETRY = AsyncRetrying(
+    wait=wait_exponential(multiplier=1),
+    retry=RETRY_ON_503_OR_EXCEPTION,
+    stop=stop_after_attempt(3),
+    retry_error_callback=_return_last_outcome,
+)
+
+#: Inner layer for async document/v1 operations: retry a 429 response.
+#: Deliberately unbounded (``stop_never``) so that sustained backpressure from
+#: Vespa slows the feed down instead of failing it. ``feed_async_iterable`` has
+#: no adaptive throttler, so this is the only backpressure mechanism on that path.
+THROTTLE_RETRY = AsyncRetrying(
+    wait=wait_exponential(multiplier=1, max=10),
+    retry=RETRY_ON_429,
+    stop=stop_never,
+)
+
+#: Used by every sync data-plane request (``VespaSync._request_with_retry``):
+#: retry a 429 response or a connection error. The stop is overridden per client
+#: from ``VespaSync.num_retries_429`` (default 10 retries, i.e. 11 attempts).
+#: On exhaustion the last response is returned or the last exception re-raised.
+SYNC_REQUEST_RETRY = Retrying(
+    retry=retry_any(retry_if_exception(is_connection_error), RETRY_ON_429),
+    wait=wait_golden_jitter(),
+    stop=stop_after_attempt(11),
+    retry_error_callback=_return_last_outcome,
+)
+
+#: Per-slice retry in ``Vespa.visit`` on top of ``SYNC_REQUEST_RETRY``: retry an
+#: ``HTTPError`` raised by ``raise_for_status`` up to 3 attempts, no wait.
+VISIT_RETRY = Retrying(
+    retry=retry_if_exception_type(HTTPError),
+    stop=stop_after_attempt(3),
+)
+
+#: ``VespaCloud`` control-plane requests: 3 attempts, exponential wait capped at 3s.
+CONTROL_PLANE_RETRY = Retrying(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, max=3),
+    reraise=True,
+)
+
+#: Validation of external model URLs in ``vespa.models``: 3 attempts, 1-10s wait.
+URL_VALIDATION_RETRY = Retrying(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    reraise=True,
+)


### PR DESCRIPTION
## Context

> 🤖  Code written by Claude, reviewed and tested by me

Retry strategies have drifted across the codebase, and we want to gather them in one place, both to make them easier to change, and to reduce introducing new strategies and/or strategy drift in calling methods.

## What's changed? 

Every tenacity policy in the library now lives in vespa/retries.py as a module-level Retrying/AsyncRetrying constant. Call sites use POLICY.wraps or POLICY.copy()(fn, ...), so the constants are never mutated and tests have a stable patch target.

Behaviour-preserving, with two deliberate exceptions called out below.

- QUERY_RETRY: default for VespaAsync.query (5 attempts, random exp wait).
- DOCV1_RETRY + THROTTLE_RETRY: the two-layer policy for the async document/v1 methods, now applied once in a shared _docv1_request helper instead of four copies of stacked decorators.
- SYNC_REQUEST_RETRY: replaces the hand-rolled loop in VespaSync._request_with_retry; wait_golden_jitter reproduces the old 0.1 * 1.618**n + uniform(0, 1) formula and num_retries_429 still bounds it.
- VISIT_RETRY, CONTROL_PLANE_RETRY, URL_VALIDATION_RETRY: the decorators from Vespa.visit, VespaCloud and vespa.models, unchanged.

Deliberate changes:
- THROTTLE_RETRY spells out stop=stop_never. The 429 retry was already unbounded by omission; it is now explicit and documented, because it is the only backpressure mechanism on feed_async_iterable.
- The 429 wait differed between feed_data_point (wait_random_exponential(multiplier=1, max=3)) and its three siblings (wait_exponential(multiplier=1, max=10)). All four now share wait_random_exponential(multiplier=1, max=10): jittered so concurrent tasks that hit 429 together do not retry in lockstep, with the larger 10s cap. Release note: 429 retries on the async document API now use random exponential backoff capped at 10s.

Also, minor fixes:
- test_query_exhausts_retries[None-5] patched a tenacity private that had no effect and slept for real (9-34s). It now patches vespa.application.QUERY_RETRY and runs in ~0.1s.
- New tests/unit/test_retries.py covers policy shape, sync 429/connection retry, unbounded docv1 429, 503 exhaustion and exception re-raise.
- query.ipynb no longer claims queries retry 429/500/503/504 three times, which was true of neither client. API docs gain a vespa.retries page.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

